### PR TITLE
Bump tdlib-json-cli to v1.8.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule TDLib.Mixfile do
       version: "0.0.3",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
-      compilers: [:elixir_make] ++ Mix.compilers,
+      compilers: Mix.compilers,
       deps: deps(),
 
       # Hex

--- a/mix.exs
+++ b/mix.exs
@@ -54,9 +54,8 @@ defmodule TDLib.Mixfile do
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:tdlib_json_cli,
-        git: "https://github.com/oott123/tdlib-json-cli",
+        git: "https://github.com/PushSMS/tdlib-json-cli",
         submodules: true,
-        tag: "v1.7.0",
         app: false,
         compile: false
       }

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm", "00e3ebdc821fb3a36957320d49e8f4bfa310d73ea31c90e5f925dc75e030da8f"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "tdlib_json_cli": {:git, "https://github.com/oott123/tdlib-json-cli", "3637de2c8f98065576006df16f09541fca387ad3", [tag: "v1.7.0", submodules: true]},
+  "tdlib_json_cli": {:git, "https://github.com/PushSMS/tdlib-json-cli", "ad3300d1b7d327df7950e027ba670cd93ac30026", [submodules: true]},
 }


### PR DESCRIPTION
Пришлось обновить `tdlib-json-cli` до `v1.8.0` чтобы обновился tdlib до 1.8.
Не компилился `tdlib-json-cli`, поэтому сделал форк с минимальными изменениями (по факту вернул там предыдущую версию кода). 
https://github.com/PushSMS/tdlib-json-cli

Создал issue на эту тему в официальном репозитории
https://github.com/oott123/tdlib-json-cli/issues/10

Также в этом PR убрал автоматический запуск компиляции. Теперь либа ждет скомпиленный файлик по пути `config :tdlib, backend_binary: "some_path"`