### PR TITLE
Replace String.Casing.titlecase_once deprecated methods

### DIFF
--- a/lib/mix/tasks/generate_types.ex
+++ b/lib/mix/tasks/generate_types.ex
@@ -133,8 +133,7 @@ defmodule Mix.Tasks.GenerateTypes do
   end
 
   defp build_module_name(string) do
-    {char, rest} = String.Casing.titlecase_once(string, :default)
-    char <> rest
+    Macro.camelize(string)
   end
 
   def run(_) do

--- a/lib/tdlib/handler.ex
+++ b/lib/tdlib/handler.ex
@@ -124,9 +124,12 @@ defmodule TDLib.Handler do
   end
 
   defp match(:object, json, prefix) do
-    {char, rest} = json |> Map.get("@type")
-                        |> String.Casing.titlecase_once(:default)
-    string = prefix <> char <> rest
+    camelized_type =
+      json
+      |> Map.get("@type")
+      |> Macro.camelize()
+
+    string = prefix <> camelized_type
     module = String.to_existing_atom(string)
 
     struct = struct(module)


### PR DESCRIPTION
`String.Casing.titlecase_once(string)` doesn't work with elixir 1.13