### PR TITLE
Add tdlib 1.8.31 support

### DIFF
--- a/lib/tdlib.ex
+++ b/lib/tdlib.ex
@@ -2,7 +2,7 @@ defmodule TDLib do
   alias TDLib.{Session, Object}
   alias TDLib.SessionRegistry, as: Registry
 
-  @default_config %Object.TdlibParameters{
+  @default_config %{
     :use_test_dc              => false,
     :database_directory       => "/tmp/tdlib",
     :files_directory          => "", # When empty database_directory will be used

--- a/lib/tdlib.ex
+++ b/lib/tdlib.ex
@@ -1,5 +1,5 @@
 defmodule TDLib do
-  alias TDLib.{Session, Object}
+  alias TDLib.Session
   alias TDLib.SessionRegistry, as: Registry
 
   @default_config %{

--- a/lib/tdlib/backend.ex
+++ b/lib/tdlib/backend.ex
@@ -56,7 +56,7 @@ defmodule TDLib.Backend do
           # Forward msg to the client
           Kernel.send handler_pid, {:tdlib, msg}
         else
-          Logger.warn "#{state.name}: incoming message but no handler registered."
+          Logger.warning "#{state.name}: incoming message but no handler registered."
         end
 
         {:noreply, new_state}

--- a/lib/tdlib/handler.ex
+++ b/lib/tdlib/handler.ex
@@ -67,13 +67,7 @@ defmodule TDLib.Handler do
             case struct.authorization_state do
               %Object.AuthorizationStateWaitTdlibParameters{} ->
                 config = Registry.get(session) |> Map.get(:config)
-                transmit session, %Method.SetTdlibParameters{
-                  :parameters  => config
-                }
-              %Object.AuthorizationStateWaitEncryptionKey{} ->
-                transmit session, %Method.CheckDatabaseEncryptionKey{
-                  encryption_key: Registry.get(session, :encryption_key)
-                }
+                transmit session, struct(Method.SetTdlibParameters, config)
               _ -> :ignore
             end
           _ -> :ignore

--- a/lib/tdlib/handler.ex
+++ b/lib/tdlib/handler.ex
@@ -7,7 +7,7 @@ defmodule TDLib.Handler do
   # Must be a multiple of 4
   @moduledoc false
   @backend_verbosity_level 2
-  @disable_handling Application.get_env(:telegram_tdlib, :disable_handling)
+  @disable_handling Application.compile_env(:telegram_tdlib, :disable_handling)
 
   def start_link(session_name) do
     GenServer.start_link(__MODULE__, session_name, [])
@@ -28,7 +28,7 @@ defmodule TDLib.Handler do
     cond do
       "@cli" in keys -> json |> handle_cli(session)
       "@type" in keys -> json |> handle_object(session)
-      true -> Logger.warn "#{session}: unknown structure received"
+      true -> Logger.warning "#{session}: unknown structure received"
     end
 
     {:noreply, session}

--- a/lib/tdlib/method.ex
+++ b/lib/tdlib/method.ex
@@ -1,8 +1,28 @@
 defmodule TDLib.Method do
   @moduledoc """
   This module was generated using Telegram's TDLib documentation. It contains
-  513 submodules (= structs).
+  762 submodules (= structs).
   """
+defmodule GetWebAppLinkUrl do
+  @moduledoc  """
+  Returns an HTTPS URL of a Web App to open after a link of the type internalLinkTypeWebApp is clicked.
+  Returns object_ptr<HttpUrl>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat in which the link was clicked; pass 0 if none. |
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | web_app_short_name | string | Short name of the Web App. |
+  | start_parameter | string | Start parameter from <a class="el" href="classtd_1_1td__api_1_1internal_link_type_web_app.html">internalLinkTypeWebApp</a>. |
+  | theme | themeParameters | Preferred Web App theme; pass null to use the default theme. |
+  | application_name | string | Short name of the application; 0-64 English letters, digits, and underscores. |
+  | allow_write_access | bool | Pass true if the current user allowed the bot to send them messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_web_app_link_url.html).
+  """
+
+  defstruct "@type": "getWebAppLinkUrl", "@extra": nil, chat_id: nil, bot_user_id: nil, web_app_short_name: nil, start_parameter: nil, theme: nil, application_name: nil, allow_write_access: nil
+end
 defmodule GetTrendingStickerSets do
   @moduledoc  """
   Returns a list of trending sticker sets. For optimal performance, the number of returned sticker sets is chosen by TDLib.
@@ -10,13 +30,14 @@ defmodule GetTrendingStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
+  | sticker_type | StickerType | Type of the sticker sets to return. |
   | offset | int32 | The offset from which to return the sticker sets; must be non-negative. |
   | limit | int32 | The maximum number of sticker sets to be returned; up to 100. For optimal performance, the number of returned sticker sets is chosen by TDLib and can be smaller than the specified limit, even if the end of the list has not been reached. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_trending_sticker_sets.html).
   """
 
-  defstruct "@type": "getTrendingStickerSets", "@extra": nil, offset: nil, limit: nil
+  defstruct "@type": "getTrendingStickerSets", "@extra": nil, sticker_type: nil, offset: nil, limit: nil
 end
 defmodule EndGroupCallScreenSharing do
   @moduledoc  """
@@ -61,9 +82,27 @@ defmodule GetMessageFileType do
 
   defstruct "@type": "getMessageFileType", "@extra": nil, message_file_head: nil
 end
+defmodule EditBusinessMessageText do
+  @moduledoc  """
+  Edits the text of a text or game message sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
+  | input_message_content | InputMessageContent | New text content of the message. Must be of type <a class="el" href="classtd_1_1td__api_1_1input_message_text.html">inputMessageText</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_message_text.html).
+  """
+
+  defstruct "@type": "editBusinessMessageText", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil, input_message_content: nil
+end
 defmodule EditMessageCaption do
   @moduledoc  """
-  Edits the message content caption. Returns the edited message after the edit is completed on the server side.
+  Edits the message content caption. Returns the edited message after the edit is completed on the server side. Can be used only if message.can_be_edited == true.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -71,12 +110,29 @@ defmodule EditMessageCaption do
   | chat_id | int53 | The chat the message belongs to. |
   | message_id | int53 | Identifier of the message. |
   | reply_markup | ReplyMarkup | The new message reply markup; pass null if none; for bots only. |
-  | caption | formattedText | New message content caption; 0-GetOption("message_caption_length_max") characters; pass null to remove caption. |
+  | caption | formattedText | New message content caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters; pass null to remove caption. |
+  | show_caption_above_media | bool | Pass true to show the caption above the media; otherwise, caption will be shown below the media. Can be true only for animation, photo, and video messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_message_caption.html).
   """
 
-  defstruct "@type": "editMessageCaption", "@extra": nil, chat_id: nil, message_id: nil, reply_markup: nil, caption: nil
+  defstruct "@type": "editMessageCaption", "@extra": nil, chat_id: nil, message_id: nil, reply_markup: nil, caption: nil, show_caption_above_media: nil
+end
+defmodule SetChatProfileAccentColor do
+  @moduledoc  """
+  Changes accent color and background custom emoji for profile of a supergroup or channel chat. Requires can_change_info administrator right.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | profile_accent_color_id | int32 | Identifier of the accent color to use for profile; pass -1 if none. The chat must have at least profileAccentColor.min_supergroup_chat_boost_level for supergroups or profileAccentColor.min_channel_chat_boost_level for channels boost level to pass the corresponding color. |
+  | profile_background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the chat's profile photo background; 0 if none. Use chatBoostLevelFeatures.can_set_profile_background_custom_emoji to check whether a custom emoji can be set. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_profile_accent_color.html).
+  """
+
+  defstruct "@type": "setChatProfileAccentColor", "@extra": nil, chat_id: nil, profile_accent_color_id: nil, profile_background_custom_emoji_id: nil
 end
 defmodule GetStickerSet do
   @moduledoc  """
@@ -106,6 +162,17 @@ defmodule GetDeepLinkInfo do
 
   defstruct "@type": "getDeepLinkInfo", "@extra": nil, link: nil
 end
+defmodule GetPremiumStickerExamples do
+  @moduledoc  """
+  Returns examples of premium stickers for demonstration purposes.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_premium_sticker_examples.html).
+  """
+
+  defstruct "@type": "getPremiumStickerExamples", "@extra": nil
+end
 defmodule SetTdlibParameters do
   @moduledoc  """
   Sets the parameters for TDLib initialization. Works only when the current authorization state is authorizationStateWaitTdlibParameters.
@@ -113,12 +180,69 @@ defmodule SetTdlibParameters do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | parameters | tdlibParameters | Parameters for TDLib initialization. |
+  | use_test_dc | bool | Pass true to use Telegram test environment instead of the production environment. |
+  | database_directory | string | The path to the directory for the persistent database; if empty, the current working directory will be used. |
+  | files_directory | string | The path to the directory for storing files; if empty, database_directory will be used. |
+  | database_encryption_key | bytes | Encryption key for the database. If the encryption key is invalid, then an error with code 401 will be returned. |
+  | use_file_database | bool | Pass true to keep information about downloaded and uploaded files between application restarts. |
+  | use_chat_info_database | bool | Pass true to keep cache of users, basic groups, supergroups, channels and secret chats between restarts. Implies use_file_database. |
+  | use_message_database | bool | Pass true to keep cache of chats and messages between restarts. Implies use_chat_info_database. |
+  | use_secret_chats | bool | Pass true to enable support for secret chats. |
+  | api_id | int32 | Application identifier for Telegram API access, which can be obtained at <a href="https://my.telegram.org">https://my.telegram.org</a>. |
+  | api_hash | string | Application identifier hash for Telegram API access, which can be obtained at <a href="https://my.telegram.org">https://my.telegram.org</a>. |
+  | system_language_code | string | IETF language tag of the user's operating system language; must be non-empty. |
+  | device_model | string | Model of the device the application is being run on; must be non-empty. |
+  | system_version | string | Version of the operating system the application is being run on. If empty, the version is automatically detected by TDLib. |
+  | application_version | string | Application version; must be non-empty. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_tdlib_parameters.html).
   """
 
-  defstruct "@type": "setTdlibParameters", "@extra": nil, parameters: nil
+  defstruct "@type": "setTdlibParameters", "@extra": nil, use_test_dc: nil, database_directory: nil, files_directory: nil, database_encryption_key: nil, use_file_database: nil, use_chat_info_database: nil, use_message_database: nil, use_secret_chats: nil, api_id: nil, api_hash: nil, system_language_code: nil, device_model: nil, system_version: nil, application_version: nil
+end
+defmodule OpenChatSimilarChat do
+  @moduledoc  """
+  Informs TDLib that a chat was opened from the list of similar chats. The method is independent of openChat and closeChat methods.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the original chat, which similar chats were requested. |
+  | opened_chat_id | int53 | Identifier of the opened chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1open_chat_similar_chat.html).
+  """
+
+  defstruct "@type": "openChatSimilarChat", "@extra": nil, chat_id: nil, opened_chat_id: nil
+end
+defmodule UnpinAllMessageThreadMessages do
+  @moduledoc  """
+  Removes all pinned messages from a forum topic; requires can_pin_messages member right in the supergroup.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier in which messages will be unpinned. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1unpin_all_message_thread_messages.html).
+  """
+
+  defstruct "@type": "unpinAllMessageThreadMessages", "@extra": nil, chat_id: nil, message_thread_id: nil
+end
+defmodule ToggleHasSponsoredMessagesEnabled do
+  @moduledoc  """
+  Toggles whether the current user has sponsored messages enabled. The setting has no effect for users without Telegram Premium for which sponsored messages are always enabled.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | has_sponsored_messages_enabled | bool | Pass true to enable sponsored messages for the current user; false to disable them. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_has_sponsored_messages_enabled.html).
+  """
+
+  defstruct "@type": "toggleHasSponsoredMessagesEnabled", "@extra": nil, has_sponsored_messages_enabled: nil
 end
 defmodule CreateTemporaryPassword do
   @moduledoc  """
@@ -127,7 +251,7 @@ defmodule CreateTemporaryPassword do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | Persistent user password. |
+  | password | string | The 2-step verification password of the current user. |
   | valid_for | int32 | Time during which the temporary password will be valid, in seconds; must be between 60 and 86400. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_temporary_password.html).
@@ -146,22 +270,6 @@ defmodule ClearRecentlyFoundChats do
 
   defstruct "@type": "clearRecentlyFoundChats", "@extra": nil
 end
-defmodule SendPhoneNumberConfirmationCode do
-  @moduledoc  """
-  Sends phone number confirmation code to handle links of the type internalLinkTypePhoneNumberConfirmation.
-  Returns object_ptr<AuthenticationCodeInfo>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | hash | string | Hash value from the link. |
-  | phone_number | string | Phone number value from the link. |
-  | settings | phoneNumberAuthenticationSettings | Settings for the authentication of the user's phone number; pass null to use default settings. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_phone_number_confirmation_code.html).
-  """
-
-  defstruct "@type": "sendPhoneNumberConfirmationCode", "@extra": nil, hash: nil, phone_number: nil, settings: nil
-end
 defmodule ToggleSupergroupJoinByRequest do
   @moduledoc  """
   Toggles whether all users directly joining the supergroup need to be approved by supergroup administrators; requires can_restrict_members administrator right.
@@ -169,7 +277,7 @@ defmodule ToggleSupergroupJoinByRequest do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | supergroup_id | int53 | Identifier of the channel. |
+  | supergroup_id | int53 | Identifier of the supergroup that isn't a broadcast group. |
   | join_by_request | bool | New value of join_by_request. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_join_by_request.html).
@@ -278,6 +386,23 @@ defmodule SearchFileDownloads do
 
   defstruct "@type": "searchFileDownloads", "@extra": nil, query: nil, only_active: nil, only_completed: nil, offset: nil, limit: nil
 end
+defmodule ReplaceStickerInSet do
+  @moduledoc  """
+  Replaces existing sticker in a set. The function is equivalent to removeStickerFromSet, then addStickerToSet, then setStickerPositionInSet.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Sticker set owner; ignored for regular users. |
+  | name | string | Sticker set name. The sticker set must be owned by the current user. |
+  | old_sticker | InputFile | Sticker to remove from the set. |
+  | new_sticker | inputSticker | Sticker to add to the set. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1replace_sticker_in_set.html).
+  """
+
+  defstruct "@type": "replaceStickerInSet", "@extra": nil, user_id: nil, name: nil, old_sticker: nil, new_sticker: nil
+end
 defmodule TerminateAllOtherSessions do
   @moduledoc  """
   Terminates all other sessions of the current user.
@@ -288,6 +413,17 @@ defmodule TerminateAllOtherSessions do
   """
 
   defstruct "@type": "terminateAllOtherSessions", "@extra": nil
+end
+defmodule GetAutosaveSettings do
+  @moduledoc  """
+  Returns autosave settings for the current user.
+  Returns object_ptr<AutosaveSettings>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_autosave_settings.html).
+  """
+
+  defstruct "@type": "getAutosaveSettings", "@extra": nil
 end
 defmodule SetChatLocation do
   @moduledoc  """
@@ -326,11 +462,11 @@ defmodule GetInlineQueryResults do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | bot_user_id | int53 | The identifier of the target bot. |
+  | bot_user_id | int53 | Identifier of the target bot. |
   | chat_id | int53 | Identifier of the chat where the query was sent. |
   | user_location | location | Location of the user; pass null if unknown or the bot doesn't need user's location. |
   | query | string | Text of the query. |
-  | offset | string | Offset of the first entry to return. |
+  | offset | string | Offset of the first entry to return; use empty string to get the first chunk of results. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_inline_query_results.html).
   """
@@ -355,23 +491,38 @@ defmodule GetGroupCallStreamSegment do
 
   defstruct "@type": "getGroupCallStreamSegment", "@extra": nil, group_call_id: nil, time_offset: nil, scale: nil, channel_id: nil, video_quality: nil
 end
-defmodule GetChatSponsoredMessage do
+defmodule SetLoginEmailAddress do
   @moduledoc  """
-  Returns sponsored message to be shown in a chat; for channel chats only. Returns a 404 error if there is no sponsored message in the chat.
-  Returns object_ptr<SponsoredMessage>.
+  Changes the login email address of the user. The email address can be changed only if the current user already has login email and passwordState.login_email_address_pattern is non-empty. The change will not be applied until the new login email address is confirmed with checkLoginEmailAddressCode. To use Apple ID/Google ID instead of an email address, call checkLoginEmailAddressCode directly.
+  Returns object_ptr<EmailAddressAuthenticationCodeInfo>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Identifier of the chat. |
+  | new_login_email_address | string | New login email address. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_sponsored_message.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_login_email_address.html).
   """
 
-  defstruct "@type": "getChatSponsoredMessage", "@extra": nil, chat_id: nil
+  defstruct "@type": "setLoginEmailAddress", "@extra": nil, new_login_email_address: nil
+end
+defmodule SetSupergroupCustomEmojiStickerSet do
+  @moduledoc  """
+  Changes the custom emoji sticker set of a supergroup; requires can_change_info administrator right. The chat must have at least chatBoostFeatures.min_custom_emoji_sticker_set_boost_level boost level to pass the corresponding color.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup. |
+  | custom_emoji_sticker_set_id | int64 | New value of the custom emoji sticker set identifier for the supergroup. Use 0 to remove the custom emoji sticker set in the supergroup. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_supergroup_custom_emoji_sticker_set.html).
+  """
+
+  defstruct "@type": "setSupergroupCustomEmojiStickerSet", "@extra": nil, supergroup_id: nil, custom_emoji_sticker_set_id: nil
 end
 defmodule SetChatMemberStatus do
   @moduledoc  """
-  Changes the status of a chat member, needs appropriate privileges. This function is currently not suitable for transferring chat ownership; use transferChatOwnership instead. Use addChatMember or banChatMember if some additional parameters needs to be passed.
+  Changes the status of a chat member; requires can_invite_users member right to add a chat member, can_promote_members administrator right to change administrator rights of the member, and can_restrict_members administrator right to change restrictions of a user. This function is currently not suitable for transferring chat ownership; use transferChatOwnership instead. Use addChatMember or banChatMember if some additional parameters needs to be passed.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -385,9 +536,37 @@ defmodule SetChatMemberStatus do
 
   defstruct "@type": "setChatMemberStatus", "@extra": nil, chat_id: nil, member_id: nil, status: nil
 end
+defmodule ClearSearchedForTags do
+  @moduledoc  """
+  Clears the list of recently searched for hashtags or cashtags.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | clear_cashtags | bool | Pass true to clear the list of recently searched for cashtags; otherwise, the list of recently searched for hashtags will be cleared. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1clear_searched_for_tags.html).
+  """
+
+  defstruct "@type": "clearSearchedForTags", "@extra": nil, clear_cashtags: nil
+end
+defmodule GetCustomEmojiStickers do
+  @moduledoc  """
+  Returns the list of custom emoji stickers by their identifiers. Stickers are returned in arbitrary order. Only found stickers are returned.
+  Returns object_ptr<Stickers>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_ids | int64 | Identifiers of custom emoji stickers. At most 200 custom emoji stickers can be received simultaneously. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_custom_emoji_stickers.html).
+  """
+
+  defstruct "@type": "getCustomEmojiStickers", "@extra": nil, custom_emoji_ids: nil
+end
 defmodule AddFileToDownloads do
   @moduledoc  """
-  Adds a file from a message to the list of file downloads. Download progress and completion of the download will be notified through updateFile updates. If message database is used, the list of file downloads is persistent across application restarts. The downloading is independent from download using downloadFile, i.e. it continues if downloadFile is canceled or is used to download a part of the file.
+  Adds a file from a message to the list of file downloads. Download progress and completion of the download will be notified through updateFile updates. If message database is used, the list of file downloads is persistent across application restarts. The downloading is independent of download using downloadFile, i.e. it continues if downloadFile is canceled or is used to download a part of the file.
   Returns object_ptr<File>.
 
   | Name | Type | Description |
@@ -401,6 +580,20 @@ defmodule AddFileToDownloads do
   """
 
   defstruct "@type": "addFileToDownloads", "@extra": nil, file_id: nil, chat_id: nil, message_id: nil, priority: nil
+end
+defmodule DeleteDefaultBackground do
+  @moduledoc  """
+  Deletes default background for chats.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | for_dark_theme | bool | Pass true if the background is deleted for a dark theme. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_default_background.html).
+  """
+
+  defstruct "@type": "deleteDefaultBackground", "@extra": nil, for_dark_theme: nil
 end
 defmodule CleanFileName do
   @moduledoc  """
@@ -416,6 +609,62 @@ defmodule CleanFileName do
 
   defstruct "@type": "cleanFileName", "@extra": nil, file_name: nil
 end
+defmodule GetMessageEffect do
+  @moduledoc  """
+  Returns information about a message effect. Returns a 404 error if the effect is not found.
+  Returns object_ptr<MessageEffect>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | effect_id | int64 | Unique identifier of the effect. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_effect.html).
+  """
+
+  defstruct "@type": "getMessageEffect", "@extra": nil, effect_id: nil
+end
+defmodule ReportPhoneNumberCodeMissing do
+  @moduledoc  """
+  Reports that authentication code wasn't delivered via SMS to the specified phone number; for official mobile applications only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | mobile_network_code | string | Current mobile network code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_phone_number_code_missing.html).
+  """
+
+  defstruct "@type": "reportPhoneNumberCodeMissing", "@extra": nil, mobile_network_code: nil
+end
+defmodule SendAuthenticationFirebaseSms do
+  @moduledoc  """
+  Sends Firebase Authentication SMS to the phone number of the user. Works only when the current authorization state is authorizationStateWaitCode and the server returned code of the type authenticationCodeTypeFirebaseAndroid or authenticationCodeTypeFirebaseIos.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | Play Integrity API or SafetyNet Attestation API token for the Android application, or secret from push notification for the iOS application. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_authentication_firebase_sms.html).
+  """
+
+  defstruct "@type": "sendAuthenticationFirebaseSms", "@extra": nil, token: nil
+end
+defmodule SetDefaultMessageAutoDeleteTime do
+  @moduledoc  """
+  Changes the default message auto-delete time for new chats.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_auto_delete_time | messageAutoDeleteTime | New default message auto-delete time; must be from 0 up to 365 * 86400 and be divisible by 86400. If 0, then messages aren't deleted automatically. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_default_message_auto_delete_time.html).
+  """
+
+  defstruct "@type": "setDefaultMessageAutoDeleteTime", "@extra": nil, message_auto_delete_time: nil
+end
 defmodule AddChatToList do
   @moduledoc  """
   Adds a chat to a chat list. A chat can't be simultaneously in Main and Archive chat lists, so it is automatically removed from another one if needed.
@@ -430,6 +679,24 @@ defmodule AddChatToList do
   """
 
   defstruct "@type": "addChatToList", "@extra": nil, chat_id: nil, chat_list: nil
+end
+defmodule AddQuickReplyShortcutInlineQueryResultMessage do
+  @moduledoc  """
+  Adds a message to a quick reply shortcut via inline bot. If shortcut doesn't exist and there are less than getOption("quick_reply_shortcut_count_max") shortcuts, then a new shortcut is created. The shortcut must not contain more than getOption("quick_reply_shortcut_message_count_max") messages after adding the new message. Returns the added message.
+  Returns object_ptr<QuickReplyMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_name | string | Name of the target shortcut. |
+  | reply_to_message_id | int53 | Identifier of a quick reply message in the same shortcut to be replied; pass 0 if none. |
+  | query_id | int64 | Identifier of the inline query. |
+  | result_id | string | Identifier of the inline query result. |
+  | hide_via_bot | bool | Pass true to hide the bot, via which the message is sent. Can be used only for bots <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("animation_search_bot_username"), <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("photo_search_bot_username"), and <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("venue_search_bot_username"). |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_quick_reply_shortcut_inline_query_result_message.html).
+  """
+
+  defstruct "@type": "addQuickReplyShortcutInlineQueryResultMessage", "@extra": nil, shortcut_name: nil, reply_to_message_id: nil, query_id: nil, result_id: nil, hide_via_bot: nil
 end
 defmodule DeleteRevokedChatInviteLink do
   @moduledoc  """
@@ -448,7 +715,7 @@ defmodule DeleteRevokedChatInviteLink do
 end
 defmodule ResendEmailAddressVerificationCode do
   @moduledoc  """
-  Re-sends the code to verify an email address to be added to a user's Telegram Passport.
+  Resends the code to verify an email address to be added to a user's Telegram Passport.
   Returns object_ptr<EmailAddressAuthenticationCodeInfo>.
 
 
@@ -456,6 +723,20 @@ defmodule ResendEmailAddressVerificationCode do
   """
 
   defstruct "@type": "resendEmailAddressVerificationCode", "@extra": nil
+end
+defmodule ReadChatList do
+  @moduledoc  """
+  Traverse all chats in a chat list and marks all messages in the chats as read.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_list | ChatList | Chat list in which to mark all chats as read. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1read_chat_list.html).
+  """
+
+  defstruct "@type": "readChatList", "@extra": nil, chat_list: nil
 end
 defmodule GetMe do
   @moduledoc  """
@@ -467,6 +748,36 @@ defmodule GetMe do
   """
 
   defstruct "@type": "getMe", "@extra": nil
+end
+defmodule GetChatArchivedStories do
+  @moduledoc  """
+  Returns the list of all stories posted by the given chat; requires can_edit_stories right in the chat. The stories are returned in a reverse chronological order (i.e., in order of decreasing story_id). For optimal performance, the number of returned stories is chosen by TDLib.
+  Returns object_ptr<Stories>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | from_story_id | int32 | Identifier of the story starting from which stories must be returned; use 0 to get results from the last story. |
+  | limit | int32 | The maximum number of stories to be returned For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_archived_stories.html).
+  """
+
+  defstruct "@type": "getChatArchivedStories", "@extra": nil, chat_id: nil, from_story_id: nil, limit: nil
+end
+defmodule GetChatBoostLink do
+  @moduledoc  """
+  Returns an HTTPS link to boost the specified supergroup or channel chat.
+  Returns object_ptr<ChatBoostLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boost_link.html).
+  """
+
+  defstruct "@type": "getChatBoostLink", "@extra": nil, chat_id: nil
 end
 defmodule RemoveNotificationGroup do
   @moduledoc  """
@@ -483,9 +794,24 @@ defmodule RemoveNotificationGroup do
 
   defstruct "@type": "removeNotificationGroup", "@extra": nil, notification_group_id: nil, max_notification_id: nil
 end
+defmodule GetSearchedForTags do
+  @moduledoc  """
+  Returns recently searched for hashtags or cashtags by their prefix.
+  Returns object_ptr<Hashtags>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tag_prefix | string | Prefix of hashtags or cashtags to return. |
+  | limit | int32 | The maximum number of items to be returned. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_searched_for_tags.html).
+  """
+
+  defstruct "@type": "getSearchedForTags", "@extra": nil, tag_prefix: nil, limit: nil
+end
 defmodule GetAttachmentMenuBot do
   @moduledoc  """
-  Returns information about a bot that can be added to attachment menu.
+  Returns information about a bot that can be added to attachment or side menu.
   Returns object_ptr<AttachmentMenuBot>.
 
   | Name | Type | Description |
@@ -516,6 +842,21 @@ defmodule SetGameScore do
 
   defstruct "@type": "setGameScore", "@extra": nil, chat_id: nil, message_id: nil, edit_message: nil, user_id: nil, score: nil, force: nil
 end
+defmodule ClickChatSponsoredMessage do
+  @moduledoc  """
+  Informs TDLib that the user opened the sponsored chat via the button, the name, the photo, or a mention in the sponsored message.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier of the sponsored message. |
+  | message_id | int53 | Identifier of the sponsored message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1click_chat_sponsored_message.html).
+  """
+
+  defstruct "@type": "clickChatSponsoredMessage", "@extra": nil, chat_id: nil, message_id: nil
+end
 defmodule SearchBackground do
   @moduledoc  """
   Searches for a background by its name.
@@ -544,19 +885,19 @@ defmodule AddNetworkStatistics do
 
   defstruct "@type": "addNetworkStatistics", "@extra": nil, entry: nil
 end
-defmodule GetChatFilterDefaultIconName do
+defmodule CheckLoginEmailAddressCode do
   @moduledoc  """
-  Returns default icon name for a filter. Can be called synchronously.
-  Returns object_ptr<Text>.
+  Checks the login email address authentication.
+  Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | filter | chatFilter | Chat filter. |
+  | code | EmailAddressAuthentication | Email address authentication to check. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_filter_default_icon_name.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_login_email_address_code.html).
   """
 
-  defstruct "@type": "getChatFilterDefaultIconName", "@extra": nil, filter: nil
+  defstruct "@type": "checkLoginEmailAddressCode", "@extra": nil, code: nil
 end
 defmodule ToggleGroupCallMuteNewParticipants do
   @moduledoc  """
@@ -587,9 +928,57 @@ defmodule EditCustomLanguagePackInfo do
 
   defstruct "@type": "editCustomLanguagePackInfo", "@extra": nil, info: nil
 end
+defmodule EditChatFolder do
+  @moduledoc  """
+  Edits existing chat folder. Returns information about the edited chat folder.
+  Returns object_ptr<ChatFolderInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | folder | chatFolder | The edited chat folder. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_chat_folder.html).
+  """
+
+  defstruct "@type": "editChatFolder", "@extra": nil, chat_folder_id: nil, folder: nil
+end
+defmodule EditBusinessChatLink do
+  @moduledoc  """
+  Edits a business chat link of the current account. Requires Telegram Business subscription. Returns the edited link.
+  Returns object_ptr<BusinessChatLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link | string | The link to edit. |
+  | link_info | inputBusinessChatLink | New description of the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_chat_link.html).
+  """
+
+  defstruct "@type": "editBusinessChatLink", "@extra": nil, link: nil, link_info: nil
+end
+defmodule AddMessageReaction do
+  @moduledoc  """
+  Adds a reaction or a tag to a message. Use getMessageAvailableReactions to receive the list of available reactions for the message.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which the message belongs. |
+  | message_id | int53 | Identifier of the message. |
+  | reaction_type | ReactionType | Type of the reaction to add. |
+  | is_big | bool | Pass true if the reaction is added with a big animation. |
+  | update_recent_reactions | bool | Pass true if the reaction needs to be added to recent reactions; tags are never added to the list of recent reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_message_reaction.html).
+  """
+
+  defstruct "@type": "addMessageReaction", "@extra": nil, chat_id: nil, message_id: nil, reaction_type: nil, is_big: nil, update_recent_reactions: nil
+end
 defmodule SetStickerPositionInSet do
   @moduledoc  """
-  Changes the position of a sticker in the set to which it belongs; for bots only. The sticker set must have been created by the bot.
+  Changes the position of a sticker in the set to which it belongs. The sticker set must be owned by the current user.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -633,7 +1022,7 @@ defmodule CancelDownloadFile do
 end
 defmodule EditMessageReplyMarkup do
   @moduledoc  """
-  Edits the message reply markup; for bots only. Returns the edited message after the edit is completed on the server side.
+  Edits the message reply markup; for bots only. Returns the edited message after the edit is completed on the server side. Can be used only if message.can_be_edited == true.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -689,9 +1078,20 @@ defmodule GetInactiveSupergroupChats do
 
   defstruct "@type": "getInactiveSupergroupChats", "@extra": nil
 end
+defmodule ResendLoginEmailAddressCode do
+  @moduledoc  """
+  Resends the login email address verification code.
+  Returns object_ptr<EmailAddressAuthenticationCodeInfo>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_login_email_address_code.html).
+  """
+
+  defstruct "@type": "resendLoginEmailAddressCode", "@extra": nil
+end
 defmodule SetChatPhoto do
   @moduledoc  """
-  Changes the photo of a chat. Supported only for basic groups, supergroups and channels. Requires can_change_info administrator right.
+  Changes the photo of a chat. Supported only for basic groups, supergroups and channels. Requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -703,6 +1103,20 @@ defmodule SetChatPhoto do
   """
 
   defstruct "@type": "setChatPhoto", "@extra": nil, chat_id: nil, photo: nil
+end
+defmodule GetSavedMessagesTags do
+  @moduledoc  """
+  Returns tags used in Saved Messages or a Saved Messages topic.
+  Returns object_ptr<SavedMessagesTags>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which tags will be returned; pass 0 to get all Saved Messages tags. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_saved_messages_tags.html).
+  """
+
+  defstruct "@type": "getSavedMessagesTags", "@extra": nil, saved_messages_topic_id: nil
 end
 defmodule TestGetDifference do
   @moduledoc  """
@@ -717,7 +1131,7 @@ defmodule TestGetDifference do
 end
 defmodule UnpinChatMessage do
   @moduledoc  """
-  Removes a pinned message from a chat; requires can_pin_messages rights in the group or can_edit_messages rights in the channel.
+  Removes a pinned message from a chat; requires can_pin_messages member right if the chat is a basic group or supergroup, or can_edit_messages administrator right if the chat is a channel.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -739,14 +1153,14 @@ defmodule GetMessageLink do
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which the message belongs. |
   | message_id | int53 | Identifier of the message. |
-  | media_timestamp | int32 | If not 0, timestamp from which the video/audio/video note/voice note playing must start, in seconds. The media can be in the message content or in its web page preview. |
+  | media_timestamp | int32 | If not 0, timestamp from which the video/audio/video note/voice note/story playing must start, in seconds. The media can be in the message content or in its web page preview. |
   | for_album | bool | Pass true to create a link for the whole media album. |
-  | for_comment | bool | Pass true to create a link to the message as a channel post comment, or from a message thread. |
+  | in_message_thread | bool | Pass true to create a link to the message as a channel post comment, in a message thread, or a forum topic. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_link.html).
   """
 
-  defstruct "@type": "getMessageLink", "@extra": nil, chat_id: nil, message_id: nil, media_timestamp: nil, for_album: nil, for_comment: nil
+  defstruct "@type": "getMessageLink", "@extra": nil, chat_id: nil, message_id: nil, media_timestamp: nil, for_album: nil, in_message_thread: nil
 end
 defmodule RemoveRecentlyFoundChat do
   @moduledoc  """
@@ -762,20 +1176,53 @@ defmodule RemoveRecentlyFoundChat do
 
   defstruct "@type": "removeRecentlyFoundChat", "@extra": nil, chat_id: nil
 end
-defmodule ToggleMessageSenderIsBlocked do
+defmodule RemoveBusinessConnectedBotFromChat do
   @moduledoc  """
-  Changes the block state of a message sender. Currently, only users and supergroup chats can be blocked.
+  Removes the connected business bot from a specific chat by adding the chat to businessRecipients.excluded_chat_ids.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sender_id | MessageSender | Identifier of a message sender to block/unblock. |
-  | is_blocked | bool | New value of is_blocked. |
+  | chat_id | int53 | Chat identifier. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_message_sender_is_blocked.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_business_connected_bot_from_chat.html).
   """
 
-  defstruct "@type": "toggleMessageSenderIsBlocked", "@extra": nil, sender_id: nil, is_blocked: nil
+  defstruct "@type": "removeBusinessConnectedBotFromChat", "@extra": nil, chat_id: nil
+end
+defmodule EditStory do
+  @moduledoc  """
+  Changes content and caption of a story. Can be called only if story.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Identifier of the story to edit. |
+  | content | InputStoryContent | New content of the story; pass null to keep the current content. |
+  | areas | inputStoryAreas | New clickable rectangle areas to be shown on the story media; pass null to keep the current areas. Areas can't be edited if story content isn't changed. |
+  | caption | formattedText | New story caption; pass null to keep the current caption. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_story.html).
+  """
+
+  defstruct "@type": "editStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil, content: nil, areas: nil, caption: nil
+end
+defmodule AddQuickReplyShortcutMessageAlbum do
+  @moduledoc  """
+  Adds 2-10 messages grouped together into an album to a quick reply shortcut. Currently, only audio, document, photo and video messages can be grouped into an album. Documents and audio files can be only grouped in an album with messages of the same type. Returns sent messages.
+  Returns object_ptr<QuickReplyMessages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_name | string | Name of the target shortcut. |
+  | reply_to_message_id | int53 | Identifier of a quick reply message in the same shortcut to be replied; pass 0 if none. |
+  | input_message_contents | InputMessageContent | Contents of messages to be sent. At most 10 messages can be added to an album. All messages must have the same value of show_caption_above_media. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_quick_reply_shortcut_message_album.html).
+  """
+
+  defstruct "@type": "addQuickReplyShortcutMessageAlbum", "@extra": nil, shortcut_name: nil, reply_to_message_id: nil, input_message_contents: nil
 end
 defmodule OpenChat do
   @moduledoc  """
@@ -791,9 +1238,49 @@ defmodule OpenChat do
 
   defstruct "@type": "openChat", "@extra": nil, chat_id: nil
 end
+defmodule SetBusinessAwayMessageSettings do
+  @moduledoc  """
+  Changes the business away message settings of the current user. Requires Telegram Business subscription.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | away_message_settings | businessAwayMessageSettings | The new settings for the away message of the business; pass null to disable the away message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_away_message_settings.html).
+  """
+
+  defstruct "@type": "setBusinessAwayMessageSettings", "@extra": nil, away_message_settings: nil
+end
+defmodule GetDefaultBackgroundCustomEmojiStickers do
+  @moduledoc  """
+  Returns default list of custom emoji stickers for reply background.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_background_custom_emoji_stickers.html).
+  """
+
+  defstruct "@type": "getDefaultBackgroundCustomEmojiStickers", "@extra": nil
+end
+defmodule SetProfileAccentColor do
+  @moduledoc  """
+  Changes accent color and background custom emoji for profile of the current user; for Telegram Premium users only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | profile_accent_color_id | int32 | Identifier of the accent color to use for profile; pass -1 if none. |
+  | profile_background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the user's profile photo background; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_profile_accent_color.html).
+  """
+
+  defstruct "@type": "setProfileAccentColor", "@extra": nil, profile_accent_color_id: nil, profile_background_custom_emoji_id: nil
+end
 defmodule UpgradeBasicGroupChatToSupergroupChat do
   @moduledoc  """
-  Creates a new supergroup from an existing basic group and sends a corresponding messageChatUpgradeTo and messageChatUpgradeFrom; requires creator privileges. Deactivates the original basic group.
+  Creates a new supergroup from an existing basic group and sends a corresponding messageChatUpgradeTo and messageChatUpgradeFrom; requires owner privileges. Deactivates the original basic group.
   Returns object_ptr<Chat>.
 
   | Name | Type | Description |
@@ -850,6 +1337,31 @@ defmodule CheckStickerSetName do
 
   defstruct "@type": "checkStickerSetName", "@extra": nil, name: nil
 end
+defmodule GetRecentEmojiStatuses do
+  @moduledoc  """
+  Returns recent emoji statuses for self status.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_recent_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getRecentEmojiStatuses", "@extra": nil
+end
+defmodule ApplyPremiumGiftCode do
+  @moduledoc  """
+  Applies a Telegram Premium gift code.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | string | The code to apply. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1apply_premium_gift_code.html).
+  """
+
+  defstruct "@type": "applyPremiumGiftCode", "@extra": nil, code: nil
+end
 defmodule SetMenuButton do
   @moduledoc  """
   Sets menu button for the given user or for all users; for bots only.
@@ -894,6 +1406,34 @@ defmodule CreateBasicGroupChat do
 
   defstruct "@type": "createBasicGroupChat", "@extra": nil, basic_group_id: nil, force: nil
 end
+defmodule CheckChatFolderInviteLink do
+  @moduledoc  """
+  Checks the validity of an invite link for a chat folder and returns information about the corresponding chat folder.
+  Returns object_ptr<ChatFolderInviteLinkInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invite_link | string | Invite link to be checked. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "checkChatFolderInviteLink", "@extra": nil, invite_link: nil
+end
+defmodule GetChatFolderChatCount do
+  @moduledoc  """
+  Returns approximate number of chats in a being created chat folder. Main and archive chat lists must be fully preloaded for this function to work correctly.
+  Returns object_ptr<Count>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | folder | chatFolder | The new chat folder. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder_chat_count.html).
+  """
+
+  defstruct "@type": "getChatFolderChatCount", "@extra": nil, folder: nil
+end
 defmodule ToggleChatHasProtectedContent do
   @moduledoc  """
   Changes the ability of users to save, forward, or copy chat content. Supported only for basic groups, supergroups and channels. Requires owner privileges.
@@ -911,7 +1451,7 @@ defmodule ToggleChatHasProtectedContent do
 end
 defmodule SearchChats do
   @moduledoc  """
-  Searches for the specified query in the title and username of already known chats, this is an offline request. Returns chats in the order seen in the main chat list.
+  Searches for the specified query in the title and username of already known chats; this is an offline request. Returns chats in the order seen in the main chat list.
   Returns object_ptr<Chats>.
 
   | Name | Type | Description |
@@ -975,6 +1515,22 @@ defmodule WriteGeneratedFilePart do
   """
 
   defstruct "@type": "writeGeneratedFilePart", "@extra": nil, generation_id: nil, offset: nil, data: nil
+end
+defmodule SendPhoneNumberCode do
+  @moduledoc  """
+  Sends a code to the specified phone number. Aborts previous phone number verification if there was one. On success, returns information about the sent code.
+  Returns object_ptr<AuthenticationCodeInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | phone_number | string | The phone number, in international format. |
+  | settings | phoneNumberAuthenticationSettings | Settings for the authentication of the user's phone number; pass null to use default settings. |
+  | type | PhoneNumberCodeType | Type of the request for which the code is sent. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_phone_number_code.html).
+  """
+
+  defstruct "@type": "sendPhoneNumberCode", "@extra": nil, phone_number: nil, settings: nil, type: nil
 end
 defmodule TestUseUpdate do
   @moduledoc  """
@@ -1040,14 +1596,29 @@ defmodule GetArchivedStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_masks | bool | Pass true to return mask stickers sets; pass false to return ordinary sticker sets. |
-  | offset_sticker_set_id | int64 | Identifier of the sticker set from which to return the result. |
+  | sticker_type | StickerType | Type of the sticker sets to return. |
+  | offset_sticker_set_id | int64 | Identifier of the sticker set from which to return the result; use 0 to get results from the beginning. |
   | limit | int32 | The maximum number of sticker sets to return; up to 100. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_archived_sticker_sets.html).
   """
 
-  defstruct "@type": "getArchivedStickerSets", "@extra": nil, is_masks: nil, offset_sticker_set_id: nil, limit: nil
+  defstruct "@type": "getArchivedStickerSets", "@extra": nil, sticker_type: nil, offset_sticker_set_id: nil, limit: nil
+end
+defmodule GetPremiumGiveawayInfo do
+  @moduledoc  """
+  Returns information about a Telegram Premium giveaway.
+  Returns object_ptr<PremiumGiveawayInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the channel chat which started the giveaway. |
+  | message_id | int53 | Identifier of the giveaway or a giveaway winners message in the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_premium_giveaway_info.html).
+  """
+
+  defstruct "@type": "getPremiumGiveawayInfo", "@extra": nil, chat_id: nil, message_id: nil
 end
 defmodule TerminateSession do
   @moduledoc  """
@@ -1088,6 +1659,68 @@ defmodule JoinChatByInviteLink do
 
   defstruct "@type": "joinChatByInviteLink", "@extra": nil, invite_link: nil
 end
+defmodule GetChatFolderChatsToLeave do
+  @moduledoc  """
+  Returns identifiers of pinned or always included chats from a chat folder, which are suggested to be left when the chat folder is deleted.
+  Returns object_ptr<Chats>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder_chats_to_leave.html).
+  """
+
+  defstruct "@type": "getChatFolderChatsToLeave", "@extra": nil, chat_folder_id: nil
+end
+defmodule GetSavedMessagesTopicMessageByDate do
+  @moduledoc  """
+  Returns the last message sent in a Saved Messages topic no later than the specified date.
+  Returns object_ptr<Message>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which message will be returned. |
+  | date | int32 | Point in time (Unix timestamp) relative to which to search for messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_saved_messages_topic_message_by_date.html).
+  """
+
+  defstruct "@type": "getSavedMessagesTopicMessageByDate", "@extra": nil, saved_messages_topic_id: nil, date: nil
+end
+defmodule GetInternalLink do
+  @moduledoc  """
+  Returns an HTTPS or a tg: link with the given type. Can be called before authorization.
+  Returns object_ptr<HttpUrl>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | type | InternalLinkType | Expected type of the link. |
+  | is_http | bool | Pass true to create an HTTPS link (only available for some link types); pass false to create a tg: link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_internal_link.html).
+  """
+
+  defstruct "@type": "getInternalLink", "@extra": nil, type: nil, is_http: nil
+end
+defmodule ShareUsersWithBot do
+  @moduledoc  """
+  Shares users after pressing a keyboardButtonTypeRequestUsers button with the bot.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat with the bot. |
+  | message_id | int53 | Identifier of the message with the button. |
+  | button_id | int32 | Identifier of the button. |
+  | shared_user_ids | int53 | Identifiers of the shared users. |
+  | only_check | bool | Pass true to check that the users can be shared by the button instead of actually sharing them. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1share_users_with_bot.html).
+  """
+
+  defstruct "@type": "shareUsersWithBot", "@extra": nil, chat_id: nil, message_id: nil, button_id: nil, shared_user_ids: nil, only_check: nil
+end
 defmodule GetLocalizationTargetInfo do
   @moduledoc  """
   Returns information about the current localization target. This is an offline request if only_local is true. Can be called before authorization.
@@ -1117,6 +1750,21 @@ defmodule RevokeChatInviteLink do
 
   defstruct "@type": "revokeChatInviteLink", "@extra": nil, chat_id: nil, invite_link: nil
 end
+defmodule SetStickerSetTitle do
+  @moduledoc  """
+  Sets a sticker set title.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | Sticker set name. The sticker set must be owned by the current user. |
+  | title | string | New sticker set title. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_sticker_set_title.html).
+  """
+
+  defstruct "@type": "setStickerSetTitle", "@extra": nil, name: nil, title: nil
+end
 defmodule GetFile do
   @moduledoc  """
   Returns information about a file; this is an offline request.
@@ -1145,35 +1793,54 @@ defmodule RemoveRecentHashtag do
 
   defstruct "@type": "removeRecentHashtag", "@extra": nil, hashtag: nil
 end
-defmodule SetBackground do
+defmodule SendBusinessMessage do
   @moduledoc  """
-  Changes the background selected by the user; adds background to the list of installed backgrounds.
-  Returns object_ptr<Background>.
+  Sends a message on behalf of a business account; for bots only. Returns the message after it was sent.
+  Returns object_ptr<BusinessMessage>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | background | InputBackground | The input background to use; pass null to create a new filled backgrounds or to remove the current background. |
-  | type | BackgroundType | Background type; pass null to use the default type of the remote background or to remove the current background. |
-  | for_dark_theme | bool | Pass true if the background is changed for a dark theme. |
+  | business_connection_id | string | Unique identifier of business connection on behalf of which to send the request. |
+  | chat_id | int53 | Target chat. |
+  | reply_to | InputMessageReplyTo | Information about the message to be replied; pass null if none. |
+  | disable_notification | bool | Pass true to disable notification for the message. |
+  | protect_content | bool | Pass true if the content of the message must be protected from forwarding and saving. |
+  | effect_id | int64 | Identifier of the effect to apply to the message. |
+  | reply_markup | ReplyMarkup | Markup for replying to the message; pass null if none. |
+  | input_message_content | InputMessageContent | The content of the message to be sent. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_background.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_business_message.html).
   """
 
-  defstruct "@type": "setBackground", "@extra": nil, background: nil, type: nil, for_dark_theme: nil
+  defstruct "@type": "sendBusinessMessage", "@extra": nil, business_connection_id: nil, chat_id: nil, reply_to: nil, disable_notification: nil, protect_content: nil, effect_id: nil, reply_markup: nil, input_message_content: nil
 end
-defmodule CheckPhoneNumberVerificationCode do
+defmodule GetChatActiveStories do
   @moduledoc  """
-  Checks the phone number verification code for Telegram Passport.
-  Returns object_ptr<Ok>.
+  Returns the list of active stories posted by the given chat.
+  Returns object_ptr<ChatActiveStories>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | code | string | Verification code to check. |
+  | chat_id | int53 | Chat identifier. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_phone_number_verification_code.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_active_stories.html).
   """
 
-  defstruct "@type": "checkPhoneNumberVerificationCode", "@extra": nil, code: nil
+  defstruct "@type": "getChatActiveStories", "@extra": nil, chat_id: nil
+end
+defmodule CreateChatFolder do
+  @moduledoc  """
+  Creates new chat folder. Returns information about the created chat folder. There can be up to getOption("chat_folder_count_max") chat folders, but the limit can be increased with Telegram Premium.
+  Returns object_ptr<ChatFolderInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | folder | chatFolder | The new chat folder. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_chat_folder.html).
+  """
+
+  defstruct "@type": "createChatFolder", "@extra": nil, folder: nil
 end
 defmodule GetStatisticalGraph do
   @moduledoc  """
@@ -1200,11 +1867,12 @@ defmodule ResendMessages do
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to send messages. |
   | message_ids | int53 | Identifiers of the messages to resend. Message identifiers must be in a strictly increasing order. |
+  | quote | inputTextQuote | New manually chosen quote from the message to be replied; pass null if none. Ignored if more than one message is re-sent, or if messageSendingStateFailed.need_another_reply_quote == false. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_messages.html).
   """
 
-  defstruct "@type": "resendMessages", "@extra": nil, chat_id: nil, message_ids: nil
+  defstruct "@type": "resendMessages", "@extra": nil, chat_id: nil, message_ids: nil, quote: nil
 end
 defmodule GetCountryCode do
   @moduledoc  """
@@ -1226,16 +1894,32 @@ defmodule SendWebAppData do
   |------|------| ------------|
   | bot_user_id | int53 | Identifier of the target bot. |
   | button_text | string | Text of the <a class="el" href="classtd_1_1td__api_1_1keyboard_button_type_web_app.html">keyboardButtonTypeWebApp</a> button, which opened the Web App. |
-  | data | string | Received data. |
+  | data | string | The data. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_web_app_data.html).
   """
 
   defstruct "@type": "sendWebAppData", "@extra": nil, bot_user_id: nil, button_text: nil, data: nil
 end
+defmodule GetChatPostedToChatPageStories do
+  @moduledoc  """
+  Returns the list of stories that posted by the given chat to its chat page. If from_story_id == 0, then pinned stories are returned first. Then, stories are returned in a reverse chronological order (i.e., in order of decreasing story_id). For optimal performance, the number of returned stories is chosen by TDLib.
+  Returns object_ptr<Stories>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | from_story_id | int32 | Identifier of the story starting from which stories must be returned; use 0 to get results from pinned and the newest story. |
+  | limit | int32 | The maximum number of stories to be returned For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_posted_to_chat_page_stories.html).
+  """
+
+  defstruct "@type": "getChatPostedToChatPageStories", "@extra": nil, chat_id: nil, from_story_id: nil, limit: nil
+end
 defmodule GetRecentlyOpenedChats do
   @moduledoc  """
-  Returns recently opened chats, this is an offline request. Returns chats in the order of last opening.
+  Returns recently opened chats; this is an offline request. Returns chats in the order of last opening.
   Returns object_ptr<Chats>.
 
   | Name | Type | Description |
@@ -1261,6 +1945,22 @@ defmodule GetStorageStatistics do
 
   defstruct "@type": "getStorageStatistics", "@extra": nil, chat_limit: nil
 end
+defmodule GetChatRevenueTransactions do
+  @moduledoc  """
+  Returns the list of revenue transactions for a chat. Currently, this method can be used only for channels if supergroupFullInfo.can_get_revenue_statistics == true.
+  Returns object_ptr<ChatRevenueTransactions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | offset | int32 | Number of transactions to skip. |
+  | limit | int32 | The maximum number of transactions to be returned; up to 200. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_revenue_transactions.html).
+  """
+
+  defstruct "@type": "getChatRevenueTransactions", "@extra": nil, chat_id: nil, offset: nil, limit: nil
+end
 defmodule OptimizeStorage do
   @moduledoc  """
   Optimizes storage usage, i.e. deletes some files and returns new storage usage statistics. Secret thumbnails can't be deleted.
@@ -1283,6 +1983,17 @@ defmodule OptimizeStorage do
 
   defstruct "@type": "optimizeStorage", "@extra": nil, size: nil, ttl: nil, count: nil, immunity_delay: nil, file_types: nil, chat_ids: nil, exclude_chat_ids: nil, return_deleted_file_statistics: nil, chat_limit: nil
 end
+defmodule GetSupportName do
+  @moduledoc  """
+  Returns localized name of the Telegram support user; for Telegram support only.
+  Returns object_ptr<Text>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_support_name.html).
+  """
+
+  defstruct "@type": "getSupportName", "@extra": nil
+end
 defmodule GetBackgroundUrl do
   @moduledoc  """
   Constructs a persistent HTTP URL for a background.
@@ -1291,7 +2002,7 @@ defmodule GetBackgroundUrl do
   | Name | Type | Description |
   |------|------| ------------|
   | name | string | Background name. |
-  | type | BackgroundType | Background type. |
+  | type | BackgroundType | Background type; <a class="el" href="classtd_1_1td__api_1_1background_type_chat_theme.html">backgroundTypeChatTheme</a> isn't supported. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_background_url.html).
   """
@@ -1321,7 +2032,7 @@ defmodule SetChatNotificationSettings do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | notification_settings | chatNotificationSettings | New notification settings for the chat. If the chat is muted for more than 1 week, it is considered to be muted forever. |
+  | notification_settings | chatNotificationSettings | New notification settings for the chat. If the chat is muted for more than 366 days, it is considered to be muted forever. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_notification_settings.html).
   """
@@ -1357,32 +2068,17 @@ defmodule DeleteCommands do
 
   defstruct "@type": "deleteCommands", "@extra": nil, scope: nil, language_code: nil
 end
-defmodule DeleteChatFilter do
-  @moduledoc  """
-  Deletes existing chat filter.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_filter_id | int32 | Chat filter identifier. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_chat_filter.html).
-  """
-
-  defstruct "@type": "deleteChatFilter", "@extra": nil, chat_filter_id: nil
-end
 defmodule SearchMessages do
   @moduledoc  """
   Searches for messages in all chats except secret chats. Returns the results in reverse chronological order (i.e., in order of decreasing (date, chat_id, message_id)). For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit.
-  Returns object_ptr<Messages>.
+  Returns object_ptr<FoundMessages>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_list | ChatList | Chat list in which to search messages; pass null to search in all chats regardless of their chat list. Only Main and Archive chat lists are supported. |
+  | only_in_channels | bool | Pass true to search only for messages in channels. |
   | query | string | Query to search for. |
-  | offset_date | int32 | The date of the message starting from which the results need to be fetched. Use 0 or any date in the future to get results from the last message. |
-  | offset_chat_id | int53 | The chat identifier of the last found message, or 0 for the first request. |
-  | offset_message_id | int53 | The message identifier of the last found message, or 0 for the first request. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
   | limit | int32 | The maximum number of messages to be returned; up to 100. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
   | filter | SearchMessagesFilter | Additional filter for messages to search; pass null to search for all messages. Filters <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_mention.html">searchMessagesFilterMention</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_mention.html">searchMessagesFilterUnreadMention</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_reaction.html">searchMessagesFilterUnreadReaction</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_failed_to_send.html">searchMessagesFilterFailedToSend</a>, and <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_pinned.html">searchMessagesFilterPinned</a> are unsupported in this function. |
   | min_date | int32 | If not 0, the minimum date of the messages to return. |
@@ -1391,7 +2087,22 @@ defmodule SearchMessages do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_messages.html).
   """
 
-  defstruct "@type": "searchMessages", "@extra": nil, chat_list: nil, query: nil, offset_date: nil, offset_chat_id: nil, offset_message_id: nil, limit: nil, filter: nil, min_date: nil, max_date: nil
+  defstruct "@type": "searchMessages", "@extra": nil, chat_list: nil, only_in_channels: nil, query: nil, offset: nil, limit: nil, filter: nil, min_date: nil, max_date: nil
+end
+defmodule CloseStory do
+  @moduledoc  """
+  Informs TDLib that a story is closed by the user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story to close. |
+  | story_id | int32 | The identifier of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1close_story.html).
+  """
+
+  defstruct "@type": "closeStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
 end
 defmodule GetLogStream do
   @moduledoc  """
@@ -1425,7 +2136,7 @@ defmodule GetPaymentReceipt do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Chat identifier of the PaymentSuccessful message. |
+  | chat_id | int53 | Chat identifier of the <a class="el" href="classtd_1_1td__api_1_1message_payment_successful.html">messagePaymentSuccessful</a> message. |
   | message_id | int53 | Message identifier. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_payment_receipt.html).
@@ -1441,28 +2152,14 @@ defmodule ViewMessages do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the messages are being viewed. |
   | message_ids | int53 | The identifiers of the messages being viewed. |
+  | source | MessageSource | Source of the message view; pass null to guess the source based on chat open state. |
   | force_read | bool | Pass true to mark as read the specified messages even the chat is closed. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1view_messages.html).
   """
 
-  defstruct "@type": "viewMessages", "@extra": nil, chat_id: nil, message_thread_id: nil, message_ids: nil, force_read: nil
-end
-defmodule GetChatFilter do
-  @moduledoc  """
-  Returns information about a chat filter by its identifier.
-  Returns object_ptr<ChatFilter>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_filter_id | int32 | Chat filter identifier. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_filter.html).
-  """
-
-  defstruct "@type": "getChatFilter", "@extra": nil, chat_filter_id: nil
+  defstruct "@type": "viewMessages", "@extra": nil, chat_id: nil, message_ids: nil, source: nil, force_read: nil
 end
 defmodule DisableProxy do
   @moduledoc  """
@@ -1491,7 +2188,7 @@ defmodule GetSecretChat do
 end
 defmodule EditMessageLiveLocation do
   @moduledoc  """
-  Edits the message content of a live location. Messages can be edited for a limited period of time specified in the live location. Returns the edited message after the edit is completed on the server side.
+  Edits the message content of a live location. Messages can be edited for a limited period of time specified in the live location. Returns the edited message after the edit is completed on the server side. Can be used only if message.can_be_edited == true.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -1500,13 +2197,14 @@ defmodule EditMessageLiveLocation do
   | message_id | int53 | Identifier of the message. |
   | reply_markup | ReplyMarkup | The new message reply markup; pass null if none; for bots only. |
   | location | location | New location content of the message; pass null to stop sharing the live location. |
+  | live_period | int32 | New time relative to the message send date, for which the location can be updated, in seconds. If 0x7FFFFFFF specified, then the location can be updated forever. Otherwise, must not exceed the current live_period by more than a day, and the live location expiration date must remain in the next 90 days. Pass 0 to keep the current live_period. |
   | heading | int32 | The new direction in which the location moves, in degrees; 1-360. Pass 0 if unknown. |
   | proximity_alert_radius | int32 | The new maximum distance for proximity alerts, in meters (0-100000). Pass 0 if the notification is disabled. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_message_live_location.html).
   """
 
-  defstruct "@type": "editMessageLiveLocation", "@extra": nil, chat_id: nil, message_id: nil, reply_markup: nil, location: nil, heading: nil, proximity_alert_radius: nil
+  defstruct "@type": "editMessageLiveLocation", "@extra": nil, chat_id: nil, message_id: nil, reply_markup: nil, location: nil, live_period: nil, heading: nil, proximity_alert_radius: nil
 end
 defmodule SharePhoneNumber do
   @moduledoc  """
@@ -1565,6 +2263,21 @@ defmodule AddSavedNotificationSound do
 
   defstruct "@type": "addSavedNotificationSound", "@extra": nil, sound: nil
 end
+defmodule SetAccentColor do
+  @moduledoc  """
+  Changes accent color and background custom emoji for the current user; for Telegram Premium users only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | accent_color_id | int32 | Identifier of the accent color to use. |
+  | background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the reply header and link preview background; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_accent_color.html).
+  """
+
+  defstruct "@type": "setAccentColor", "@extra": nil, accent_color_id: nil, background_custom_emoji_id: nil
+end
 defmodule RecoverPassword do
   @moduledoc  """
   Recovers the 2-step verification password using a recovery code sent to an email address that was previously set up.
@@ -1573,13 +2286,42 @@ defmodule RecoverPassword do
   | Name | Type | Description |
   |------|------| ------------|
   | recovery_code | string | Recovery code to check. |
-  | new_password | string | New password of the user; may be empty to remove the password. |
+  | new_password | string | New 2-step verification password of the user; may be empty to remove the password. |
   | new_hint | string | New password hint; may be empty. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recover_password.html).
   """
 
   defstruct "@type": "recoverPassword", "@extra": nil, recovery_code: nil, new_password: nil, new_hint: nil
+end
+defmodule ToggleChatViewAsTopics do
+  @moduledoc  """
+  Changes the view_as_topics setting of a forum chat or Saved Messages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | view_as_topics | bool | New value of view_as_topics. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_chat_view_as_topics.html).
+  """
+
+  defstruct "@type": "toggleChatViewAsTopics", "@extra": nil, chat_id: nil, view_as_topics: nil
+end
+defmodule GetChatBoostLinkInfo do
+  @moduledoc  """
+  Returns information about a link to boost a chat. Can be called for any internal link of the type internalLinkTypeChatBoost.
+  Returns object_ptr<ChatBoostLinkInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | The link to boost a chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boost_link_info.html).
+  """
+
+  defstruct "@type": "getChatBoostLinkInfo", "@extra": nil, url: nil
 end
 defmodule ToggleGroupCallParticipantIsHandRaised do
   @moduledoc  """
@@ -1599,7 +2341,7 @@ defmodule ToggleGroupCallParticipantIsHandRaised do
 end
 defmodule DeleteChat do
   @moduledoc  """
-  Deletes a chat along with all messages in the corresponding chat for all chat members. For group chats this will release the username and remove all members. Use the field chat.can_be_deleted_for_all_users to find whether the method can be applied to the chat.
+  Deletes a chat along with all messages in the corresponding chat for all chat members. For group chats this will release the usernames and remove all members. Use the field chat.can_be_deleted_for_all_users to find whether the method can be applied to the chat.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -1628,17 +2370,18 @@ defmodule ClickAnimatedEmojiMessage do
 end
 defmodule SearchStickerSets do
   @moduledoc  """
-  Searches for ordinary sticker sets by looking for specified query in their title and name. Excludes installed sticker sets from the results.
+  Searches for sticker sets by looking for specified query in their title and name. Excludes installed sticker sets from the results.
   Returns object_ptr<StickerSets>.
 
   | Name | Type | Description |
   |------|------| ------------|
+  | sticker_type | StickerType | Type of the sticker sets to return. |
   | query | string | Query to search for. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_sticker_sets.html).
   """
 
-  defstruct "@type": "searchStickerSets", "@extra": nil, query: nil
+  defstruct "@type": "searchStickerSets", "@extra": nil, sticker_type: nil, query: nil
 end
 defmodule RemoveTopChat do
   @moduledoc  """
@@ -1666,9 +2409,39 @@ defmodule GetAuthorizationState do
 
   defstruct "@type": "getAuthorizationState", "@extra": nil
 end
+defmodule ToggleBotUsernameIsActive do
+  @moduledoc  """
+  Changes active state for a username of a bot. The editable username can't be disabled. May return an error with a message "USERNAMES_ACTIVE_TOO_MUCH" if the maximum number of active usernames has been reached. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | username | string | The username to change. |
+  | is_active | bool | Pass true to activate the username; pass false to disable it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_bot_username_is_active.html).
+  """
+
+  defstruct "@type": "toggleBotUsernameIsActive", "@extra": nil, bot_user_id: nil, username: nil, is_active: nil
+end
+defmodule GetChatFolderNewChats do
+  @moduledoc  """
+  Returns new chats added to a shareable chat folder by its owner. The method must be called at most once in getOption("chat_folder_new_chats_update_period") for the given chat folder.
+  Returns object_ptr<Chats>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder_new_chats.html).
+  """
+
+  defstruct "@type": "getChatFolderNewChats", "@extra": nil, chat_folder_id: nil
+end
 defmodule StopPoll do
   @moduledoc  """
-  Stops a poll. A poll in a message can be stopped when the message has can_be_edited flag set.
+  Stops a poll. A poll in a message can be stopped when the message has can_be_edited flag is set.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -1682,6 +2455,41 @@ defmodule StopPoll do
 
   defstruct "@type": "stopPoll", "@extra": nil, chat_id: nil, message_id: nil, reply_markup: nil
 end
+defmodule SendBusinessMessageAlbum do
+  @moduledoc  """
+  Sends 2-10 messages grouped together into an album on behalf of a business account; for bots only. Currently, only audio, document, photo and video messages can be grouped into an album. Documents and audio files can be only grouped in an album with messages of the same type. Returns sent messages.
+  Returns object_ptr<BusinessMessages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which to send the request. |
+  | chat_id | int53 | Target chat. |
+  | reply_to | InputMessageReplyTo | Information about the message to be replied; pass null if none. |
+  | disable_notification | bool | Pass true to disable notification for the message. |
+  | protect_content | bool | Pass true if the content of the message must be protected from forwarding and saving. |
+  | effect_id | int64 | Identifier of the effect to apply to the message. |
+  | input_message_contents | InputMessageContent | Contents of messages to be sent. At most 10 messages can be added to an album. All messages must have the same value of show_caption_above_media. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_business_message_album.html).
+  """
+
+  defstruct "@type": "sendBusinessMessageAlbum", "@extra": nil, business_connection_id: nil, chat_id: nil, reply_to: nil, disable_notification: nil, protect_content: nil, effect_id: nil, input_message_contents: nil
+end
+defmodule GetBotName do
+  @moduledoc  """
+  Returns the name of a bot in the given language. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Text>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code or an empty string. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_bot_name.html).
+  """
+
+  defstruct "@type": "getBotName", "@extra": nil, bot_user_id: nil, language_code: nil
+end
 defmodule GetMessageAddedReactions do
   @moduledoc  """
   Returns reactions added for a message, along with their sender.
@@ -1691,25 +2499,14 @@ defmodule GetMessageAddedReactions do
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which the message belongs. |
   | message_id | int53 | Identifier of the message. |
-  | reaction | string | If non-empty, only added reactions with the specified text representation will be returned. |
+  | reaction_type | ReactionType | Type of the reactions to return; pass null to return all added reactions. |
   | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
   | limit | int32 | The maximum number of reactions to be returned; must be positive and can't be greater than 100. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_added_reactions.html).
   """
 
-  defstruct "@type": "getMessageAddedReactions", "@extra": nil, chat_id: nil, message_id: nil, reaction: nil, offset: nil, limit: nil
-end
-defmodule CanPurchasePremium do
-  @moduledoc  """
-  Checks whether Telegram Premium purchase is possible. Must be called before in-store Premium purchase.
-  Returns object_ptr<Ok>.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_purchase_premium.html).
-  """
-
-  defstruct "@type": "canPurchasePremium", "@extra": nil
+  defstruct "@type": "getMessageAddedReactions", "@extra": nil, chat_id: nil, message_id: nil, reaction_type: nil, offset: nil, limit: nil
 end
 defmodule RemoveRecentSticker do
   @moduledoc  """
@@ -1745,21 +2542,6 @@ defmodule EditChatInviteLink do
 
   defstruct "@type": "editChatInviteLink", "@extra": nil, chat_id: nil, invite_link: nil, name: nil, expiration_date: nil, member_limit: nil, creates_join_request: nil
 end
-defmodule ReorderChatFilters do
-  @moduledoc  """
-  Changes the order of chat filters.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_filter_ids | int32 | Identifiers of chat filters in the new correct order. |
-  | main_chat_list_position | int32 | Position of the main chat list among chat filters, 0-based. Can be non-zero only for Premium users. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_chat_filters.html).
-  """
-
-  defstruct "@type": "reorderChatFilters", "@extra": nil, chat_filter_ids: nil, main_chat_list_position: nil
-end
 defmodule GetPassportElement do
   @moduledoc  """
   Returns one of the available Telegram Passport elements.
@@ -1768,7 +2550,7 @@ defmodule GetPassportElement do
   | Name | Type | Description |
   |------|------| ------------|
   | type | PassportElementType | Telegram Passport element type. |
-  | password | string | Password of the current user. |
+  | password | string | The 2-step verification password of the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_passport_element.html).
   """
@@ -1777,7 +2559,7 @@ defmodule GetPassportElement do
 end
 defmodule AddRecentSticker do
   @moduledoc  """
-  Manually adds a new sticker to the list of recently used stickers. The new sticker is added to the top of the list. If the sticker was already in the list, it is removed from the list first. Only stickers belonging to a sticker set can be added to this list.
+  Manually adds a new sticker to the list of recently used stickers. The new sticker is added to the top of the list. If the sticker was already in the list, it is removed from the list first. Only stickers belonging to a sticker set or in WEBP or WEBM format can be added to this list. Emoji stickers can't be added to recent stickers.
   Returns object_ptr<Stickers>.
 
   | Name | Type | Description |
@@ -1789,6 +2571,21 @@ defmodule AddRecentSticker do
   """
 
   defstruct "@type": "addRecentSticker", "@extra": nil, is_attached: nil, sticker: nil
+end
+defmodule SetChatEmojiStatus do
+  @moduledoc  """
+  Changes the emoji status of a chat. Use chatBoostLevelFeatures.can_set_emoji_status to check whether an emoji status can be set. Requires can_change_info administrator right.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | emoji_status | emojiStatus | New emoji status; pass null to remove emoji status. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_emoji_status.html).
+  """
+
+  defstruct "@type": "setChatEmojiStatus", "@extra": nil, chat_id: nil, emoji_status: nil
 end
 defmodule GetRecentStickers do
   @moduledoc  """
@@ -1835,7 +2632,7 @@ defmodule GetPhoneNumberInfoSync do
 end
 defmodule GetLogTags do
   @moduledoc  """
-  Returns list of available TDLib internal log tags, for example, ["actor", "binlog", "connections", "notifications", "proxy"]. Can be called synchronously.
+  Returns the list of available TDLib internal log tags, for example, ["actor", "binlog", "connections", "notifications", "proxy"]. Can be called synchronously.
   Returns object_ptr<LogTags>.
 
 
@@ -1843,6 +2640,20 @@ defmodule GetLogTags do
   """
 
   defstruct "@type": "getLogTags", "@extra": nil
+end
+defmodule ReorderActiveUsernames do
+  @moduledoc  """
+  Changes order of active usernames of the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | usernames | string | The new order of active usernames. All currently active usernames must be specified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_active_usernames.html).
+  """
+
+  defstruct "@type": "reorderActiveUsernames", "@extra": nil, usernames: nil
 end
 defmodule ClearAllDraftMessages do
   @moduledoc  """
@@ -1857,6 +2668,21 @@ defmodule ClearAllDraftMessages do
   """
 
   defstruct "@type": "clearAllDraftMessages", "@extra": nil, exclude_secret_chats: nil
+end
+defmodule SearchWebApp do
+  @moduledoc  """
+  Returns information about a Web App by its short name. Returns a 404 error if the Web App is not found.
+  Returns object_ptr<FoundWebApp>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | web_app_short_name | string | Short name of the Web App. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_web_app.html).
+  """
+
+  defstruct "@type": "searchWebApp", "@extra": nil, bot_user_id: nil, web_app_short_name: nil
 end
 defmodule RemoveAllFilesFromDownloads do
   @moduledoc  """
@@ -1885,6 +2711,35 @@ defmodule DeleteSavedOrderInfo do
 
   defstruct "@type": "deleteSavedOrderInfo", "@extra": nil
 end
+defmodule ToggleSupergroupCanHaveSponsoredMessages do
+  @moduledoc  """
+  Toggles whether sponsored messages are shown in the channel chat; requires owner privileges in the channel. The chat must have at least chatBoostFeatures.min_sponsored_message_disable_boost_level boost level to disable sponsored messages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | The identifier of the channel. |
+  | can_have_sponsored_messages | bool | The new value of can_have_sponsored_messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_can_have_sponsored_messages.html).
+  """
+
+  defstruct "@type": "toggleSupergroupCanHaveSponsoredMessages", "@extra": nil, supergroup_id: nil, can_have_sponsored_messages: nil
+end
+defmodule SetBirthdate do
+  @moduledoc  """
+  Changes the birthdate of the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | birthdate | birthdate | The new value of the current user's birthdate; pass null to remove the birthdate. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_birthdate.html).
+  """
+
+  defstruct "@type": "setBirthdate", "@extra": nil, birthdate: nil
+end
 defmodule SetChatClientData do
   @moduledoc  """
   Changes application-specific data associated with a chat.
@@ -1900,6 +2755,24 @@ defmodule SetChatClientData do
 
   defstruct "@type": "setChatClientData", "@extra": nil, chat_id: nil, client_data: nil
 end
+defmodule SetChatBackground do
+  @moduledoc  """
+  Sets the background in a specific chat. Supported only in private and secret chats with non-deleted users, and in chats with sufficient boost level and can_change_info administrator right.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | background | InputBackground | The input background to use; pass null to create a new filled or chat theme background. |
+  | type | BackgroundType | Background type; pass null to use default background type for the chosen background; <a class="el" href="classtd_1_1td__api_1_1background_type_chat_theme.html">backgroundTypeChatTheme</a> isn't supported for private and secret chats. Use chatBoostLevelFeatures.chat_theme_background_count and chatBoostLevelFeatures.can_set_custom_background to check whether the background type can be set in the boosted chat. |
+  | dark_theme_dimming | int32 | Dimming of the background in dark themes, as a percentage; 0-100. Applied only to Wallpaper and Fill types of background. |
+  | only_for_self | bool | Pass true to set background only for self; pass false to set background for all chat users. Always false for backgrounds set in boosted chats. Background can be set for both users only by Telegram Premium users and if set background isn't of the type <a class="el" href="classtd_1_1td__api_1_1input_background_previous.html">inputBackgroundPrevious</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_background.html).
+  """
+
+  defstruct "@type": "setChatBackground", "@extra": nil, chat_id: nil, background: nil, type: nil, dark_theme_dimming: nil, only_for_self: nil
+end
 defmodule SendMessage do
   @moduledoc  """
   Sends a message. Returns the sent message.
@@ -1908,8 +2781,8 @@ defmodule SendMessage do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Target chat. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the message will be sent. |
-  | reply_to_message_id | int53 | Identifier of the replied message; 0 if none. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the message will be sent. |
+  | reply_to | InputMessageReplyTo | Information about the message or story to be replied; pass null if none. |
   | options | messageSendOptions | Options to be used to send the message; pass null to use default options. |
   | reply_markup | ReplyMarkup | Markup for replying to the message; pass null if none; for bots only. |
   | input_message_content | InputMessageContent | The content of the message to be sent. |
@@ -1917,7 +2790,7 @@ defmodule SendMessage do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_message.html).
   """
 
-  defstruct "@type": "sendMessage", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to_message_id: nil, options: nil, reply_markup: nil, input_message_content: nil
+  defstruct "@type": "sendMessage", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to: nil, options: nil, reply_markup: nil, input_message_content: nil
 end
 defmodule GetSavedNotificationSound do
   @moduledoc  """
@@ -1933,6 +2806,21 @@ defmodule GetSavedNotificationSound do
 
   defstruct "@type": "getSavedNotificationSound", "@extra": nil, notification_sound_id: nil
 end
+defmodule GetChatSimilarChatCount do
+  @moduledoc  """
+  Returns approximate number of chats similar to the given chat.
+  Returns object_ptr<Count>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the target chat; must be an identifier of a channel chat. |
+  | return_local | bool | Pass true to get the number of chats without sending network requests, or -1 if the number of chats is unknown locally. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_similar_chat_count.html).
+  """
+
+  defstruct "@type": "getChatSimilarChatCount", "@extra": nil, chat_id: nil, return_local: nil
+end
 defmodule SearchInstalledStickerSets do
   @moduledoc  """
   Searches for installed sticker sets by looking for specified query in their title and name.
@@ -1940,28 +2828,49 @@ defmodule SearchInstalledStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_masks | bool | Pass true to return mask sticker sets; pass false to return ordinary sticker sets. |
+  | sticker_type | StickerType | Type of the sticker sets to search for. |
   | query | string | Query to search for. |
   | limit | int32 | The maximum number of sticker sets to return. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_installed_sticker_sets.html).
   """
 
-  defstruct "@type": "searchInstalledStickerSets", "@extra": nil, is_masks: nil, query: nil, limit: nil
+  defstruct "@type": "searchInstalledStickerSets", "@extra": nil, sticker_type: nil, query: nil, limit: nil
 end
-defmodule CheckPhoneNumberConfirmationCode do
+defmodule SearchSavedMessages do
   @moduledoc  """
-  Checks phone number confirmation code.
-  Returns object_ptr<Ok>.
+  Searches for messages tagged by the given reaction and with the given words in the Saved Messages chat; for Telegram Premium users only. Returns the results in reverse chronological order, i.e. in order of decreasing message_id For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit.
+  Returns object_ptr<FoundChatMessages>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | code | string | Confirmation code to check. |
+  | saved_messages_topic_id | int53 | If not 0, only messages in the specified Saved Messages topic will be considered; pass 0 to consider all messages. |
+  | tag | ReactionType | Tag to search for; pass null to return all suitable messages. |
+  | query | string | Query to search for. |
+  | from_message_id | int53 | Identifier of the message starting from which messages must be fetched; use 0 to get results from the last message. |
+  | offset | int32 | Specify 0 to get results from exactly the message from_message_id or a negative offset to get the specified message and some newer messages. |
+  | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_phone_number_confirmation_code.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_saved_messages.html).
   """
 
-  defstruct "@type": "checkPhoneNumberConfirmationCode", "@extra": nil, code: nil
+  defstruct "@type": "searchSavedMessages", "@extra": nil, saved_messages_topic_id: nil, tag: nil, query: nil, from_message_id: nil, offset: nil, limit: nil
+end
+defmodule GetStoryStatistics do
+  @moduledoc  """
+  Returns detailed statistics about a story. Can be used only if story.can_get_statistics == true.
+  Returns object_ptr<StoryStatistics>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | story_id | int32 | Story identifier. |
+  | is_dark | bool | Pass true if a dark theme is used by the application. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story_statistics.html).
+  """
+
+  defstruct "@type": "getStoryStatistics", "@extra": nil, chat_id: nil, story_id: nil, is_dark: nil
 end
 defmodule GetChatMessageCount do
   @moduledoc  """
@@ -1972,12 +2881,52 @@ defmodule GetChatMessageCount do
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat in which to count messages. |
   | filter | SearchMessagesFilter | Filter for message content; <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_empty.html">searchMessagesFilterEmpty</a> is unsupported in this function. |
+  | saved_messages_topic_id | int53 | If not 0, only messages in the specified Saved Messages topic will be counted; pass 0 to count all messages, or for chats other than Saved Messages. |
   | return_local | bool | Pass true to get the number of messages without sending network requests, or -1 if the number of messages is unknown locally. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_message_count.html).
   """
 
-  defstruct "@type": "getChatMessageCount", "@extra": nil, chat_id: nil, filter: nil, return_local: nil
+  defstruct "@type": "getChatMessageCount", "@extra": nil, chat_id: nil, filter: nil, saved_messages_topic_id: nil, return_local: nil
+end
+defmodule GetBusinessChatLinkInfo do
+  @moduledoc  """
+  Returns information about a business chat link.
+  Returns object_ptr<BusinessChatLinkInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link_name | string | Name of the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_business_chat_link_info.html).
+  """
+
+  defstruct "@type": "getBusinessChatLinkInfo", "@extra": nil, link_name: nil
+end
+defmodule GetStarPaymentOptions do
+  @moduledoc  """
+  Returns available options for Telegram stars purchase.
+  Returns object_ptr<StarPaymentOptions>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_star_payment_options.html).
+  """
+
+  defstruct "@type": "getStarPaymentOptions", "@extra": nil
+end
+defmodule GetChatBoostFeatures do
+  @moduledoc  """
+  Returns the list of features available for different chat boost levels; this is an offline request.
+  Returns object_ptr<ChatBoostFeatures>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_channel | bool | Pass true to get the list of features for channels; pass false to get the list of features for supergroups. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boost_features.html).
+  """
+
+  defstruct "@type": "getChatBoostFeatures", "@extra": nil, is_channel: nil
 end
 defmodule SendCustomRequest do
   @moduledoc  """
@@ -1996,7 +2945,7 @@ defmodule SendCustomRequest do
 end
 defmodule AddFavoriteSticker do
   @moduledoc  """
-  Adds a new sticker to the list of favorite stickers. The new sticker is added to the top of the list. If the sticker was already in the list, it is removed from the list first. Only stickers belonging to a sticker set can be added to this list.
+  Adds a new sticker to the list of favorite stickers. The new sticker is added to the top of the list. If the sticker was already in the list, it is removed from the list first. Only stickers belonging to a sticker set or in WEBP or WEBM format can be added to this list. Emoji stickers can't be added to favorite stickers.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -2007,6 +2956,23 @@ defmodule AddFavoriteSticker do
   """
 
   defstruct "@type": "addFavoriteSticker", "@extra": nil, sticker: nil
+end
+defmodule EditBusinessMessageReplyMarkup do
+  @moduledoc  """
+  Edits the reply markup of a message sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_message_reply_markup.html).
+  """
+
+  defstruct "@type": "editBusinessMessageReplyMarkup", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil
 end
 defmodule SetScopeNotificationSettings do
   @moduledoc  """
@@ -2054,6 +3020,52 @@ defmodule ToggleChatDefaultDisableNotification do
 
   defstruct "@type": "toggleChatDefaultDisableNotification", "@extra": nil, chat_id: nil, default_disable_notification: nil
 end
+defmodule TranslateMessageText do
+  @moduledoc  """
+  Extracts text or caption of the given message and translates it to the given language. If the current user is a Telegram Premium user, then text formatting is preserved.
+  Returns object_ptr<FormattedText>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which the message belongs. |
+  | message_id | int53 | Identifier of the message. |
+  | to_language_code | string | Language code of the language to which the message is translated. Must be one of "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg", "ca", "ceb", "zh-CN", "zh", "zh-Hans", "zh-TW", "zh-Hant", "co", "hr", "cs", "da", "nl", "en", "eo", "et", "fi", "fr", "fy", "gl", "ka", "de", "el", "gu", "ht", "ha", "haw", "he", "iw", "hi", "hmn", "hu", "is", "ig", "id", "in", "ga", "it", "ja", "jv", "kn", "kk", "km", "rw", "ko", "ku", "ky", "lo", "la", "lv", "lt", "lb", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mn", "my", "ne", "no", "ny", "or", "ps", "fa", "pl", "pt", "pa", "ro", "ru", "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so", "es", "su", "sw", "sv", "tl", "tg", "ta", "tt", "te", "th", "tr", "tk", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi", "ji", "yo", "zu". |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1translate_message_text.html).
+  """
+
+  defstruct "@type": "translateMessageText", "@extra": nil, chat_id: nil, message_id: nil, to_language_code: nil
+end
+defmodule GetChatSimilarChats do
+  @moduledoc  """
+  Returns a list of chats similar to the given chat.
+  Returns object_ptr<Chats>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the target chat; must be an identifier of a channel chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_similar_chats.html).
+  """
+
+  defstruct "@type": "getChatSimilarChats", "@extra": nil, chat_id: nil
+end
+defmodule PreliminaryUploadFile do
+  @moduledoc  """
+  Preliminary uploads a file to the cloud before sending it in a message, which can be useful for uploading of being recorded voice and video notes. In all other cases there is no need to preliminary upload a file. Updates updateFile will be used to notify about upload progress. The upload will not be completed until the file is sent in a message.
+  Returns object_ptr<File>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | file | InputFile | File to upload. |
+  | file_type | FileType | File type; pass null if unknown. |
+  | priority | int32 | Priority of the upload (1-32). The higher the priority, the earlier the file will be uploaded. If the priorities of two files are equal, then the first one for which <a class="el" href="classtd_1_1td__api_1_1preliminary_upload_file.html">preliminaryUploadFile</a> was called will be uploaded first. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1preliminary_upload_file.html).
+  """
+
+  defstruct "@type": "preliminaryUploadFile", "@extra": nil, file: nil, file_type: nil, priority: nil
+end
 defmodule SearchContacts do
   @moduledoc  """
   Searches for the specified query in the first names, last names and usernames of the known user contacts.
@@ -2069,6 +3081,21 @@ defmodule SearchContacts do
 
   defstruct "@type": "searchContacts", "@extra": nil, query: nil, limit: nil
 end
+defmodule ToggleUsernameIsActive do
+  @moduledoc  """
+  Changes active state for a username of the current user. The editable username can't be disabled. May return an error with a message "USERNAMES_ACTIVE_TOO_MUCH" if the maximum number of active usernames has been reached.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | username | string | The username to change. |
+  | is_active | bool | Pass true to activate the username; pass false to disable it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_username_is_active.html).
+  """
+
+  defstruct "@type": "toggleUsernameIsActive", "@extra": nil, username: nil, is_active: nil
+end
 defmodule GetInstalledStickerSets do
   @moduledoc  """
   Returns a list of installed sticker sets.
@@ -2076,12 +3103,12 @@ defmodule GetInstalledStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_masks | bool | Pass true to return mask sticker sets; pass false to return ordinary sticker sets. |
+  | sticker_type | StickerType | Type of the sticker sets to return. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_installed_sticker_sets.html).
   """
 
-  defstruct "@type": "getInstalledStickerSets", "@extra": nil, is_masks: nil
+  defstruct "@type": "getInstalledStickerSets", "@extra": nil, sticker_type: nil
 end
 defmodule SendEmailAddressVerificationCode do
   @moduledoc  """
@@ -2097,6 +3124,92 @@ defmodule SendEmailAddressVerificationCode do
 
   defstruct "@type": "sendEmailAddressVerificationCode", "@extra": nil, email_address: nil
 end
+defmodule LoadSavedMessagesTopics do
+  @moduledoc  """
+  Loads more Saved Messages topics. The loaded topics will be sent through updateSavedMessagesTopic. Topics are sorted by their topic.order in descending order. Returns a 404 error if all topics have been loaded.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | limit | int32 | The maximum number of topics to be loaded. For optimal performance, the number of loaded topics is chosen by TDLib and can be smaller than the specified limit, even if the end of the list is not reached. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1load_saved_messages_topics.html).
+  """
+
+  defstruct "@type": "loadSavedMessagesTopics", "@extra": nil, limit: nil
+end
+defmodule LoadQuickReplyShortcutMessages do
+  @moduledoc  """
+  Loads quick reply messages that can be sent by a given quick reply shortcut. The loaded messages will be sent through updateQuickReplyShortcutMessages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1load_quick_reply_shortcut_messages.html).
+  """
+
+  defstruct "@type": "loadQuickReplyShortcutMessages", "@extra": nil, shortcut_id: nil
+end
+defmodule GetStarTransactions do
+  @moduledoc  """
+  Returns the list of Telegram star transactions for the specified owner.
+  Returns object_ptr<StarTransactions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | owner_id | MessageSender | Identifier of the owner of the Telegram stars; can be the identifier of the current user, identifier of an owned bot, or identifier of a channel chat with supergroupFullInfo.can_get_revenue_statistics == true. |
+  | direction | StarTransactionDirection | Direction of the transactions to receive; pass null to get all transactions. |
+  | offset | string | Offset of the first transaction to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of transactions to return. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_star_transactions.html).
+  """
+
+  defstruct "@type": "getStarTransactions", "@extra": nil, owner_id: nil, direction: nil, offset: nil, limit: nil
+end
+defmodule SetChatMessageAutoDeleteTime do
+  @moduledoc  """
+  Changes the message auto-delete or self-destruct (for secret chats) time in a chat. Requires change_info administrator right in basic groups, supergroups and channels Message auto-delete time can't be changed in a chat with the current user (Saved Messages) and the chat 777000 (Telegram).
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_auto_delete_time | int32 | New time value, in seconds; unless the chat is secret, it must be from 0 up to 365 * 86400 and be divisible by 86400. If 0, then messages aren't deleted automatically. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_message_auto_delete_time.html).
+  """
+
+  defstruct "@type": "setChatMessageAutoDeleteTime", "@extra": nil, chat_id: nil, message_auto_delete_time: nil
+end
+defmodule ProcessChatFolderNewChats do
+  @moduledoc  """
+  Process new chats added to a shareable chat folder by its owner.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | added_chat_ids | int53 | Identifiers of the new chats, which are added to the chat folder. The chats are automatically joined if they aren't joined yet. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1process_chat_folder_new_chats.html).
+  """
+
+  defstruct "@type": "processChatFolderNewChats", "@extra": nil, chat_folder_id: nil, added_chat_ids: nil
+end
+defmodule GetDefaultEmojiStatuses do
+  @moduledoc  """
+  Returns default emoji statuses for self status.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getDefaultEmojiStatuses", "@extra": nil
+end
 defmodule GetSuggestedStickerSetName do
   @moduledoc  """
   Returns a suggested name for a new sticker set with a given title.
@@ -2111,6 +3224,50 @@ defmodule GetSuggestedStickerSetName do
 
   defstruct "@type": "getSuggestedStickerSetName", "@extra": nil, title: nil
 end
+defmodule GetForumTopicLink do
+  @moduledoc  """
+  Returns an HTTPS link to a topic in a forum chat. This is an offline request.
+  Returns object_ptr<MessageLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_forum_topic_link.html).
+  """
+
+  defstruct "@type": "getForumTopicLink", "@extra": nil, chat_id: nil, message_thread_id: nil
+end
+defmodule ReadAllMessageThreadMentions do
+  @moduledoc  """
+  Marks all mentions in a forum topic as read.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_thread_id | int53 | Message thread identifier in which mentions are marked as read. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1read_all_message_thread_mentions.html).
+  """
+
+  defstruct "@type": "readAllMessageThreadMentions", "@extra": nil, chat_id: nil, message_thread_id: nil
+end
+defmodule ConfirmSession do
+  @moduledoc  """
+  Confirms an unconfirmed session of the current user from another device.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | session_id | int64 | Session identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1confirm_session.html).
+  """
+
+  defstruct "@type": "confirmSession", "@extra": nil, session_id: nil
+end
 defmodule ToggleGroupCallParticipantIsMuted do
   @moduledoc  """
   Toggles whether a participant of an active group call is muted, unmuted, or allowed to unmute themselves.
@@ -2120,7 +3277,7 @@ defmodule ToggleGroupCallParticipantIsMuted do
   |------|------| ------------|
   | group_call_id | int32 | Group call identifier. |
   | participant_id | MessageSender | Participant identifier. |
-  | is_muted | bool | Pass true to mute the user; pass false to unmute the them. |
+  | is_muted | bool | Pass true to mute the user; pass false to unmute them. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_group_call_participant_is_muted.html).
   """
@@ -2145,7 +3302,7 @@ defmodule ProcessChatJoinRequests do
 end
 defmodule RequestQrCodeAuthentication do
   @moduledoc  """
-  Requests QR code authentication by scanning a QR code on another logged in device. Works only when the current authorization state is authorizationStateWaitPhoneNumber, or if there is no pending authentication query and the current authorization state is authorizationStateWaitCode, authorizationStateWaitRegistration, or authorizationStateWaitPassword.
+  Requests QR code authentication by scanning a QR code on another logged in device. Works only when the current authorization state is authorizationStateWaitPhoneNumber, or if there is no pending authentication query and the current authorization state is authorizationStateWaitEmailAddress, authorizationStateWaitEmailCode, authorizationStateWaitCode, authorizationStateWaitRegistration, or authorizationStateWaitPassword.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -2156,6 +3313,21 @@ defmodule RequestQrCodeAuthentication do
   """
 
   defstruct "@type": "requestQrCodeAuthentication", "@extra": nil, other_user_ids: nil
+end
+defmodule AddChatFolderByInviteLink do
+  @moduledoc  """
+  Adds a chat folder by an invite link.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invite_link | string | Invite link for the chat folder. |
+  | chat_ids | int53 | Identifiers of the chats added to the chat folder. The chats are automatically joined if they aren't joined yet. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_chat_folder_by_invite_link.html).
+  """
+
+  defstruct "@type": "addChatFolderByInviteLink", "@extra": nil, invite_link: nil, chat_ids: nil
 end
 defmodule GetProxyLink do
   @moduledoc  """
@@ -2197,6 +3369,17 @@ defmodule GetLogVerbosityLevel do
 
   defstruct "@type": "getLogVerbosityLevel", "@extra": nil
 end
+defmodule HideContactCloseBirthdays do
+  @moduledoc  """
+  Hides the list of contacts that have close birthdays for 24 hours.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1hide_contact_close_birthdays.html).
+  """
+
+  defstruct "@type": "hideContactCloseBirthdays", "@extra": nil
+end
 defmodule LoadGroupCallParticipants do
   @moduledoc  """
   Loads more participants of a group call. The loaded participants will be received through updates. Use the field groupCall.loaded_all_participants to check whether all participants have already been loaded.
@@ -2227,9 +3410,23 @@ defmodule SetPassportElementErrors do
 
   defstruct "@type": "setPassportElementErrors", "@extra": nil, user_id: nil, errors: nil
 end
+defmodule GetChatFolderInviteLinks do
+  @moduledoc  """
+  Returns invite links created by the current user for a shareable chat folder.
+  Returns object_ptr<ChatFolderInviteLinks>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder_invite_links.html).
+  """
+
+  defstruct "@type": "getChatFolderInviteLinks", "@extra": nil, chat_folder_id: nil
+end
 defmodule EditMessageText do
   @moduledoc  """
-  Edits the text of a message (or a text of a game message). Returns the edited message after the edit is completed on the server side.
+  Edits the text of a message (or a text of a game message). Returns the edited message after the edit is completed on the server side. Can be used only if message.can_be_edited == true.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -2251,7 +3448,7 @@ defmodule ImportMessages do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Identifier of a chat to which the messages will be imported. It must be an identifier of a private chat with a mutual contact or an identifier of a supergroup chat with can_change_info administrator right. |
+  | chat_id | int53 | Identifier of a chat to which the messages will be imported. It must be an identifier of a private chat with a mutual contact or an identifier of a supergroup chat with can_change_info member right. |
   | message_file | InputFile | File with messages to import. Only <a class="el" href="classtd_1_1td__api_1_1input_file_local.html">inputFileLocal</a> and <a class="el" href="classtd_1_1td__api_1_1input_file_generated.html">inputFileGenerated</a> are supported. The file must not be previously uploaded. |
   | attached_files | InputFile | Files used in the imported messages. Only <a class="el" href="classtd_1_1td__api_1_1input_file_local.html">inputFileLocal</a> and <a class="el" href="classtd_1_1td__api_1_1input_file_generated.html">inputFileGenerated</a> are supported. The files must not be previously uploaded. |
 
@@ -2260,16 +3457,19 @@ defmodule ImportMessages do
 
   defstruct "@type": "importMessages", "@extra": nil, chat_id: nil, message_file: nil, attached_files: nil
 end
-defmodule ResendChangePhoneNumberCode do
+defmodule CanBotSendMessages do
   @moduledoc  """
-  Re-sends the authentication code sent to confirm a new phone number for the current user. Works only if the previously received authenticationCodeInfo next_code_type was not null and the server-specified timeout has passed.
-  Returns object_ptr<AuthenticationCodeInfo>.
+  Checks whether the specified bot can send messages to the user. Returns a 404 error if can't and the access can be granted by call to allowBotToSendMessages.
+  Returns object_ptr<Ok>.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_change_phone_number_code.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_bot_send_messages.html).
   """
 
-  defstruct "@type": "resendChangePhoneNumberCode", "@extra": nil
+  defstruct "@type": "canBotSendMessages", "@extra": nil, bot_user_id: nil
 end
 defmodule GetMessageImportConfirmationText do
   @moduledoc  """
@@ -2278,7 +3478,7 @@ defmodule GetMessageImportConfirmationText do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Identifier of a chat to which the messages will be imported. It must be an identifier of a private chat with a mutual contact or an identifier of a supergroup chat with can_change_info administrator right. |
+  | chat_id | int53 | Identifier of a chat to which the messages will be imported. It must be an identifier of a private chat with a mutual contact or an identifier of a supergroup chat with can_change_info member right. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_import_confirmation_text.html).
   """
@@ -2287,12 +3487,12 @@ defmodule GetMessageImportConfirmationText do
 end
 defmodule RemoveStickerFromSet do
   @moduledoc  """
-  Removes a sticker from the set to which it belongs; for bots only. The sticker set must have been created by the bot.
+  Removes a sticker from the set to which it belongs. The sticker set must be owned by the current user.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sticker | InputFile | Sticker. |
+  | sticker | InputFile | Sticker to remove from the set. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_sticker_from_set.html).
   """
@@ -2301,7 +3501,7 @@ defmodule RemoveStickerFromSet do
 end
 defmodule GetUserProfilePhotos do
   @moduledoc  """
-  Returns the profile photos of a user. The result of this query may be outdated: some photos might have been deleted already.
+  Returns the profile photos of a user. Personal and public photo aren't returned.
   Returns object_ptr<ChatPhotos>.
 
   | Name | Type | Description |
@@ -2314,6 +3514,67 @@ defmodule GetUserProfilePhotos do
   """
 
   defstruct "@type": "getUserProfilePhotos", "@extra": nil, user_id: nil, offset: nil, limit: nil
+end
+defmodule GetKeywordEmojis do
+  @moduledoc  """
+  Return emojis matching the keyword. Supported only if the file database is enabled. Order of results is unspecified.
+  Returns object_ptr<Emojis>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | string | Text to search for. |
+  | input_language_codes | string | List of possible IETF language tags of the user's input language; may be empty if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_keyword_emojis.html).
+  """
+
+  defstruct "@type": "getKeywordEmojis", "@extra": nil, text: nil, input_language_codes: nil
+end
+defmodule GetPremiumGiftCodePaymentOptions do
+  @moduledoc  """
+  Returns available options for Telegram Premium gift code or giveaway creation.
+  Returns object_ptr<PremiumGiftCodePaymentOptions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boosted_chat_id | int53 | Identifier of the supergroup or channel chat, which will be automatically boosted by receivers of the gift codes and which is administered by the user; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_premium_gift_code_payment_options.html).
+  """
+
+  defstruct "@type": "getPremiumGiftCodePaymentOptions", "@extra": nil, boosted_chat_id: nil
+end
+defmodule GetAllStickerEmojis do
+  @moduledoc  """
+  Returns unique emoji that correspond to stickers to be found by the getStickers(sticker_type, query, 1000000, chat_id).
+  Returns object_ptr<Emojis>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker_type | StickerType | Type of the stickers to search for. |
+  | query | string | Search query. |
+  | chat_id | int53 | Chat identifier for which to find stickers. |
+  | return_only_main_emoji | bool | Pass true if only main emoji for each found sticker must be included in the result. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_all_sticker_emojis.html).
+  """
+
+  defstruct "@type": "getAllStickerEmojis", "@extra": nil, sticker_type: nil, query: nil, chat_id: nil, return_only_main_emoji: nil
+end
+defmodule ToggleChatIsTranslatable do
+  @moduledoc  """
+  Changes the translatable state of a chat.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | is_translatable | bool | New value of is_translatable. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_chat_is_translatable.html).
+  """
+
+  defstruct "@type": "toggleChatIsTranslatable", "@extra": nil, chat_id: nil, is_translatable: nil
 end
 defmodule PingProxy do
   @moduledoc  """
@@ -2328,6 +3589,32 @@ defmodule PingProxy do
   """
 
   defstruct "@type": "pingProxy", "@extra": nil, proxy_id: nil
+end
+defmodule ResetAuthenticationEmailAddress do
+  @moduledoc  """
+  Resets the login email address. May return an error with a message "TASK_ALREADY_EXISTS" if reset is still pending. Works only when the current authorization state is authorizationStateWaitEmailCode and authorization_state.can_reset_email_address == true.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reset_authentication_email_address.html).
+  """
+
+  defstruct "@type": "resetAuthenticationEmailAddress", "@extra": nil
+end
+defmodule SetQuickReplyShortcutName do
+  @moduledoc  """
+  Changes name of a quick reply shortcut.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut. |
+  | name | string | New name for the shortcut. Use <a class="el" href="classtd_1_1td__api_1_1check_quick_reply_shortcut_name.html">checkQuickReplyShortcutName</a> to check its validness. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_quick_reply_shortcut_name.html).
+  """
+
+  defstruct "@type": "setQuickReplyShortcutName", "@extra": nil, shortcut_id: nil, name: nil
 end
 defmodule GetLanguagePackInfo do
   @moduledoc  """
@@ -2356,6 +3643,24 @@ defmodule SearchStickerSet do
   """
 
   defstruct "@type": "searchStickerSet", "@extra": nil, name: nil
+end
+defmodule EditBusinessMessageMedia do
+  @moduledoc  """
+  Edits the content of a message with an animation, an audio, a document, a photo or a video in a message sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none; for bots only. |
+  | input_message_content | InputMessageContent | New content of the message. Must be one of the following types: <a class="el" href="classtd_1_1td__api_1_1input_message_animation.html">inputMessageAnimation</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_audio.html">inputMessageAudio</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_document.html">inputMessageDocument</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_photo.html">inputMessagePhoto</a> or <a class="el" href="classtd_1_1td__api_1_1input_message_video.html">inputMessageVideo</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_message_media.html).
+  """
+
+  defstruct "@type": "editBusinessMessageMedia", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil, input_message_content: nil
 end
 defmodule GetPhoneNumberInfo do
   @moduledoc  """
@@ -2400,9 +3705,23 @@ defmodule GetJsonString do
 
   defstruct "@type": "getJsonString", "@extra": nil, json_value: nil
 end
+defmodule SetAuthenticationEmailAddress do
+  @moduledoc  """
+  Sets the email address of the user and sends an authentication code to the email address. Works only when the current authorization state is authorizationStateWaitEmailAddress.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | email_address | string | The email address of the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_authentication_email_address.html).
+  """
+
+  defstruct "@type": "setAuthenticationEmailAddress", "@extra": nil, email_address: nil
+end
 defmodule ReplaceVideoChatRtmpUrl do
   @moduledoc  """
-  Replaces the current RTMP URL for streaming to the chat; requires creator privileges.
+  Replaces the current RTMP URL for streaming to the chat; requires owner privileges.
   Returns object_ptr<RtmpUrl>.
 
   | Name | Type | Description |
@@ -2413,6 +3732,52 @@ defmodule ReplaceVideoChatRtmpUrl do
   """
 
   defstruct "@type": "replaceVideoChatRtmpUrl", "@extra": nil, chat_id: nil
+end
+defmodule ReportStory do
+  @moduledoc  """
+  Reports a story to the Telegram moderators.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story to report. |
+  | story_id | int32 | The identifier of the story to report. |
+  | reason | ReportReason | The reason for reporting the story. |
+  | text | string | Additional report details; 0-1024 characters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_story.html).
+  """
+
+  defstruct "@type": "reportStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil, reason: nil, text: nil
+end
+defmodule DisableAllSupergroupUsernames do
+  @moduledoc  """
+  Disables all active non-editable usernames of a supergroup or channel, requires owner privileges in the supergroup or channel.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup or channel. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1disable_all_supergroup_usernames.html).
+  """
+
+  defstruct "@type": "disableAllSupergroupUsernames", "@extra": nil, supergroup_id: nil
+end
+defmodule SetUserPersonalProfilePhoto do
+  @moduledoc  """
+  Changes a personal profile photo of a contact user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | photo | InputChatPhoto | Profile photo to set; pass null to delete the photo; <a class="el" href="classtd_1_1td__api_1_1input_chat_photo_previous.html">inputChatPhotoPrevious</a> isn't supported in this function. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_user_personal_profile_photo.html).
+  """
+
+  defstruct "@type": "setUserPersonalProfilePhoto", "@extra": nil, user_id: nil, photo: nil
 end
 defmodule AddLogMessage do
   @moduledoc  """
@@ -2443,6 +3808,21 @@ defmodule DeleteProfilePhoto do
 
   defstruct "@type": "deleteProfilePhoto", "@extra": nil, profile_photo_id: nil
 end
+defmodule SetUserSupportInfo do
+  @moduledoc  """
+  Sets support information for the given user; for Telegram support only.
+  Returns object_ptr<UserSupportInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | message | formattedText | New information message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_user_support_info.html).
+  """
+
+  defstruct "@type": "setUserSupportInfo", "@extra": nil, user_id: nil, message: nil
+end
 defmodule GetPassportAuthorizationForm do
   @moduledoc  """
   Returns a Telegram Passport authorization form for sharing data with a service.
@@ -2462,7 +3842,7 @@ defmodule GetPassportAuthorizationForm do
 end
 defmodule GetSavedNotificationSounds do
   @moduledoc  """
-  Returns list of saved notification sounds. If a sound isn't in the list, then default sound needs to be used.
+  Returns the list of saved notification sounds. If a sound isn't in the list, then default sound needs to be used.
   Returns object_ptr<NotificationSounds>.
 
 
@@ -2496,6 +3876,20 @@ defmodule RequestPasswordRecovery do
 
   defstruct "@type": "requestPasswordRecovery", "@extra": nil
 end
+defmodule SetBusinessStartPage do
+  @moduledoc  """
+  Changes the business start page of the current user. Requires Telegram Business subscription.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | start_page | inputBusinessStartPage | The new start page of the business; pass null to remove custom start page. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_start_page.html).
+  """
+
+  defstruct "@type": "setBusinessStartPage", "@extra": nil, start_page: nil
+end
 defmodule AnswerCallbackQuery do
   @moduledoc  """
   Sets the result of a callback query; for bots only.
@@ -2514,6 +3908,21 @@ defmodule AnswerCallbackQuery do
 
   defstruct "@type": "answerCallbackQuery", "@extra": nil, callback_query_id: nil, text: nil, show_alert: nil, url: nil, cache_time: nil
 end
+defmodule GetBotInfoDescription do
+  @moduledoc  """
+  Returns the text shown in the chat with a bot if the chat is empty in the given language. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Text>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code or an empty string. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_bot_info_description.html).
+  """
+
+  defstruct "@type": "getBotInfoDescription", "@extra": nil, bot_user_id: nil, language_code: nil
+end
 defmodule GetLoginUrl do
   @moduledoc  """
   Returns an HTTP URL which can be used to automatically authorize the user on a website after clicking an inline button of type inlineKeyboardButtonTypeLoginUrl. Use the method getLoginUrlInfo to find whether a prior user confirmation is needed. If an error is returned, then the button must be handled as an ordinary URL button.
@@ -2531,6 +3940,46 @@ defmodule GetLoginUrl do
 
   defstruct "@type": "getLoginUrl", "@extra": nil, chat_id: nil, message_id: nil, button_id: nil, allow_write_access: nil
 end
+defmodule DeleteChatFolder do
+  @moduledoc  """
+  Deletes existing chat folder.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | leave_chat_ids | int53 | Identifiers of the chats to leave. The chats must be pinned or always included in the folder. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_chat_folder.html).
+  """
+
+  defstruct "@type": "deleteChatFolder", "@extra": nil, chat_folder_id: nil, leave_chat_ids: nil
+end
+defmodule ResendPhoneNumberCode do
+  @moduledoc  """
+  Resends the authentication code sent to a phone number. Works only if the previously received authenticationCodeInfo next_code_type was not null and the server-specified timeout has passed.
+  Returns object_ptr<AuthenticationCodeInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reason | ResendCodeReason | Reason of code resending; pass null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_phone_number_code.html).
+  """
+
+  defstruct "@type": "resendPhoneNumberCode", "@extra": nil, reason: nil
+end
+defmodule ActivateStoryStealthMode do
+  @moduledoc  """
+  Activates stealth mode for stories, which hides all views of stories from the current user in the last "story_stealth_mode_past_period" seconds and for the next "story_stealth_mode_future_period" seconds; for Telegram Premium users only.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1activate_story_stealth_mode.html).
+  """
+
+  defstruct "@type": "activateStoryStealthMode", "@extra": nil
+end
 defmodule CreateNewSupergroupChat do
   @moduledoc  """
   Creates a new supergroup or channel and sends a corresponding messageSupergroupChatCreate. Returns the newly created chat.
@@ -2539,15 +3988,17 @@ defmodule CreateNewSupergroupChat do
   | Name | Type | Description |
   |------|------| ------------|
   | title | string | Title of the new chat; 1-128 characters. |
-  | is_channel | bool | Pass true to create a channel chat. |
+  | is_forum | bool | Pass true to create a forum supergroup chat. |
+  | is_channel | bool | Pass true to create a channel chat; ignored if a forum is created. |
   | description | string | Chat description; 0-255 characters. |
   | location | chatLocation | Chat location if a location-based supergroup is being created; pass null to create an ordinary supergroup chat. |
-  | for_import | bool | Pass true to create a supergroup for importing messages using importMessage. |
+  | message_auto_delete_time | int32 | Message auto-delete time value, in seconds; must be from 0 up to 365 * 86400 and be divisible by 86400. If 0, then messages aren't deleted automatically. |
+  | for_import | bool | Pass true to create a supergroup for importing messages using <a class="el" href="classtd_1_1td__api_1_1import_messages.html">importMessages</a>. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_new_supergroup_chat.html).
   """
 
-  defstruct "@type": "createNewSupergroupChat", "@extra": nil, title: nil, is_channel: nil, description: nil, location: nil, for_import: nil
+  defstruct "@type": "createNewSupergroupChat", "@extra": nil, title: nil, is_forum: nil, is_channel: nil, description: nil, location: nil, message_auto_delete_time: nil, for_import: nil
 end
 defmodule GetPreferredCountryLanguage do
   @moduledoc  """
@@ -2562,6 +4013,31 @@ defmodule GetPreferredCountryLanguage do
   """
 
   defstruct "@type": "getPreferredCountryLanguage", "@extra": nil, country_code: nil
+end
+defmodule GetBusinessChatLinks do
+  @moduledoc  """
+  Returns business chat links created for the current account.
+  Returns object_ptr<BusinessChatLinks>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_business_chat_links.html).
+  """
+
+  defstruct "@type": "getBusinessChatLinks", "@extra": nil
+end
+defmodule SetEmojiStatus do
+  @moduledoc  """
+  Changes the emoji status of the current user; for Telegram Premium users only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji_status | emojiStatus | New emoji status; pass null to switch to the default badge. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_emoji_status.html).
+  """
+
+  defstruct "@type": "setEmojiStatus", "@extra": nil, emoji_status: nil
 end
 defmodule GetActiveSessions do
   @moduledoc  """
@@ -2596,6 +4072,24 @@ defmodule ResetPassword do
 
   defstruct "@type": "resetPassword", "@extra": nil
 end
+defmodule ShareChatWithBot do
+  @moduledoc  """
+  Shares a chat after pressing a keyboardButtonTypeRequestChat button with the bot.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat with the bot. |
+  | message_id | int53 | Identifier of the message with the button. |
+  | button_id | int32 | Identifier of the button. |
+  | shared_chat_id | int53 | Identifier of the shared chat. |
+  | only_check | bool | Pass true to check that the chat can be shared by the button instead of actually sharing it. Doesn't check bot_is_member and bot_administrator_rights restrictions. If the bot must be a member, then all chats from <a class="el" href="classtd_1_1td__api_1_1get_groups_in_common.html">getGroupsInCommon</a> and all chats, where the user can add the bot, are suitable. In the latter case the bot will be automatically added to the chat. If the bot must be an administrator, then all chats, where the bot already has requested rights or can be added to administrators by the user, are suitable. In the latter case the bot will be automatically granted requested rights. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1share_chat_with_bot.html).
+  """
+
+  defstruct "@type": "shareChatWithBot", "@extra": nil, chat_id: nil, message_id: nil, button_id: nil, shared_chat_id: nil, only_check: nil
+end
 defmodule GetChatSparseMessagePositions do
   @moduledoc  """
   Returns sparse positions of messages of the specified type in the chat to be used for shared media scroll implementation. Returns the results in reverse chronological order (i.e., in order of decreasing message_id). Cannot be used in secret chats or with searchMessagesFilterFailedToSend filter without an enabled message database.
@@ -2607,11 +4101,42 @@ defmodule GetChatSparseMessagePositions do
   | filter | SearchMessagesFilter | Filter for message content. Filters <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_empty.html">searchMessagesFilterEmpty</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_mention.html">searchMessagesFilterMention</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_mention.html">searchMessagesFilterUnreadMention</a>, and <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_reaction.html">searchMessagesFilterUnreadReaction</a> are unsupported in this function. |
   | from_message_id | int53 | The message identifier from which to return information about message positions. |
   | limit | int32 | The expected number of message positions to be returned; 50-2000. A smaller number of positions can be returned, if there are not enough appropriate messages. |
+  | saved_messages_topic_id | int53 | If not 0, only messages in the specified Saved Messages topic will be considered; pass 0 to consider all messages, or for chats other than Saved Messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_sparse_message_positions.html).
   """
 
-  defstruct "@type": "getChatSparseMessagePositions", "@extra": nil, chat_id: nil, filter: nil, from_message_id: nil, limit: nil
+  defstruct "@type": "getChatSparseMessagePositions", "@extra": nil, chat_id: nil, filter: nil, from_message_id: nil, limit: nil, saved_messages_topic_id: nil
+end
+defmodule SetBusinessLocation do
+  @moduledoc  """
+  Changes the business location of the current user. Requires Telegram Business subscription.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | location | businessLocation | The new location of the business; pass null to remove the location. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_location.html).
+  """
+
+  defstruct "@type": "setBusinessLocation", "@extra": nil, location: nil
+end
+defmodule ToggleForumTopicIsPinned do
+  @moduledoc  """
+  Changes the pinned state of a forum topic; requires can_manage_topics right in the supergroup. There can be up to getOption("pinned_forum_topic_count_max") pinned forum topics.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+  | is_pinned | bool | Pass true to pin the topic; pass false to unpin it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_forum_topic_is_pinned.html).
+  """
+
+  defstruct "@type": "toggleForumTopicIsPinned", "@extra": nil, chat_id: nil, message_thread_id: nil, is_pinned: nil
 end
 defmodule GetPasswordState do
   @moduledoc  """
@@ -2624,21 +4149,52 @@ defmodule GetPasswordState do
 
   defstruct "@type": "getPasswordState", "@extra": nil
 end
-defmodule SetStickerSetThumbnail do
+defmodule SearchPublicStoriesByLocation do
   @moduledoc  """
-  Sets a sticker set thumbnail; for bots only. Returns the sticker set.
-  Returns object_ptr<StickerSet>.
+  Searches for public stories by the given address location. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit.
+  Returns object_ptr<FoundStories>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | user_id | int53 | Sticker set owner. |
-  | name | string | Sticker set name. |
-  | thumbnail | InputFile | Thumbnail to set in PNG, TGS, or WEBM format; pass null to remove the sticker set thumbnail. Thumbnail format must match the format of stickers in the set. |
+  | address | locationAddress | Address of the location. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of stories to be returned; up to 100. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_public_stories_by_location.html).
+  """
+
+  defstruct "@type": "searchPublicStoriesByLocation", "@extra": nil, address: nil, offset: nil, limit: nil
+end
+defmodule SetStickerSetThumbnail do
+  @moduledoc  """
+  Sets a sticker set thumbnail.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Sticker set owner; ignored for regular users. |
+  | name | string | Sticker set name. The sticker set must be owned by the current user. |
+  | thumbnail | InputFile | Thumbnail to set; pass null to remove the sticker set thumbnail. |
+  | format | StickerFormat | Format of the thumbnail; pass null if thumbnail is removed. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_sticker_set_thumbnail.html).
   """
 
-  defstruct "@type": "setStickerSetThumbnail", "@extra": nil, user_id: nil, name: nil, thumbnail: nil
+  defstruct "@type": "setStickerSetThumbnail", "@extra": nil, user_id: nil, name: nil, thumbnail: nil, format: nil
+end
+defmodule GetEmojiReaction do
+  @moduledoc  """
+  Returns information about an emoji reaction. Returns a 404 error if the reaction is not found.
+  Returns object_ptr<EmojiReaction>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji | string | Text representation of the reaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_emoji_reaction.html).
+  """
+
+  defstruct "@type": "getEmojiReaction", "@extra": nil, emoji: nil
 end
 defmodule SendCallRating do
   @moduledoc  """
@@ -2684,7 +4240,7 @@ defmodule CancelPasswordReset do
 end
 defmodule GetCurrentState do
   @moduledoc  """
-  Returns all updates needed to restore current TDLib state, i.e. all actual UpdateAuthorizationState/UpdateUser/UpdateNewChat and others. This is especially useful if TDLib is run in a separate process. Can be called before initialization.
+  Returns all updates needed to restore current TDLib state, i.e. all actual updateAuthorizationState/updateUser/updateNewChat and others. This is especially useful if TDLib is run in a separate process. Can be called before initialization.
   Returns object_ptr<Updates>.
 
 
@@ -2701,7 +4257,7 @@ defmodule ToggleGroupCallScreenSharingIsPaused do
   | Name | Type | Description |
   |------|------| ------------|
   | group_call_id | int32 | Group call identifier. |
-  | is_paused | bool | True if screen sharing is paused. |
+  | is_paused | bool | Pass true to pause screen sharing; pass false to unpause it. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_group_call_screen_sharing_is_paused.html).
   """
@@ -2710,13 +4266,13 @@ defmodule ToggleGroupCallScreenSharingIsPaused do
 end
 defmodule RecoverAuthenticationPassword do
   @moduledoc  """
-  Recovers the password with a password recovery code sent to an email address that was previously set up. Works only when the current authorization state is authorizationStateWaitPassword.
+  Recovers the 2-step verification password with a password recovery code sent to an email address that was previously set up. Works only when the current authorization state is authorizationStateWaitPassword.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | recovery_code | string | Recovery code to check. |
-  | new_password | string | New password of the user; may be empty to remove the password. |
+  | new_password | string | New 2-step verification password of the user; may be empty to remove the password. |
   | new_hint | string | New password hint; may be empty. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recover_authentication_password.html).
@@ -2738,6 +4294,24 @@ defmodule DeleteLanguagePack do
 
   defstruct "@type": "deleteLanguagePack", "@extra": nil, language_pack_id: nil
 end
+defmodule EditForumTopic do
+  @moduledoc  """
+  Edits title and icon of a topic in a forum supergroup chat; requires can_manage_topics right in the supergroup unless the user is creator of the topic.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+  | name | string | New name of the topic; 0-128 characters. If empty, the previous topic name is kept. |
+  | edit_icon_custom_emoji | bool | Pass true to edit the icon of the topic. Icon of the General topic can't be edited. |
+  | icon_custom_emoji_id | int64 | Identifier of the new custom emoji for topic icon; pass 0 to remove the custom emoji. Ignored if edit_icon_custom_emoji is false. Telegram Premium users can use any custom emoji, other users can use only a custom emoji returned by <a class="el" href="classtd_1_1td__api_1_1get_forum_topic_default_icons.html">getForumTopicDefaultIcons</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_forum_topic.html).
+  """
+
+  defstruct "@type": "editForumTopic", "@extra": nil, chat_id: nil, message_thread_id: nil, name: nil, edit_icon_custom_emoji: nil, icon_custom_emoji_id: nil
+end
 defmodule SetRecoveryEmailAddress do
   @moduledoc  """
   Changes the 2-step verification recovery email address of the user. If a new recovery email address is specified, then the change will not be applied until the new recovery email address is confirmed. If new_recovery_email_address is the same as the email address that is currently set up, this call succeeds immediately and aborts all other requests waiting for an email confirmation.
@@ -2745,7 +4319,7 @@ defmodule SetRecoveryEmailAddress do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | Password of the current user. |
+  | password | string | The 2-step verification password of the current user. |
   | new_recovery_email_address | string | New recovery email address. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_recovery_email_address.html).
@@ -2785,8 +4359,8 @@ defmodule CreatePrivateChat do
 end
 defmodule AddChatMembers do
   @moduledoc  """
-  Adds multiple new members to a chat. Currently, this method is only available for supergroups and channels. This method can't be used to join a chat. Members can't be added to a channel if it has more than 200 members.
-  Returns object_ptr<Ok>.
+  Adds multiple new members to a chat; requires can_invite_users member right. Currently, this method is only available for supergroups and channels. This method can't be used to join a chat. Members can't be added to a channel if it has more than 200 members. Returns information about members that weren't added.
+  Returns object_ptr<FailedToAddMembers>.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -2800,12 +4374,12 @@ defmodule AddChatMembers do
 end
 defmodule GetTextEntities do
   @moduledoc  """
-  Returns all entities (mentions, hashtags, cashtags, bot commands, bank card numbers, URLs, and email addresses) contained in the text. Can be called synchronously.
+  Returns all entities (mentions, hashtags, cashtags, bot commands, bank card numbers, URLs, and email addresses) found in the text. Can be called synchronously.
   Returns object_ptr<TextEntities>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | text | string | The text in which to look for entites. |
+  | text | string | The text in which to look for entities. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_text_entities.html).
   """
@@ -2855,18 +4429,19 @@ defmodule DeleteChatMessagesBySender do
 end
 defmodule ToggleBotIsAddedToAttachmentMenu do
   @moduledoc  """
-  Adds or removes a bot to attachment menu. Bot can be added to attachment menu, only if userTypeBot.can_be_added_to_attachment_menu == true.
+  Adds or removes a bot to attachment and side menu. Bot can be added to the menu, only if userTypeBot.can_be_added_to_attachment_menu == true.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | bot_user_id | int53 | Bot's user identifier. |
   | is_added | bool | Pass true to add the bot to attachment menu; pass false to remove the bot from attachment menu. |
+  | allow_write_access | bool | Pass true if the current user allowed the bot to send them messages. Ignored if is_added is false. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_bot_is_added_to_attachment_menu.html).
   """
 
-  defstruct "@type": "toggleBotIsAddedToAttachmentMenu", "@extra": nil, bot_user_id: nil, is_added: nil
+  defstruct "@type": "toggleBotIsAddedToAttachmentMenu", "@extra": nil, bot_user_id: nil, is_added: nil, allow_write_access: nil
 end
 defmodule TestCallVectorInt do
   @moduledoc  """
@@ -2882,10 +4457,88 @@ defmodule TestCallVectorInt do
 
   defstruct "@type": "testCallVectorInt", "@extra": nil, x: nil
 end
+defmodule ReorderBotActiveUsernames do
+  @moduledoc  """
+  Changes order of active usernames of a bot. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | usernames | string | The new order of active usernames. All currently active usernames must be specified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_bot_active_usernames.html).
+  """
+
+  defstruct "@type": "reorderBotActiveUsernames", "@extra": nil, bot_user_id: nil, usernames: nil
+end
+defmodule GetUserSupportInfo do
+  @moduledoc  """
+  Returns support information for the given user; for Telegram support only.
+  Returns object_ptr<UserSupportInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_user_support_info.html).
+  """
+
+  defstruct "@type": "getUserSupportInfo", "@extra": nil, user_id: nil
+end
+defmodule SetDefaultBackground do
+  @moduledoc  """
+  Sets default background for chats; adds the background to the list of installed backgrounds.
+  Returns object_ptr<Background>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | background | InputBackground | The input background to use; pass null to create a new filled background. |
+  | type | BackgroundType | Background type; pass null to use the default type of the remote background; <a class="el" href="classtd_1_1td__api_1_1background_type_chat_theme.html">backgroundTypeChatTheme</a> isn't supported. |
+  | for_dark_theme | bool | Pass true if the background is set for a dark theme. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_default_background.html).
+  """
+
+  defstruct "@type": "setDefaultBackground", "@extra": nil, background: nil, type: nil, for_dark_theme: nil
+end
+defmodule SendStory do
+  @moduledoc  """
+  Sends a new story to a chat; requires can_post_stories right for supergroup and channel chats. Returns a temporary story.
+  Returns object_ptr<Story>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat that will post the story. |
+  | content | InputStoryContent | Content of the story. |
+  | areas | inputStoryAreas | Clickable rectangle areas to be shown on the story media; pass null if none. |
+  | caption | formattedText | Story caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("story_caption_length_max") characters; can have entities only if <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("can_use_text_entities_in_story_caption"). |
+  | privacy_settings | StoryPrivacySettings | The privacy settings for the story; ignored for stories sent to supergroup and channel chats. |
+  | active_period | int32 | Period after which the story is moved to archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400 for Telegram Premium users, and 86400 otherwise. |
+  | from_story_full_id | storyFullId | Full identifier of the original story, which content was used to create the story. |
+  | is_posted_to_chat_page | bool | Pass true to keep the story accessible after expiration. |
+  | protect_content | bool | Pass true if the content of the story must be protected from forwarding and screenshotting. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_story.html).
+  """
+
+  defstruct "@type": "sendStory", "@extra": nil, chat_id: nil, content: nil, areas: nil, caption: nil, privacy_settings: nil, active_period: nil, from_story_full_id: nil, is_posted_to_chat_page: nil, protect_content: nil
+end
+defmodule GetChatsToSendStories do
+  @moduledoc  """
+  Returns supergroup and channel chats in which the current user has the right to post stories. The chats must be rechecked with canSendStory before actually trying to post a story there.
+  Returns object_ptr<Chats>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chats_to_send_stories.html).
+  """
+
+  defstruct "@type": "getChatsToSendStories", "@extra": nil
+end
 defmodule SearchChatMessages do
   @moduledoc  """
-  Searches for messages with given words in the chat. Returns the results in reverse chronological order, i.e. in order of decreasing message_id. Cannot be used in secret chats with a non-empty query (searchSecretMessages must be used instead), or without an enabled message database. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit.
-  Returns object_ptr<Messages>.
+  Searches for messages with given words in the chat. Returns the results in reverse chronological order, i.e. in order of decreasing message_id. Cannot be used in secret chats with a non-empty query (searchSecretMessages must be used instead), or without an enabled message database. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. A combination of query, sender_id, filter and message_thread_id search criteria is expected to be supported, only if it is required for Telegram official application implementation.
+  Returns object_ptr<FoundChatMessages>.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -2893,15 +4546,16 @@ defmodule SearchChatMessages do
   | query | string | Query to search for. |
   | sender_id | MessageSender | Identifier of the sender of messages to search for; pass null to search for messages from any sender. Not supported in secret chats. |
   | from_message_id | int53 | Identifier of the message starting from which history must be fetched; use 0 to get results from the last message. |
-  | offset | int32 | Specify 0 to get results from exactly the from_message_id or a negative offset to get the specified message and some newer messages. |
+  | offset | int32 | Specify 0 to get results from exactly the message from_message_id or a negative offset to get the specified message and some newer messages. |
   | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
   | filter | SearchMessagesFilter | Additional filter for messages to search; pass null to search for all messages. |
   | message_thread_id | int53 | If not 0, only messages in the specified thread will be returned; supergroups only. |
+  | saved_messages_topic_id | int53 | If not 0, only messages in the specified Saved Messages topic will be returned; pass 0 to return all messages, or for chats other than Saved Messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_chat_messages.html).
   """
 
-  defstruct "@type": "searchChatMessages", "@extra": nil, chat_id: nil, query: nil, sender_id: nil, from_message_id: nil, offset: nil, limit: nil, filter: nil, message_thread_id: nil
+  defstruct "@type": "searchChatMessages", "@extra": nil, chat_id: nil, query: nil, sender_id: nil, from_message_id: nil, offset: nil, limit: nil, filter: nil, message_thread_id: nil, saved_messages_topic_id: nil
 end
 defmodule ToggleSessionCanAcceptSecretChats do
   @moduledoc  """
@@ -2911,29 +4565,12 @@ defmodule ToggleSessionCanAcceptSecretChats do
   | Name | Type | Description |
   |------|------| ------------|
   | session_id | int64 | Session identifier. |
-  | can_accept_secret_chats | bool | Pass true to allow accepring secret chats by the session; pass false otherwise. |
+  | can_accept_secret_chats | bool | Pass true to allow accepting secret chats by the session; pass false otherwise. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_session_can_accept_secret_chats.html).
   """
 
   defstruct "@type": "toggleSessionCanAcceptSecretChats", "@extra": nil, session_id: nil, can_accept_secret_chats: nil
-end
-defmodule SetMessageReaction do
-  @moduledoc  """
-  Changes chosen reaction for a message.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_id | int53 | Identifier of the chat to which the message belongs. |
-  | message_id | int53 | Identifier of the message. |
-  | reaction | string | Text representation of the new chosen reaction. Can be an empty string or the currently chosen non-big reaction to remove the reaction. |
-  | is_big | bool | Pass true if the reaction is added with a big animation. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_message_reaction.html).
-  """
-
-  defstruct "@type": "setMessageReaction", "@extra": nil, chat_id: nil, message_id: nil, reaction: nil, is_big: nil
 end
 defmodule GetOption do
   @moduledoc  """
@@ -2949,6 +4586,21 @@ defmodule GetOption do
 
   defstruct "@type": "getOption", "@extra": nil, name: nil
 end
+defmodule ReorderChatFolders do
+  @moduledoc  """
+  Changes the order of chat folders.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_ids | int32 | Identifiers of chat folders in the new correct order. |
+  | main_chat_list_position | int32 | Position of the main chat list among chat folders, 0-based. Can be non-zero only for Premium users. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_chat_folders.html).
+  """
+
+  defstruct "@type": "reorderChatFolders", "@extra": nil, chat_folder_ids: nil, main_chat_list_position: nil
+end
 defmodule GetBasicGroup do
   @moduledoc  """
   Returns information about a basic group by its identifier. This is an offline request if the current user is not a bot.
@@ -2963,9 +4615,23 @@ defmodule GetBasicGroup do
 
   defstruct "@type": "getBasicGroup", "@extra": nil, basic_group_id: nil
 end
+defmodule CanSendStory do
+  @moduledoc  """
+  Checks whether the current user can send a story on behalf of a chat; requires can_post_stories right for supergroup and channel chats.
+  Returns object_ptr<CanSendStoryResult>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story.html).
+  """
+
+  defstruct "@type": "canSendStory", "@extra": nil, chat_id: nil
+end
 defmodule UnpinAllChatMessages do
   @moduledoc  """
-  Removes all pinned messages from a chat; requires can_pin_messages rights in the group or can_edit_messages rights in the channel.
+  Removes all pinned messages from a chat; requires can_pin_messages member right if the chat is a basic group or supergroup, or can_edit_messages administrator right if the chat is a channel.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -2986,18 +4652,18 @@ defmodule AddLocalMessage do
   |------|------| ------------|
   | chat_id | int53 | Target chat. |
   | sender_id | MessageSender | Identifier of the sender of the message. |
-  | reply_to_message_id | int53 | Identifier of the replied message; 0 if none. |
+  | reply_to | InputMessageReplyTo | Information about the message or story to be replied; pass null if none. |
   | disable_notification | bool | Pass true to disable notification for the message. |
   | input_message_content | InputMessageContent | The content of the message to be added. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_local_message.html).
   """
 
-  defstruct "@type": "addLocalMessage", "@extra": nil, chat_id: nil, sender_id: nil, reply_to_message_id: nil, disable_notification: nil, input_message_content: nil
+  defstruct "@type": "addLocalMessage", "@extra": nil, chat_id: nil, sender_id: nil, reply_to: nil, disable_notification: nil, input_message_content: nil
 end
 defmodule EditMessageMedia do
   @moduledoc  """
-  Edits the content of a message with an animation, an audio, a document, a photo or a video, including message caption. If only the caption needs to be edited, use editMessageCaption instead. The media can't be edited if the message was set to self-destruct or to a self-destructing media. The type of message content in an album can't be changed with exception of replacing a photo with a video or vice versa. Returns the edited message after the edit is completed on the server side.
+  Edits the content of a message with an animation, an audio, a document, a photo or a video, including message caption. If only the caption needs to be edited, use editMessageCaption instead. The media can't be edited if the message was set to self-destruct or to a self-destructing media. The type of message content in an album can't be changed with exception of replacing a photo with a video or vice versa. Returns the edited message after the edit is completed on the server side. Can be used only if message.can_be_edited == true.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -3014,18 +4680,30 @@ defmodule EditMessageMedia do
 end
 defmodule CreateNewBasicGroupChat do
   @moduledoc  """
-  Creates a new basic group and sends a corresponding messageBasicGroupChatCreate. Returns the newly created chat.
-  Returns object_ptr<Chat>.
+  Creates a new basic group and sends a corresponding messageBasicGroupChatCreate. Returns information about the newly created chat.
+  Returns object_ptr<CreatedBasicGroupChat>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | user_ids | int53 | Identifiers of users to be added to the basic group. |
+  | user_ids | int53 | Identifiers of users to be added to the basic group; may be empty to create a basic group without other members. |
   | title | string | Title of the new basic group; 1-128 characters. |
+  | message_auto_delete_time | int32 | Message auto-delete time value, in seconds; must be from 0 up to 365 * 86400 and be divisible by 86400. If 0, then messages aren't deleted automatically. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_new_basic_group_chat.html).
   """
 
-  defstruct "@type": "createNewBasicGroupChat", "@extra": nil, user_ids: nil, title: nil
+  defstruct "@type": "createNewBasicGroupChat", "@extra": nil, user_ids: nil, title: nil, message_auto_delete_time: nil
+end
+defmodule GetUserLink do
+  @moduledoc  """
+  Returns an HTTPS link, which can be used to get information about the current user.
+  Returns object_ptr<UserLink>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_user_link.html).
+  """
+
+  defstruct "@type": "getUserLink", "@extra": nil
 end
 defmodule ReportChatPhoto do
   @moduledoc  """
@@ -3036,13 +4714,30 @@ defmodule ReportChatPhoto do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | file_id | int32 | Identifier of the photo to report. Only full photos from <a class="el" href="classtd_1_1td__api_1_1chat_photo.html">chatPhoto</a> can be reported. |
-  | reason | ChatReportReason | The reason for reporting the chat photo. |
+  | reason | ReportReason | The reason for reporting the chat photo. |
   | text | string | Additional report details; 0-1024 characters. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_photo.html).
   """
 
   defstruct "@type": "reportChatPhoto", "@extra": nil, chat_id: nil, file_id: nil, reason: nil, text: nil
+end
+defmodule GetSavedMessagesTopicHistory do
+  @moduledoc  """
+  Returns messages in a Saved Messages topic. The messages are returned in a reverse chronological order (i.e., in order of decreasing message_id).
+  Returns object_ptr<Messages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which messages will be fetched. |
+  | from_message_id | int53 | Identifier of the message starting from which messages must be fetched; use 0 to get results from the last message. |
+  | offset | int32 | Specify 0 to get results from exactly the message from_message_id or a negative offset up to 99 to get additionally some newer messages. |
+  | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than or equal to -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_saved_messages_topic_history.html).
+  """
+
+  defstruct "@type": "getSavedMessagesTopicHistory", "@extra": nil, saved_messages_topic_id: nil, from_message_id: nil, offset: nil, limit: nil
 end
 defmodule GetImportedContactCount do
   @moduledoc  """
@@ -3071,6 +4766,21 @@ defmodule ChangeStickerSet do
 
   defstruct "@type": "changeStickerSet", "@extra": nil, set_id: nil, is_installed: nil, is_archived: nil
 end
+defmodule DeleteChatFolderInviteLink do
+  @moduledoc  """
+  Deletes an invite link for a chat folder.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | invite_link | string | Invite link to be deleted. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "deleteChatFolderInviteLink", "@extra": nil, chat_folder_id: nil, invite_link: nil
+end
 defmodule OpenMessageContent do
   @moduledoc  """
   Informs TDLib that the message content has been opened (e.g., the user has opened a photo, video, document, location or venue, or has listened to an audio file or voice note message). An updateMessageContentOpened update will be generated if something has changed.
@@ -3093,7 +4803,7 @@ defmodule GetAllPassportElements do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | Password of the current user. |
+  | password | string | The 2-step verification password of the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_all_passport_elements.html).
   """
@@ -3116,18 +4826,33 @@ defmodule AddRecentlyFoundChat do
 end
 defmodule AssignAppStoreTransaction do
   @moduledoc  """
-  Informs server about a Telegram Premium purchase through App Store. For official applications only.
+  Informs server about a purchase through App Store. For official applications only.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | receipt | bytes | App Store receipt. |
-  | is_restore | bool | Pass true if this is a restore of a Telegram Premium purchase. |
+  | purpose | StorePaymentPurpose | Transaction purpose. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1assign_app_store_transaction.html).
   """
 
-  defstruct "@type": "assignAppStoreTransaction", "@extra": nil, receipt: nil, is_restore: nil
+  defstruct "@type": "assignAppStoreTransaction", "@extra": nil, receipt: nil, purpose: nil
+end
+defmodule ToggleSupergroupHasAggressiveAntiSpamEnabled do
+  @moduledoc  """
+  Toggles whether aggressive anti-spam checks are enabled in the supergroup. Can be called only if supergroupFullInfo.can_toggle_aggressive_anti_spam == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | The identifier of the supergroup, which isn't a broadcast group. |
+  | has_aggressive_anti_spam_enabled | bool | The new value of has_aggressive_anti_spam_enabled. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_has_aggressive_anti_spam_enabled.html).
+  """
+
+  defstruct "@type": "toggleSupergroupHasAggressiveAntiSpamEnabled", "@extra": nil, supergroup_id: nil, has_aggressive_anti_spam_enabled: nil
 end
 defmodule ReadAllChatMentions do
   @moduledoc  """
@@ -3156,7 +4881,7 @@ defmodule ResendRecoveryEmailAddressCode do
 end
 defmodule SetAuthenticationPhoneNumber do
   @moduledoc  """
-  Sets the phone number of the user and sends an authentication code to the user. Works only when the current authorization state is authorizationStateWaitPhoneNumber, or if there is no pending authentication query and the current authorization state is authorizationStateWaitCode, authorizationStateWaitRegistration, or authorizationStateWaitPassword.
+  Sets the phone number of the user and sends an authentication code to the user. Works only when the current authorization state is authorizationStateWaitPhoneNumber, or if there is no pending authentication query and the current authorization state is authorizationStateWaitEmailAddress, authorizationStateWaitEmailCode, authorizationStateWaitCode, authorizationStateWaitRegistration, or authorizationStateWaitPassword.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -3171,16 +4896,16 @@ defmodule SetAuthenticationPhoneNumber do
 end
 defmodule GetPollVoters do
   @moduledoc  """
-  Returns users voted for the specified option in a non-anonymous polls. For optimal performance, the number of returned users is chosen by TDLib.
-  Returns object_ptr<Users>.
+  Returns message senders voted for the specified option in a non-anonymous polls. For optimal performance, the number of returned users is chosen by TDLib.
+  Returns object_ptr<MessageSenders>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which the poll belongs. |
   | message_id | int53 | Identifier of the message containing the poll. |
   | option_id | int32 | 0-based identifier of the answer option. |
-  | offset | int32 | Number of users to skip in the result; must be non-negative. |
-  | limit | int32 | The maximum number of users to be returned; must be positive and can't be greater than 50. For optimal performance, the number of returned users is chosen by TDLib and can be smaller than the specified limit, even if the end of the voter list has not been reached. |
+  | offset | int32 | Number of voters to skip in the result; must be non-negative. |
+  | limit | int32 | The maximum number of voters to be returned; must be positive and can't be greater than 50. For optimal performance, the number of returned voters is chosen by TDLib and can be smaller than the specified limit, even if the end of the voter list has not been reached. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_poll_voters.html).
   """
@@ -3218,6 +4943,34 @@ defmodule DeleteChatMessagesByDate do
 
   defstruct "@type": "deleteChatMessagesByDate", "@extra": nil, chat_id: nil, min_date: nil, max_date: nil, revoke: nil
 end
+defmodule GetChatBoostStatus do
+  @moduledoc  """
+  Returns the current boost status for a supergroup or a channel chat.
+  Returns object_ptr<ChatBoostStatus>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boost_status.html).
+  """
+
+  defstruct "@type": "getChatBoostStatus", "@extra": nil, chat_id: nil
+end
+defmodule GetChatFolder do
+  @moduledoc  """
+  Returns information about a chat folder by its identifier.
+  Returns object_ptr<ChatFolder>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder.html).
+  """
+
+  defstruct "@type": "getChatFolder", "@extra": nil, chat_folder_id: nil
+end
 defmodule GetThemeParametersJsonString do
   @moduledoc  """
   Converts a themeParameters object to corresponding JSON-serialized string. Can be called synchronously.
@@ -3248,23 +5001,9 @@ defmodule DeleteChatHistory do
 
   defstruct "@type": "deleteChatHistory", "@extra": nil, chat_id: nil, remove_from_chat_list: nil, revoke: nil
 end
-defmodule CheckChangePhoneNumberCode do
-  @moduledoc  """
-  Checks the authentication code sent to confirm a new phone number of the user.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | code | string | Authentication code to check. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_change_phone_number_code.html).
-  """
-
-  defstruct "@type": "checkChangePhoneNumberCode", "@extra": nil, code: nil
-end
 defmodule ResetAllNotificationSettings do
   @moduledoc  """
-  Resets all notification settings to their default values. By default, all chats are unmuted and message previews are shown.
+  Resets all chat and scope notification settings to their default values. By default, all chats are unmuted and message previews are shown.
   Returns object_ptr<Ok>.
 
 
@@ -3282,7 +5021,7 @@ defmodule GetChatHistory do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | from_message_id | int53 | Identifier of the message starting from which history must be fetched; use 0 to get results from the last message. |
-  | offset | int32 | Specify 0 to get results from exactly the from_message_id or a negative offset up to 99 to get additionally some newer messages. |
+  | offset | int32 | Specify 0 to get results from exactly the message from_message_id or a negative offset up to 99 to get additionally some newer messages. |
   | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than or equal to -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
   | only_local | bool | Pass true to get only messages that are available without sending network requests. |
 
@@ -3291,9 +5030,38 @@ defmodule GetChatHistory do
 
   defstruct "@type": "getChatHistory", "@extra": nil, chat_id: nil, from_message_id: nil, offset: nil, limit: nil, only_local: nil
 end
+defmodule GetChatsForChatFolderInviteLink do
+  @moduledoc  """
+  Returns identifiers of chats from a chat folder, suitable for adding to a chat folder invite link.
+  Returns object_ptr<Chats>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chats_for_chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "getChatsForChatFolderInviteLink", "@extra": nil, chat_folder_id: nil
+end
+defmodule SetStickerKeywords do
+  @moduledoc  """
+  Changes the list of keywords of a sticker. The sticker must belong to a regular or custom emoji sticker set that is owned by the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker | InputFile | Sticker. |
+  | keywords | string | List of up to 20 keywords with total length up to 64 characters, which can be used to find the sticker. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_sticker_keywords.html).
+  """
+
+  defstruct "@type": "setStickerKeywords", "@extra": nil, sticker: nil, keywords: nil
+end
 defmodule GetPaymentForm do
   @moduledoc  """
-  Returns an invoice payment form. This method must be called when the user presses inlineKeyboardButtonBuy.
+  Returns an invoice payment form. This method must be called when the user presses inline button of the type inlineKeyboardButtonTypeBuy.
   Returns object_ptr<PaymentForm>.
 
   | Name | Type | Description |
@@ -3306,24 +5074,59 @@ defmodule GetPaymentForm do
 
   defstruct "@type": "getPaymentForm", "@extra": nil, input_invoice: nil, theme: nil
 end
-defmodule SetChatMessageTtl do
+defmodule SearchPublicStoriesByTag do
   @moduledoc  """
-  Changes the message TTL in a chat. Requires can_delete_messages administrator right in basic groups, supergroups and channels Message TTL can't be changed in a chat with the current user (Saved Messages) and the chat 777000 (Telegram).
+  Searches for public stories containing the given hashtag or cashtag. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit.
+  Returns object_ptr<FoundStories>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tag | string | Hashtag or cashtag to search for. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of stories to be returned; up to 100. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_public_stories_by_tag.html).
+  """
+
+  defstruct "@type": "searchPublicStoriesByTag", "@extra": nil, tag: nil, offset: nil, limit: nil
+end
+defmodule SetCustomEmojiStickerSetThumbnail do
+  @moduledoc  """
+  Sets a custom emoji sticker set thumbnail.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Chat identifier. |
-  | ttl | int32 | New TTL value, in seconds; unless the chat is secret, it must be from 0 up to 365 * 86400 and be divisible by 86400. |
+  | name | string | Sticker set name. The sticker set must be owned by the current user. |
+  | custom_emoji_id | int64 | Identifier of the custom emoji from the sticker set, which will be set as sticker set thumbnail; pass 0 to remove the sticker set thumbnail. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_message_ttl.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_custom_emoji_sticker_set_thumbnail.html).
   """
 
-  defstruct "@type": "setChatMessageTtl", "@extra": nil, chat_id: nil, ttl: nil
+  defstruct "@type": "setCustomEmojiStickerSetThumbnail", "@extra": nil, name: nil, custom_emoji_id: nil
+end
+defmodule EditBusinessMessageCaption do
+  @moduledoc  """
+  Edits the caption of a message sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
+  | caption | formattedText | New message content caption; pass null to remove caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | show_caption_above_media | bool | Pass true to show the caption above the media; otherwise, caption will be shown below the media. Can be true only for animation, photo, and video messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_message_caption.html).
+  """
+
+  defstruct "@type": "editBusinessMessageCaption", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil, caption: nil, show_caption_above_media: nil
 end
 defmodule GetRemoteFile do
   @moduledoc  """
-  Returns information about a file by its remote ID; this is an offline request. Can be used to register a URL as a file for further uploading, or sending as a message. Even the request succeeds, the file can be used only if it is still accessible to the user. For example, if the file is from a message, then the message must be not deleted and accessible to the user. If the file database is disabled, then the corresponding object with the file must be preloaded by the application.
+  Returns information about a file by its remote identifier; this is an offline request. Can be used to register a URL as a file for further uploading, or sending as a message. Even the request succeeds, the file can be used only if it is still accessible to the user. For example, if the file is from a message, then the message must be not deleted and accessible to the user. If the file database is disabled, then the corresponding object with the file must be preloaded by the application.
   Returns object_ptr<File>.
 
   | Name | Type | Description |
@@ -3335,6 +5138,21 @@ defmodule GetRemoteFile do
   """
 
   defstruct "@type": "getRemoteFile", "@extra": nil, remote_file_id: nil, file_type: nil
+end
+defmodule GetChatBoostLevelFeatures do
+  @moduledoc  """
+  Returns the list of features available on the specific chat boost level; this is an offline request.
+  Returns object_ptr<ChatBoostLevelFeatures>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_channel | bool | Pass true to get the list of features for channels; pass false to get the list of features for supergroups. |
+  | level | int32 | Chat boost level. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boost_level_features.html).
+  """
+
+  defstruct "@type": "getChatBoostLevelFeatures", "@extra": nil, is_channel: nil, level: nil
 end
 defmodule ToggleGroupCallIsMyVideoEnabled do
   @moduledoc  """
@@ -3353,7 +5171,7 @@ defmodule ToggleGroupCallIsMyVideoEnabled do
 end
 defmodule ToggleSupergroupIsAllHistoryAvailable do
   @moduledoc  """
-  Toggles whether the message history of a supergroup is available to new members; requires can_change_info administrator right.
+  Toggles whether the message history of a supergroup is available to new members; requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -3384,6 +5202,20 @@ defmodule SearchSecretMessages do
 
   defstruct "@type": "searchSecretMessages", "@extra": nil, chat_id: nil, query: nil, offset: nil, limit: nil, filter: nil
 end
+defmodule SetPersonalChat do
+  @moduledoc  """
+  Changes the personal chat of the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the new personal chat; pass 0 to remove the chat. Use <a class="el" href="classtd_1_1td__api_1_1get_suitable_personal_chats.html">getSuitablePersonalChats</a> to get suitable chats. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_personal_chat.html).
+  """
+
+  defstruct "@type": "setPersonalChat", "@extra": nil, chat_id: nil
+end
 defmodule SetPassportElement do
   @moduledoc  """
   Adds an element to the user's Telegram Passport. May return an error with a message "PHONE_VERIFICATION_NEEDED" or "EMAIL_VERIFICATION_NEEDED" if the chosen phone number or the chosen email address must be verified first.
@@ -3392,27 +5224,16 @@ defmodule SetPassportElement do
   | Name | Type | Description |
   |------|------| ------------|
   | element | InputPassportElement | Input Telegram Passport element. |
-  | password | string | Password of the current user. |
+  | password | string | The 2-step verification password of the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_passport_element.html).
   """
 
   defstruct "@type": "setPassportElement", "@extra": nil, element: nil, password: nil
 end
-defmodule ResendPhoneNumberVerificationCode do
-  @moduledoc  """
-  Re-sends the code to verify a phone number to be added to a user's Telegram Passport.
-  Returns object_ptr<AuthenticationCodeInfo>.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_phone_number_verification_code.html).
-  """
-
-  defstruct "@type": "resendPhoneNumberVerificationCode", "@extra": nil
-end
 defmodule SearchChatMembers do
   @moduledoc  """
-  Searches for a specified query in the first name, last name and username of the members of a specified chat. Requires administrator rights in channels.
+  Searches for a specified query in the first name, last name and usernames of the members of a specified chat. Requires administrator rights if the chat is a channel.
   Returns object_ptr<ChatMembers>.
 
   | Name | Type | Description |
@@ -3441,6 +5262,21 @@ defmodule RemoveProxy do
 
   defstruct "@type": "removeProxy", "@extra": nil, proxy_id: nil
 end
+defmodule SetBotProfilePhoto do
+  @moduledoc  """
+  Changes a profile photo for a bot.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | photo | InputChatPhoto | Profile photo to set; pass null to delete the chat photo. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_bot_profile_photo.html).
+  """
+
+  defstruct "@type": "setBotProfilePhoto", "@extra": nil, bot_user_id: nil, photo: nil
+end
 defmodule AcceptTermsOfService do
   @moduledoc  """
   Accepts Telegram terms of services.
@@ -3457,7 +5293,7 @@ defmodule AcceptTermsOfService do
 end
 defmodule GetChatNotificationSettingsExceptions do
   @moduledoc  """
-  Returns list of chats with non-default notification settings.
+  Returns the list of chats with non-default notification settings for new messages.
   Returns object_ptr<Chats>.
 
   | Name | Type | Description |
@@ -3469,6 +5305,48 @@ defmodule GetChatNotificationSettingsExceptions do
   """
 
   defstruct "@type": "getChatNotificationSettingsExceptions", "@extra": nil, scope: nil, compare_sound: nil
+end
+defmodule GetCountryFlagEmoji do
+  @moduledoc  """
+  Returns an emoji for the given country. Returns an empty string on failure. Can be called synchronously.
+  Returns object_ptr<Text>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | country_code | string | A two-letter ISO 3166-1 alpha-2 country code as received from <a class="el" href="classtd_1_1td__api_1_1get_countries.html">getCountries</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_country_flag_emoji.html).
+  """
+
+  defstruct "@type": "getCountryFlagEmoji", "@extra": nil, country_code: nil
+end
+defmodule SearchUserByToken do
+  @moduledoc  """
+  Searches a user by a token from the user's link.
+  Returns object_ptr<User>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | Token to search for. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_user_by_token.html).
+  """
+
+  defstruct "@type": "searchUserByToken", "@extra": nil, token: nil
+end
+defmodule SetNewChatPrivacySettings do
+  @moduledoc  """
+  Changes privacy settings for new chat creation; can be used only if getOption("can_set_new_chat_privacy_settings").
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | settings | newChatPrivacySettings | New settings. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_new_chat_privacy_settings.html).
+  """
+
+  defstruct "@type": "setNewChatPrivacySettings", "@extra": nil, settings: nil
 end
 defmodule SendCallSignalingData do
   @moduledoc  """
@@ -3488,7 +5366,7 @@ end
 defmodule GetMessageViewers do
   @moduledoc  """
   Returns viewers of a recent outgoing message in a basic group or a supergroup chat. For video notes and voice notes only users, opened content of the message, are returned. The method can be called if message.can_get_viewers == true.
-  Returns object_ptr<Users>.
+  Returns object_ptr<MessageViewers>.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3502,7 +5380,7 @@ defmodule GetMessageViewers do
 end
 defmodule GetTopChats do
   @moduledoc  """
-  Returns a list of frequently used chats. Supported only if the chat info database is enabled.
+  Returns a list of frequently used chats.
   Returns object_ptr<Chats>.
 
   | Name | Type | Description |
@@ -3584,6 +5462,20 @@ defmodule GetAccountTtl do
 
   defstruct "@type": "getAccountTtl", "@extra": nil
 end
+defmodule GetBusinessConnection do
+  @moduledoc  """
+  Returns information about a business connection by its identifier; for bots only.
+  Returns object_ptr<BusinessConnection>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | connection_id | string | Identifier of the business connection to return. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_business_connection.html).
+  """
+
+  defstruct "@type": "getBusinessConnection", "@extra": nil, connection_id: nil
+end
 defmodule DeleteFile do
   @moduledoc  """
   Deletes a file from the TDLib file cache.
@@ -3597,6 +5489,32 @@ defmodule DeleteFile do
   """
 
   defstruct "@type": "deleteFile", "@extra": nil, file_id: nil
+end
+defmodule ClearAutosaveSettingsExceptions do
+  @moduledoc  """
+  Clears the list of all autosave settings exceptions. The method is guaranteed to work only after at least one call to getAutosaveSettings.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1clear_autosave_settings_exceptions.html).
+  """
+
+  defstruct "@type": "clearAutosaveSettingsExceptions", "@extra": nil
+end
+defmodule SetPinnedForumTopics do
+  @moduledoc  """
+  Changes the order of pinned forum topics; requires can_manage_topics right in the supergroup.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_thread_ids | int53 | The new list of pinned forum topics. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_pinned_forum_topics.html).
+  """
+
+  defstruct "@type": "setPinnedForumTopics", "@extra": nil, chat_id: nil, message_thread_ids: nil
 end
 defmodule ReplacePrimaryChatInviteLink do
   @moduledoc  """
@@ -3628,6 +5546,20 @@ defmodule GetCallbackQueryAnswer do
 
   defstruct "@type": "getCallbackQueryAnswer", "@extra": nil, chat_id: nil, message_id: nil, payload: nil
 end
+defmodule GetCollectibleItemInfo do
+  @moduledoc  """
+  Returns information about a given collectible item that was purchased at https://fragment.com.
+  Returns object_ptr<CollectibleItemInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | type | CollectibleItemType | Type of the collectible item. The item must be used by a user and must be visible to the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_collectible_item_info.html).
+  """
+
+  defstruct "@type": "getCollectibleItemInfo", "@extra": nil, type: nil
+end
 defmodule SetProfilePhoto do
   @moduledoc  """
   Changes a profile photo for the current user.
@@ -3636,11 +5568,29 @@ defmodule SetProfilePhoto do
   | Name | Type | Description |
   |------|------| ------------|
   | photo | InputChatPhoto | Profile photo to set. |
+  | is_public | bool | Pass true to set a public photo, which will be visible even the main photo is hidden by privacy settings. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_profile_photo.html).
   """
 
-  defstruct "@type": "setProfilePhoto", "@extra": nil, photo: nil
+  defstruct "@type": "setProfilePhoto", "@extra": nil, photo: nil, is_public: nil
+end
+defmodule SetMessageReactions do
+  @moduledoc  """
+  Sets reactions on a message; for bots only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which the message belongs. |
+  | message_id | int53 | Identifier of the message. |
+  | reaction_types | ReactionType | Types of the reaction to set. |
+  | is_big | bool | Pass true if the reactions are added with a big animation. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_message_reactions.html).
+  """
+
+  defstruct "@type": "setMessageReactions", "@extra": nil, chat_id: nil, message_id: nil, reaction_types: nil, is_big: nil
 end
 defmodule SendChatAction do
   @moduledoc  """
@@ -3650,13 +5600,14 @@ defmodule SendChatAction do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the action was performed. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the action was performed. |
+  | business_connection_id | string | Unique identifier of business connection on behalf of which to send the request; for bots only. |
   | action | ChatAction | The action description; pass null to cancel the currently active action. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_chat_action.html).
   """
 
-  defstruct "@type": "sendChatAction", "@extra": nil, chat_id: nil, message_thread_id: nil, action: nil
+  defstruct "@type": "sendChatAction", "@extra": nil, chat_id: nil, message_thread_id: nil, business_connection_id: nil, action: nil
 end
 defmodule SendCallLog do
   @moduledoc  """
@@ -3673,6 +5624,20 @@ defmodule SendCallLog do
 
   defstruct "@type": "sendCallLog", "@extra": nil, call_id: nil, log_file: nil
 end
+defmodule DeleteBusinessChatLink do
+  @moduledoc  """
+  Deletes a business chat link of the current account.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link | string | The link to delete. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_business_chat_link.html).
+  """
+
+  defstruct "@type": "deleteBusinessChatLink", "@extra": nil, link: nil
+end
 defmodule EditInlineMessageCaption do
   @moduledoc  """
   Edits the caption of an inline message sent via a bot; for bots only.
@@ -3682,12 +5647,13 @@ defmodule EditInlineMessageCaption do
   |------|------| ------------|
   | inline_message_id | string | Inline message identifier. |
   | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
-  | caption | formattedText | New message content caption; pass null to remove caption; 0-GetOption("message_caption_length_max") characters. |
+  | caption | formattedText | New message content caption; pass null to remove caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | show_caption_above_media | bool | Pass true to show the caption above the media; otherwise, caption will be shown below the media. Can be true only for animation, photo, and video messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_inline_message_caption.html).
   """
 
-  defstruct "@type": "editInlineMessageCaption", "@extra": nil, inline_message_id: nil, reply_markup: nil, caption: nil
+  defstruct "@type": "editInlineMessageCaption", "@extra": nil, inline_message_id: nil, reply_markup: nil, caption: nil, show_caption_above_media: nil
 end
 defmodule GetUser do
   @moduledoc  """
@@ -3703,16 +5669,36 @@ defmodule GetUser do
 
   defstruct "@type": "getUser", "@extra": nil, user_id: nil
 end
-defmodule ResetBackgrounds do
+defmodule SetChatPinnedStories do
   @moduledoc  """
-  Resets list of installed backgrounds to its default value.
+  Changes the list of pinned stories on a chat page; requires can_edit_stories right in the chat.
   Returns object_ptr<Ok>.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat that posted the stories. |
+  | story_ids | int32 | New list of pinned stories. All stories must be posted to the chat page first. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("pinned_story_count_max") pinned stories on a chat page. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reset_backgrounds.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_pinned_stories.html).
   """
 
-  defstruct "@type": "resetBackgrounds", "@extra": nil
+  defstruct "@type": "setChatPinnedStories", "@extra": nil, chat_id: nil, story_ids: nil
+end
+defmodule SendWebAppCustomRequest do
+  @moduledoc  """
+  Sends a custom request from a Web App.
+  Returns object_ptr<CustomRequestResult>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the bot. |
+  | method | string | The method name. |
+  | parameters | string | JSON-serialized method parameters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_web_app_custom_request.html).
+  """
+
+  defstruct "@type": "sendWebAppCustomRequest", "@extra": nil, bot_user_id: nil, method: nil, parameters: nil
 end
 defmodule ViewPremiumFeature do
   @moduledoc  """
@@ -3728,20 +5714,64 @@ defmodule ViewPremiumFeature do
 
   defstruct "@type": "viewPremiumFeature", "@extra": nil, feature: nil
 end
-defmodule SendPhoneNumberVerificationCode do
+defmodule SetMessageFactCheck do
   @moduledoc  """
-  Sends a code to verify a phone number to be added to a user's Telegram Passport.
-  Returns object_ptr<AuthenticationCodeInfo>.
+  Changes the fact-check of a message. Can be only used if getOption("can_edit_fact_check") == true.
+  Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | phone_number | string | The phone number of the user, in international format. |
-  | settings | phoneNumberAuthenticationSettings | Settings for the authentication of the user's phone number; pass null to use default settings. |
+  | chat_id | int53 | The channel chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. The message must be one of the following types: <a class="el" href="classtd_1_1td__api_1_1message_animation.html">messageAnimation</a>, <a class="el" href="classtd_1_1td__api_1_1message_audio.html">messageAudio</a>, <a class="el" href="classtd_1_1td__api_1_1message_document.html">messageDocument</a>, <a class="el" href="classtd_1_1td__api_1_1message_photo.html">messagePhoto</a>, <a class="el" href="classtd_1_1td__api_1_1message_text.html">messageText</a>, <a class="el" href="classtd_1_1td__api_1_1message_video.html">messageVideo</a>. |
+  | text | formattedText | New text of the fact-check; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("fact_check_length_max") characters; pass null to remove it. Only Bold, Italic, and TextUrl entities with <a href="https://t.me/">https://t.me/</a> links are supported. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_phone_number_verification_code.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_message_fact_check.html).
   """
 
-  defstruct "@type": "sendPhoneNumberVerificationCode", "@extra": nil, phone_number: nil, settings: nil
+  defstruct "@type": "setMessageFactCheck", "@extra": nil, chat_id: nil, message_id: nil, text: nil
+end
+defmodule AddQuickReplyShortcutMessage do
+  @moduledoc  """
+  Adds a message to a quick reply shortcut. If shortcut doesn't exist and there are less than getOption("quick_reply_shortcut_count_max") shortcuts, then a new shortcut is created. The shortcut must not contain more than getOption("quick_reply_shortcut_message_count_max") messages after adding the new message. Returns the added message.
+  Returns object_ptr<QuickReplyMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_name | string | Name of the target shortcut. |
+  | reply_to_message_id | int53 | Identifier of a quick reply message in the same shortcut to be replied; pass 0 if none. |
+  | input_message_content | InputMessageContent | The content of the message to be added; <a class="el" href="classtd_1_1td__api_1_1input_message_poll.html">inputMessagePoll</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_forwarded.html">inputMessageForwarded</a> and <a class="el" href="classtd_1_1td__api_1_1input_message_location.html">inputMessageLocation</a> with live_period aren't supported. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_quick_reply_shortcut_message.html).
+  """
+
+  defstruct "@type": "addQuickReplyShortcutMessage", "@extra": nil, shortcut_name: nil, reply_to_message_id: nil, input_message_content: nil
+end
+defmodule CreateForumTopic do
+  @moduledoc  """
+  Creates a topic in a forum supergroup chat; requires can_manage_topics administrator or can_create_topics member right in the supergroup.
+  Returns object_ptr<ForumTopicInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | name | string | Name of the topic; 1-128 characters. |
+  | icon | forumTopicIcon | Icon of the topic. Icon color must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, or 0xFB6F5F. Telegram Premium users can use any custom emoji as topic icon, other users can use only a custom emoji returned by <a class="el" href="classtd_1_1td__api_1_1get_forum_topic_default_icons.html">getForumTopicDefaultIcons</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_forum_topic.html).
+  """
+
+  defstruct "@type": "createForumTopic", "@extra": nil, chat_id: nil, name: nil, icon: nil
+end
+defmodule GetRecommendedChatFolders do
+  @moduledoc  """
+  Returns recommended chat folders for the current user.
+  Returns object_ptr<RecommendedChatFolders>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_recommended_chat_folders.html).
+  """
+
+  defstruct "@type": "getRecommendedChatFolders", "@extra": nil
 end
 defmodule SetChatMessageSender do
   @moduledoc  """
@@ -3758,17 +5788,31 @@ defmodule SetChatMessageSender do
 
   defstruct "@type": "setChatMessageSender", "@extra": nil, chat_id: nil, message_sender_id: nil
 end
+defmodule GetEmojiCategories do
+  @moduledoc  """
+  Returns available emoji categories.
+  Returns object_ptr<EmojiCategories>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | type | EmojiCategoryType | Type of emoji categories to return; pass null to get default emoji categories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_emoji_categories.html).
+  """
+
+  defstruct "@type": "getEmojiCategories", "@extra": nil, type: nil
+end
 defmodule GetMessagePublicForwards do
   @moduledoc  """
-  Returns forwarded copies of a channel message to different public channels. For optimal performance, the number of returned messages is chosen by TDLib.
-  Returns object_ptr<FoundMessages>.
+  Returns forwarded copies of a channel message to different public channels and public reposts as a story. Can be used only if message.can_get_statistics == true. For optimal performance, the number of returned messages and stories is chosen by TDLib.
+  Returns object_ptr<PublicForwards>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier of the message. |
   | message_id | int53 | Message identifier. |
   | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
-  | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
+  | limit | int32 | The maximum number of messages and stories to be returned; must be positive and can't be greater than 100. For optimal performance, the number of returned objects is chosen by TDLib and can be smaller than the specified limit. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_public_forwards.html).
   """
@@ -3789,6 +5833,22 @@ defmodule ParseMarkdown do
 
   defstruct "@type": "parseMarkdown", "@extra": nil, text: nil
 end
+defmodule SearchQuote do
+  @moduledoc  """
+  Searches for a given quote in a text. Returns found quote start position in UTF-16 code units. Returns a 404 error if the quote is not found. Can be called synchronously.
+  Returns object_ptr<FoundPosition>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | formattedText | Text in which to search for the quote. |
+  | quote | formattedText | Quote to search for. |
+  | quote_position | int32 | Approximate quote position in UTF-16 code units. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_quote.html).
+  """
+
+  defstruct "@type": "searchQuote", "@extra": nil, text: nil, quote: nil, quote_position: nil
+end
 defmodule EditProxy do
   @moduledoc  """
   Edits an existing proxy server for network requests. Can be called before authorization.
@@ -3797,7 +5857,7 @@ defmodule EditProxy do
   | Name | Type | Description |
   |------|------| ------------|
   | proxy_id | int32 | Proxy identifier. |
-  | server | string | Proxy server IP address. |
+  | server | string | Proxy server domain or IP address. |
   | port | int32 | Proxy server port. |
   | enable | bool | Pass true to immediately enable the proxy. |
   | type | ProxyType | Proxy type. |
@@ -3814,7 +5874,7 @@ defmodule SetChatDiscussionGroup do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Identifier of the channel chat. Pass 0 to remove a link from the supergroup passed in the second argument to a linked channel chat (requires can_pin_messages rights in the supergroup). |
+  | chat_id | int53 | Identifier of the channel chat. Pass 0 to remove a link from the supergroup passed in the second argument to a linked channel chat (requires can_pin_messages member right in the supergroup). |
   | discussion_chat_id | int53 | Identifier of a new channel's discussion group. Use 0 to remove the discussion group. Use the method <a class="el" href="classtd_1_1td__api_1_1get_suitable_discussion_chats.html">getSuitableDiscussionChats</a> to find all suitable groups. Basic group chats must be first upgraded to supergroup chats. If new chat members don't have access to old messages in the supergroup, then <a class="el" href="classtd_1_1td__api_1_1toggle_supergroup_is_all_history_available.html">toggleSupergroupIsAllHistoryAvailable</a> must be used first to change that. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_discussion_group.html).
@@ -3840,38 +5900,40 @@ defmodule EditInlineMessageText do
 end
 defmodule SetSupergroupUsername do
   @moduledoc  """
-  Changes the username of a supergroup or channel, requires owner privileges in the supergroup or channel.
+  Changes the editable username of a supergroup or channel, requires owner privileges in the supergroup or channel.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | supergroup_id | int53 | Identifier of the supergroup or channel. |
-  | username | string | New value of the username. Use an empty string to remove the username. |
+  | username | string | New value of the username. Use an empty string to remove the username. The username can't be completely removed if there is another active or disabled username. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_supergroup_username.html).
   """
 
   defstruct "@type": "setSupergroupUsername", "@extra": nil, supergroup_id: nil, username: nil
 end
-defmodule EditChatFilter do
+defmodule StopBusinessPoll do
   @moduledoc  """
-  Edits existing chat filter. Returns information about the edited chat filter.
-  Returns object_ptr<ChatFilterInfo>.
+  Stops a poll sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_filter_id | int32 | Chat filter identifier. |
-  | filter | chatFilter | The edited chat filter. |
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message with the poll was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message containing the poll. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_chat_filter.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1stop_business_poll.html).
   """
 
-  defstruct "@type": "editChatFilter", "@extra": nil, chat_filter_id: nil, filter: nil
+  defstruct "@type": "stopBusinessPoll", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil
 end
 defmodule GetChatAvailableMessageSenders do
   @moduledoc  """
-  Returns list of message sender identifiers, which can be used to send messages in a chat.
-  Returns object_ptr<MessageSenders>.
+  Returns the list of message sender identifiers, which can be used to send messages in a chat.
+  Returns object_ptr<ChatMessageSenders>.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3907,6 +5969,20 @@ defmodule EndGroupCall do
 
   defstruct "@type": "endGroupCall", "@extra": nil, group_call_id: nil
 end
+defmodule GetChatFolderDefaultIconName do
+  @moduledoc  """
+  Returns default icon name for a folder. Can be called synchronously.
+  Returns object_ptr<ChatFolderIcon>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | folder | chatFolder | Chat folder. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_folder_default_icon_name.html).
+  """
+
+  defstruct "@type": "getChatFolderDefaultIconName", "@extra": nil, folder: nil
+end
 defmodule GetSuggestedFileName do
   @moduledoc  """
   Returns suggested name for saving a file in a given directory.
@@ -3922,9 +5998,25 @@ defmodule GetSuggestedFileName do
 
   defstruct "@type": "getSuggestedFileName", "@extra": nil, file_id: nil, directory: nil
 end
+defmodule SetBotName do
+  @moduledoc  """
+  Sets the name of a bot. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code. If empty, the name will be shown to all users for whose languages there is no dedicated name. |
+  | name | string | New bot's name on the specified language; 0-64 characters; must be non-empty if language code is empty. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_bot_name.html).
+  """
+
+  defstruct "@type": "setBotName", "@extra": nil, bot_user_id: nil, language_code: nil, name: nil
+end
 defmodule GetVideoChatRtmpUrl do
   @moduledoc  """
-  Returns RTMP URL for streaming to the chat; requires creator privileges.
+  Returns RTMP URL for streaming to the chat; requires owner privileges.
   Returns object_ptr<RtmpUrl>.
 
   | Name | Type | Description |
@@ -3935,6 +6027,64 @@ defmodule GetVideoChatRtmpUrl do
   """
 
   defstruct "@type": "getVideoChatRtmpUrl", "@extra": nil, chat_id: nil
+end
+defmodule GetInstalledBackgrounds do
+  @moduledoc  """
+  Returns backgrounds installed by the user.
+  Returns object_ptr<Backgrounds>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | for_dark_theme | bool | Pass true to order returned backgrounds for a dark theme. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_installed_backgrounds.html).
+  """
+
+  defstruct "@type": "getInstalledBackgrounds", "@extra": nil, for_dark_theme: nil
+end
+defmodule SetReactionNotificationSettings do
+  @moduledoc  """
+  Changes notification settings for reactions.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | notification_settings | reactionNotificationSettings | The new notification settings for reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_reaction_notification_settings.html).
+  """
+
+  defstruct "@type": "setReactionNotificationSettings", "@extra": nil, notification_settings: nil
+end
+defmodule SendQuickReplyShortcutMessages do
+  @moduledoc  """
+  Sends messages from a quick reply shortcut. Requires Telegram Business subscription.
+  Returns object_ptr<Messages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which to send messages. The chat must be a private chat with a regular user. |
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut. |
+  | sending_id | int32 | Non-persistent identifier, which will be returned back in <a class="el" href="classtd_1_1td__api_1_1message_sending_state_pending.html">messageSendingStatePending</a> object and can be used to match sent messages and corresponding <a class="el" href="classtd_1_1td__api_1_1update_new_message.html">updateNewMessage</a> updates. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_quick_reply_shortcut_messages.html).
+  """
+
+  defstruct "@type": "sendQuickReplyShortcutMessages", "@extra": nil, chat_id: nil, shortcut_id: nil, sending_id: nil
+end
+defmodule RemoveSearchedForTag do
+  @moduledoc  """
+  Removes a hashtag or a cashtag from the list of recently searched for hashtags or cashtags.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tag | string | Hashtag or cashtag to delete. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_searched_for_tag.html).
+  """
+
+  defstruct "@type": "removeSearchedForTag", "@extra": nil, tag: nil
 end
 defmodule SetPinnedChats do
   @moduledoc  """
@@ -3951,6 +6101,25 @@ defmodule SetPinnedChats do
 
   defstruct "@type": "setPinnedChats", "@extra": nil, chat_list: nil, chat_ids: nil
 end
+defmodule GetChatStoryInteractions do
+  @moduledoc  """
+  Returns interactions with a story posted in a chat. Can be used only if story is posted on behalf of a chat and the user is an administrator in the chat.
+  Returns object_ptr<StoryInteractions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story. |
+  | story_id | int32 | Story identifier. |
+  | reaction_type | ReactionType | Pass the default heart reaction or a suggested reaction type to receive only interactions with the specified reaction type; pass null to receive all interactions. |
+  | prefer_forwards | bool | Pass true to get forwards and reposts first, then reactions, then other views; pass false to get interactions sorted just by interaction date. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of story interactions to return. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_story_interactions.html).
+  """
+
+  defstruct "@type": "getChatStoryInteractions", "@extra": nil, story_sender_chat_id: nil, story_id: nil, reaction_type: nil, prefer_forwards: nil, offset: nil, limit: nil
+end
 defmodule GetApplicationDownloadLink do
   @moduledoc  """
   Returns the link for downloading official Telegram application to be used when the current user invites friends to Telegram.
@@ -3964,35 +6133,34 @@ defmodule GetApplicationDownloadLink do
 end
 defmodule SearchCallMessages do
   @moduledoc  """
-  Searches for call messages. Returns the results in reverse chronological order (i. e., in order of decreasing message_id). For optimal performance, the number of returned messages is chosen by TDLib.
-  Returns object_ptr<Messages>.
+  Searches for call messages. Returns the results in reverse chronological order (i.e., in order of decreasing message_id). For optimal performance, the number of returned messages is chosen by TDLib.
+  Returns object_ptr<FoundMessages>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | from_message_id | int53 | Identifier of the message from which to search; use 0 to get results from the last message. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
   | limit | int32 | The maximum number of messages to be returned; up to 100. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
   | only_missed | bool | Pass true to search only for messages with missed/declined calls. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_call_messages.html).
   """
 
-  defstruct "@type": "searchCallMessages", "@extra": nil, from_message_id: nil, limit: nil, only_missed: nil
+  defstruct "@type": "searchCallMessages", "@extra": nil, offset: nil, limit: nil, only_missed: nil
 end
 defmodule SearchEmojis do
   @moduledoc  """
-  Searches for emojis by keywords. Supported only if the file database is enabled.
-  Returns object_ptr<Emojis>.
+  Searches for emojis by keywords. Supported only if the file database is enabled. Order of results is unspecified.
+  Returns object_ptr<EmojiKeywords>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | text | string | Text to search for. |
-  | exact_match | bool | Pass true if only emojis, which exactly match the text, needs to be returned. |
   | input_language_codes | string | List of possible IETF language tags of the user's input language; may be empty if unknown. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_emojis.html).
   """
 
-  defstruct "@type": "searchEmojis", "@extra": nil, text: nil, exact_match: nil, input_language_codes: nil
+  defstruct "@type": "searchEmojis", "@extra": nil, text: nil, input_language_codes: nil
 end
 defmodule GetMarkdownText do
   @moduledoc  """
@@ -4008,9 +6176,20 @@ defmodule GetMarkdownText do
 
   defstruct "@type": "getMarkdownText", "@extra": nil, text: nil
 end
+defmodule ResetInstalledBackgrounds do
+  @moduledoc  """
+  Resets list of installed backgrounds to its default value.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reset_installed_backgrounds.html).
+  """
+
+  defstruct "@type": "resetInstalledBackgrounds", "@extra": nil
+end
 defmodule GetChatEventLog do
   @moduledoc  """
-  Returns a list of service actions taken by chat members and administrators in the last 48 hours. Available only for supergroups and channels. Requires administrator rights. Returns results in reverse chronological order (i. e., in order of decreasing event_id).
+  Returns a list of service actions taken by chat members and administrators in the last 48 hours. Available only for supergroups and channels. Requires administrator rights. Returns results in reverse chronological order (i.e., in order of decreasing event_id).
   Returns object_ptr<ChatEvents>.
 
   | Name | Type | Description |
@@ -4064,24 +6243,9 @@ defmodule AnswerWebAppQuery do
 
   defstruct "@type": "answerWebAppQuery", "@extra": nil, web_app_query_id: nil, result: nil
 end
-defmodule ChangePhoneNumber do
-  @moduledoc  """
-  Changes the phone number of the user and sends an authentication code to the user's new phone number. On success, returns information about the sent code.
-  Returns object_ptr<AuthenticationCodeInfo>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | phone_number | string | The new phone number of the user in international format. |
-  | settings | phoneNumberAuthenticationSettings | Settings for the authentication of the user's phone number; pass null to use default settings. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1change_phone_number.html).
-  """
-
-  defstruct "@type": "changePhoneNumber", "@extra": nil, phone_number: nil, settings: nil
-end
 defmodule SendBotStartMessage do
   @moduledoc  """
-  Invites a bot to a chat (if it is not yet a member) and sends it the /start command. Bots can't be invited to a private chat other than the chat with the bot. Bots can't be invited to channels (although they can be added as admins) and secret chats. Returns the sent message.
+  Invites a bot to a chat (if it is not yet a member) and sends it the /start command; requires can_invite_users member right. Bots can't be invited to a private chat other than the chat with the bot. Bots can't be invited to channels (although they can be added as admins) and secret chats. Returns the sent message.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |
@@ -4105,6 +6269,17 @@ defmodule ClearImportedContacts do
   """
 
   defstruct "@type": "clearImportedContacts", "@extra": nil
+end
+defmodule GetDefaultChatPhotoCustomEmojiStickers do
+  @moduledoc  """
+  Returns default list of custom emoji stickers for placing on a chat photo.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_chat_photo_custom_emoji_stickers.html).
+  """
+
+  defstruct "@type": "getDefaultChatPhotoCustomEmojiStickers", "@extra": nil
 end
 defmodule RemoveContacts do
   @moduledoc  """
@@ -4136,19 +6311,48 @@ defmodule ValidateOrderInfo do
 
   defstruct "@type": "validateOrderInfo", "@extra": nil, input_invoice: nil, order_info: nil, allow_save: nil
 end
-defmodule AssignGooglePlayTransaction do
+defmodule GetCloseFriends do
   @moduledoc  """
-  Informs server about a Telegram Premium purchase through Google Play. For official applications only.
+  Returns all close friends of the current user.
+  Returns object_ptr<Users>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_close_friends.html).
+  """
+
+  defstruct "@type": "getCloseFriends", "@extra": nil
+end
+defmodule SetStickerEmojis do
+  @moduledoc  """
+  Changes the list of emojis corresponding to a sticker. The sticker must belong to a regular or custom emoji sticker set that is owned by the current user.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
+  | sticker | InputFile | Sticker. |
+  | emojis | string | New string with 1-20 emoji corresponding to the sticker. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_sticker_emojis.html).
+  """
+
+  defstruct "@type": "setStickerEmojis", "@extra": nil, sticker: nil, emojis: nil
+end
+defmodule AssignGooglePlayTransaction do
+  @moduledoc  """
+  Informs server about a purchase through Google Play. For official applications only.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | package_name | string | Application package name. |
+  | store_product_id | string | Identifier of the purchased store product. |
   | purchase_token | string | Google Play purchase token. |
+  | purpose | StorePaymentPurpose | Transaction purpose. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1assign_google_play_transaction.html).
   """
 
-  defstruct "@type": "assignGooglePlayTransaction", "@extra": nil, purchase_token: nil
+  defstruct "@type": "assignGooglePlayTransaction", "@extra": nil, package_name: nil, store_product_id: nil, purchase_token: nil, purpose: nil
 end
 defmodule CreateSupergroupChat do
   @moduledoc  """
@@ -4165,6 +6369,36 @@ defmodule CreateSupergroupChat do
 
   defstruct "@type": "createSupergroupChat", "@extra": nil, supergroup_id: nil, force: nil
 end
+defmodule ToggleSupergroupIsForum do
+  @moduledoc  """
+  Toggles whether the supergroup is a forum; requires owner privileges in the supergroup. Discussion supergroups can't be converted to forums.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup. |
+  | is_forum | bool | New value of is_forum. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_is_forum.html).
+  """
+
+  defstruct "@type": "toggleSupergroupIsForum", "@extra": nil, supergroup_id: nil, is_forum: nil
+end
+defmodule OpenStory do
+  @moduledoc  """
+  Informs TDLib that a story is opened and is being viewed by the user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the opened story. |
+  | story_id | int32 | The identifier of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1open_story.html).
+  """
+
+  defstruct "@type": "openStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
+end
 defmodule GetChatMessageCalendar do
   @moduledoc  """
   Returns information about the next messages of the specified type in the chat split by days. Returns the results in reverse chronological order. Can return partial result for the last returned day. Behavior of this method depends on the value of the option "utc_time_offset".
@@ -4175,11 +6409,12 @@ defmodule GetChatMessageCalendar do
   | chat_id | int53 | Identifier of the chat in which to return information about messages. |
   | filter | SearchMessagesFilter | Filter for message content. Filters <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_empty.html">searchMessagesFilterEmpty</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_mention.html">searchMessagesFilterMention</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_mention.html">searchMessagesFilterUnreadMention</a>, and <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_reaction.html">searchMessagesFilterUnreadReaction</a> are unsupported in this function. |
   | from_message_id | int53 | The message identifier from which to return information about messages; use 0 to get results from the last message. |
+  | saved_messages_topic_id | int53 | If not0, only messages in the specified Saved Messages topic will be considered; pass 0 to consider all messages, or for chats other than Saved Messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_message_calendar.html).
   """
 
-  defstruct "@type": "getChatMessageCalendar", "@extra": nil, chat_id: nil, filter: nil, from_message_id: nil
+  defstruct "@type": "getChatMessageCalendar", "@extra": nil, chat_id: nil, filter: nil, from_message_id: nil, saved_messages_topic_id: nil
 end
 defmodule SetDefaultChannelAdministratorRights do
   @moduledoc  """
@@ -4188,7 +6423,7 @@ defmodule SetDefaultChannelAdministratorRights do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | default_channel_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to channels; may be null. |
+  | default_channel_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to channels; pass null to remove default rights. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_default_channel_administrator_rights.html).
   """
@@ -4248,7 +6483,7 @@ defmodule GetFavoriteStickers do
 end
 defmodule RecognizeSpeech do
   @moduledoc  """
-  Recognizes speech in a voice note message. The message must be successfully sent and must not be scheduled. May return an error with a message "MSG_VOICE_TOO_LONG" if the voice note is too long to be recognized.
+  Recognizes speech in a video note or a voice note message. The message must be successfully sent, must not be scheduled, and must be from a non-secret chat.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4327,18 +6562,19 @@ defmodule CanTransferOwnership do
 end
 defmodule SearchStickers do
   @moduledoc  """
-  Searches for stickers from public sticker sets that correspond to a given emoji.
+  Searches for stickers from public sticker sets that correspond to any of the given emoji.
   Returns object_ptr<Stickers>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | emoji | string | String representation of emoji; must be non-empty. |
-  | limit | int32 | The maximum number of stickers to be returned. |
+  | sticker_type | StickerType | Type of the stickers to return. |
+  | emojis | string | Space-separated list of emojis to search for; must be non-empty. |
+  | limit | int32 | The maximum number of stickers to be returned; 0-100. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_stickers.html).
   """
 
-  defstruct "@type": "searchStickers", "@extra": nil, emoji: nil, limit: nil
+  defstruct "@type": "searchStickers", "@extra": nil, sticker_type: nil, emojis: nil, limit: nil
 end
 defmodule GetGroupCallStreams do
   @moduledoc  """
@@ -4354,21 +6590,33 @@ defmodule GetGroupCallStreams do
 
   defstruct "@type": "getGroupCallStreams", "@extra": nil, group_call_id: nil
 end
-defmodule UploadFile do
+defmodule GetStoryAvailableReactions do
   @moduledoc  """
-  Asynchronously uploads a file to the cloud without sending it in a message. updateFile will be used to notify about upload progress and successful completion of the upload. The file will not have a persistent remote identifier until it will be sent in a message.
-  Returns object_ptr<File>.
+  Returns reactions, which can be chosen for a story.
+  Returns object_ptr<AvailableReactions>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | file | InputFile | File to upload. |
-  | file_type | FileType | File type; pass null if unknown. |
-  | priority | int32 | Priority of the upload (1-32). The higher the priority, the earlier the file will be uploaded. If the priorities of two files are equal, then the first one for which <a class="el" href="classtd_1_1td__api_1_1upload_file.html">uploadFile</a> was called will be uploaded first. |
+  | row_size | int32 | Number of reaction per row, 5-25. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1upload_file.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story_available_reactions.html).
   """
 
-  defstruct "@type": "uploadFile", "@extra": nil, file: nil, file_type: nil, priority: nil
+  defstruct "@type": "getStoryAvailableReactions", "@extra": nil, row_size: nil
+end
+defmodule CheckAuthenticationEmailCode do
+  @moduledoc  """
+  Checks the authentication of an email address. Works only when the current authorization state is authorizationStateWaitEmailCode.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | EmailAddressAuthentication | Email address authentication to check. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_authentication_email_code.html).
+  """
+
+  defstruct "@type": "checkAuthenticationEmailCode", "@extra": nil, code: nil
 end
 defmodule GetBlockedMessageSenders do
   @moduledoc  """
@@ -4377,17 +6625,18 @@ defmodule GetBlockedMessageSenders do
 
   | Name | Type | Description |
   |------|------| ------------|
+  | block_list | BlockList | Block list from which to return users. |
   | offset | int32 | Number of users and chats to skip in the result; must be non-negative. |
   | limit | int32 | The maximum number of users and chats to return; up to 100. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_blocked_message_senders.html).
   """
 
-  defstruct "@type": "getBlockedMessageSenders", "@extra": nil, offset: nil, limit: nil
+  defstruct "@type": "getBlockedMessageSenders", "@extra": nil, block_list: nil, offset: nil, limit: nil
 end
 defmodule SetLocation do
   @moduledoc  """
-  Changes the location of the current user. Needs to be called if GetOption("is_location_visible") is true and location changes for more than 1 kilometer.
+  Changes the location of the current user. Needs to be called if getOption("is_location_visible") is true and location changes for more than 1 kilometer. Must not be called if the user has a business location.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4398,6 +6647,20 @@ defmodule SetLocation do
   """
 
   defstruct "@type": "setLocation", "@extra": nil, location: nil
+end
+defmodule DeleteBusinessConnectedBot do
+  @moduledoc  """
+  Deletes the business bot that is connected to the current user account.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Unique user identifier for the bot. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_business_connected_bot.html).
+  """
+
+  defstruct "@type": "deleteBusinessConnectedBot", "@extra": nil, bot_user_id: nil
 end
 defmodule SetVideoChatDefaultParticipant do
   @moduledoc  """
@@ -4432,7 +6695,7 @@ defmodule SetGroupCallParticipantIsSpeaking do
 end
 defmodule CheckAuthenticationPasswordRecoveryCode do
   @moduledoc  """
-  Checks whether a password recovery code sent to an email address is valid. Works only when the current authorization state is authorizationStateWaitPassword.
+  Checks whether a 2-step verification password recovery code sent to an email address is valid. Works only when the current authorization state is authorizationStateWaitPassword.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4443,6 +6706,21 @@ defmodule CheckAuthenticationPasswordRecoveryCode do
   """
 
   defstruct "@type": "checkAuthenticationPasswordRecoveryCode", "@extra": nil, recovery_code: nil
+end
+defmodule GetChatRevenueStatistics do
+  @moduledoc  """
+  Returns detailed revenue statistics about a chat. Currently, this method can be used only for channels if supergroupFullInfo.can_get_revenue_statistics == true.
+  Returns object_ptr<ChatRevenueStatistics>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | is_dark | bool | Pass true if a dark theme is used by the application. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_revenue_statistics.html).
+  """
+
+  defstruct "@type": "getChatRevenueStatistics", "@extra": nil, chat_id: nil, is_dark: nil
 end
 defmodule CreateCall do
   @moduledoc  """
@@ -4504,6 +6782,20 @@ defmodule GetAnimatedEmoji do
 
   defstruct "@type": "getAnimatedEmoji", "@extra": nil, emoji: nil
 end
+defmodule ReportAuthenticationCodeMissing do
+  @moduledoc  """
+  Reports that authentication code wasn't delivered via SMS; for official mobile applications only. Works only when the current authorization state is authorizationStateWaitCode.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | mobile_network_code | string | Current mobile network code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_authentication_code_missing.html).
+  """
+
+  defstruct "@type": "reportAuthenticationCodeMissing", "@extra": nil, mobile_network_code: nil
+end
 defmodule TestSquareInt do
   @moduledoc  """
   Returns the squared received number; for testing only. This is an offline method. Can be called before authorization.
@@ -4518,6 +6810,21 @@ defmodule TestSquareInt do
 
   defstruct "@type": "testSquareInt", "@extra": nil, x: nil
 end
+defmodule ToggleSupergroupHasHiddenMembers do
+  @moduledoc  """
+  Toggles whether non-administrators can receive only administrators and bots using getSupergroupMembers or searchChatMembers. Can be called only if supergroupFullInfo.can_hide_members == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup. |
+  | has_hidden_members | bool | New value of has_hidden_members. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_has_hidden_members.html).
+  """
+
+  defstruct "@type": "toggleSupergroupHasHiddenMembers", "@extra": nil, supergroup_id: nil, has_hidden_members: nil
+end
 defmodule GetPassportAuthorizationFormAvailableElements do
   @moduledoc  """
   Returns already available Telegram Passport elements suitable for completing a Telegram Passport authorization form. Result can be received only once for each authorization form.
@@ -4525,17 +6832,17 @@ defmodule GetPassportAuthorizationFormAvailableElements do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | autorization_form_id | int32 | Authorization form identifier. |
-  | password | string | Password of the current user. |
+  | authorization_form_id | int32 | Authorization form identifier. |
+  | password | string | The 2-step verification password of the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_passport_authorization_form_available_elements.html).
   """
 
-  defstruct "@type": "getPassportAuthorizationFormAvailableElements", "@extra": nil, autorization_form_id: nil, password: nil
+  defstruct "@type": "getPassportAuthorizationFormAvailableElements", "@extra": nil, authorization_form_id: nil, password: nil
 end
 defmodule ToggleSupergroupSignMessages do
   @moduledoc  """
-  Toggles whether sender signature is added to sent messages in a channel; requires can_change_info administrator right.
+  Toggles whether sender signature is added to sent messages in a channel; requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4555,7 +6862,7 @@ defmodule ToggleSupergroupJoinToSendMessages do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | supergroup_id | int53 | Identifier of the supergroup. |
+  | supergroup_id | int53 | Identifier of the supergroup that isn't a broadcast group. |
   | join_to_send_messages | bool | New value of join_to_send_messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_join_to_send_messages.html).
@@ -4565,7 +6872,7 @@ defmodule ToggleSupergroupJoinToSendMessages do
 end
 defmodule ToggleGroupCallEnabledStartNotification do
   @moduledoc  """
-  Toggles whether the current user will receive a notification when the group call will start; scheduled group calls only.
+  Toggles whether the current user will receive a notification when the group call starts; scheduled group calls only.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4577,6 +6884,22 @@ defmodule ToggleGroupCallEnabledStartNotification do
   """
 
   defstruct "@type": "toggleGroupCallEnabledStartNotification", "@extra": nil, group_call_id: nil, enabled_start_notification: nil
+end
+defmodule SetForumTopicNotificationSettings do
+  @moduledoc  """
+  Changes the notification settings of a forum topic.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+  | notification_settings | chatNotificationSettings | New notification settings for the forum topic. If the topic is muted for more than 366 days, it is considered to be muted forever. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_forum_topic_notification_settings.html).
+  """
+
+  defstruct "@type": "setForumTopicNotificationSettings", "@extra": nil, chat_id: nil, message_thread_id: nil, notification_settings: nil
 end
 defmodule ToggleDownloadIsPaused do
   @moduledoc  """
@@ -4592,6 +6915,47 @@ defmodule ToggleDownloadIsPaused do
   """
 
   defstruct "@type": "toggleDownloadIsPaused", "@extra": nil, file_id: nil, is_paused: nil
+end
+defmodule GetUserChatBoosts do
+  @moduledoc  """
+  Returns the list of boosts applied to a chat by a given user; requires administrator rights in the chat; for bots only.
+  Returns object_ptr<FoundChatBoosts>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | user_id | int53 | Identifier of the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_user_chat_boosts.html).
+  """
+
+  defstruct "@type": "getUserChatBoosts", "@extra": nil, chat_id: nil, user_id: nil
+end
+defmodule GetAvailableChatBoostSlots do
+  @moduledoc  """
+  Returns the list of available chat boost slots for the current user.
+  Returns object_ptr<ChatBoostSlots>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_available_chat_boost_slots.html).
+  """
+
+  defstruct "@type": "getAvailableChatBoostSlots", "@extra": nil
+end
+defmodule SetChatActiveStoriesList do
+  @moduledoc  """
+  Changes story list in which stories from the chat are shown.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat that posted stories. |
+  | story_list | StoryList | New list for active stories posted by the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_active_stories_list.html).
+  """
+
+  defstruct "@type": "setChatActiveStoriesList", "@extra": nil, chat_id: nil, story_list: nil
 end
 defmodule CreateChatInviteLink do
   @moduledoc  """
@@ -4656,7 +7020,7 @@ defmodule GetMessageLinkInfo do
 end
 defmodule DeleteChatReplyMarkup do
   @moduledoc  """
-  Deletes the default reply markup from a chat. Must be called after a one-time keyboard or a ForceReply reply markup has been used. UpdateChatReplyMarkup will be sent if the reply markup is changed.
+  Deletes the default reply markup from a chat. Must be called after a one-time keyboard or a replyMarkupForceReply reply markup has been used. An updateChatReplyMarkup update will be sent if the reply markup is changed.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4668,6 +7032,21 @@ defmodule DeleteChatReplyMarkup do
   """
 
   defstruct "@type": "deleteChatReplyMarkup", "@extra": nil, chat_id: nil, message_id: nil
+end
+defmodule ReorderSupergroupActiveUsernames do
+  @moduledoc  """
+  Changes order of active usernames of a supergroup or channel, requires owner privileges in the supergroup or channel.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup or channel. |
+  | usernames | string | The new order of active usernames. All currently active usernames must be specified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_supergroup_active_usernames.html).
+  """
+
+  defstruct "@type": "reorderSupergroupActiveUsernames", "@extra": nil, supergroup_id: nil, usernames: nil
 end
 defmodule ReportSupergroupSpam do
   @moduledoc  """
@@ -4695,9 +7074,47 @@ defmodule Close do
 
   defstruct "@type": "close", "@extra": nil
 end
+defmodule SearchStringsByPrefix do
+  @moduledoc  """
+  Searches specified query by word prefixes in the provided strings. Returns 0-based positions of strings that matched. Can be called synchronously.
+  Returns object_ptr<FoundPositions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | strings | string | The strings to search in for the query. |
+  | query | string | Query to search for. |
+  | limit | int32 | The maximum number of objects to return. |
+  | return_none_for_empty_query | bool | Pass true to receive no results for an empty query. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_strings_by_prefix.html).
+  """
+
+  defstruct "@type": "searchStringsByPrefix", "@extra": nil, strings: nil, query: nil, limit: nil, return_none_for_empty_query: nil
+end
+defmodule EditBusinessMessageLiveLocation do
+  @moduledoc  """
+  Edits the content of a live location in a message sent on behalf of a business account; for bots only.
+  Returns object_ptr<BusinessMessage>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | business_connection_id | string | Unique identifier of business connection on behalf of which the message was sent. |
+  | chat_id | int53 | The chat the message belongs to. |
+  | message_id | int53 | Identifier of the message. |
+  | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
+  | location | location | New location content of the message; pass null to stop sharing the live location. |
+  | live_period | int32 | New time relative to the message send date, for which the location can be updated, in seconds. If 0x7FFFFFFF specified, then the location can be updated forever. Otherwise, must not exceed the current live_period by more than a day, and the live location expiration date must remain in the next 90 days. Pass 0 to keep the current live_period. |
+  | heading | int32 | The new direction in which the location moves, in degrees; 1-360. Pass 0 if unknown. |
+  | proximity_alert_radius | int32 | The new maximum distance for proximity alerts, in meters (0-100000). Pass 0 if the notification is disabled. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_business_message_live_location.html).
+  """
+
+  defstruct "@type": "editBusinessMessageLiveLocation", "@extra": nil, business_connection_id: nil, chat_id: nil, message_id: nil, reply_markup: nil, location: nil, live_period: nil, heading: nil, proximity_alert_radius: nil
+end
 defmodule GetAttachedStickerSets do
   @moduledoc  """
-  Returns a list of sticker sets attached to a file. Currently, only photos and videos can have attached sticker sets.
+  Returns a list of sticker sets attached to a file, including regular, mask, and emoji sticker sets. Currently, only animations, photos, and videos can have attached sticker sets.
   Returns object_ptr<StickerSets>.
 
   | Name | Type | Description |
@@ -4770,6 +7187,17 @@ defmodule GetChatPinnedMessage do
 
   defstruct "@type": "getChatPinnedMessage", "@extra": nil, chat_id: nil
 end
+defmodule GetArchiveChatListSettings do
+  @moduledoc  """
+  Returns settings for automatic moving of chats to and from the Archive chat lists.
+  Returns object_ptr<ArchiveChatListSettings>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_archive_chat_list_settings.html).
+  """
+
+  defstruct "@type": "getArchiveChatListSettings", "@extra": nil
+end
 defmodule TestCallEmpty do
   @moduledoc  """
   Does nothing; for testing only. This is an offline method. Can be called before authorization.
@@ -4781,19 +7209,36 @@ defmodule TestCallEmpty do
 
   defstruct "@type": "testCallEmpty", "@extra": nil
 end
-defmodule CancelUploadFile do
+defmodule GetBusinessFeatures do
   @moduledoc  """
-  Stops the uploading of a file. Supported only for files uploaded by using uploadFile. For other files the behavior is undefined.
-  Returns object_ptr<Ok>.
+  Returns information about features, available to Business users.
+  Returns object_ptr<BusinessFeatures>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | file_id | int32 | Identifier of the file to stop uploading. |
+  | source | BusinessFeature | Source of the request; pass null if the method is called from settings or some non-standard source. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1cancel_upload_file.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_business_features.html).
   """
 
-  defstruct "@type": "cancelUploadFile", "@extra": nil, file_id: nil
+  defstruct "@type": "getBusinessFeatures", "@extra": nil, source: nil
+end
+defmodule EditChatFolderInviteLink do
+  @moduledoc  """
+  Edits an invite link for a chat folder.
+  Returns object_ptr<ChatFolderInviteLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | invite_link | string | Invite link to be edited. |
+  | name | string | New name of the link; 0-32 characters. |
+  | chat_ids | int53 | New identifiers of chats to be accessible by the invite link. Use <a class="el" href="classtd_1_1td__api_1_1get_chats_for_chat_folder_invite_link.html">getChatsForChatFolderInviteLink</a> to get suitable chats. Basic groups will be automatically converted to supergroups before link editing. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "editChatFolderInviteLink", "@extra": nil, chat_folder_id: nil, invite_link: nil, name: nil, chat_ids: nil
 end
 defmodule SetAlarm do
   @moduledoc  """
@@ -4831,13 +7276,29 @@ defmodule SendPassportAuthorizationForm do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | autorization_form_id | int32 | Authorization form identifier. |
+  | authorization_form_id | int32 | Authorization form identifier. |
   | types | PassportElementType | Types of Telegram Passport elements chosen by user to complete the authorization form. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_passport_authorization_form.html).
   """
 
-  defstruct "@type": "sendPassportAuthorizationForm", "@extra": nil, autorization_form_id: nil, types: nil
+  defstruct "@type": "sendPassportAuthorizationForm", "@extra": nil, authorization_form_id: nil, types: nil
+end
+defmodule ToggleForumTopicIsClosed do
+  @moduledoc  """
+  Toggles whether a topic is closed in a forum supergroup chat; requires can_manage_topics right in the supergroup unless the user is creator of the topic.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+  | is_closed | bool | Pass true to close the topic; pass false to reopen it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_forum_topic_is_closed.html).
+  """
+
+  defstruct "@type": "toggleForumTopicIsClosed", "@extra": nil, chat_id: nil, message_thread_id: nil, is_closed: nil
 end
 defmodule GetAutoDownloadSettingsPresets do
   @moduledoc  """
@@ -4849,6 +7310,39 @@ defmodule GetAutoDownloadSettingsPresets do
   """
 
   defstruct "@type": "getAutoDownloadSettingsPresets", "@extra": nil
+end
+defmodule SetChatAccentColor do
+  @moduledoc  """
+  Changes accent color and background custom emoji of a channel chat. Requires can_change_info administrator right.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | accent_color_id | int32 | Identifier of the accent color to use. The chat must have at least accentColor.min_channel_chat_boost_level boost level to pass the corresponding color. |
+  | background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the reply header and link preview background; 0 if none. Use chatBoostLevelFeatures.can_set_background_custom_emoji to check whether a custom emoji can be set. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_accent_color.html).
+  """
+
+  defstruct "@type": "setChatAccentColor", "@extra": nil, chat_id: nil, accent_color_id: nil, background_custom_emoji_id: nil
+end
+defmodule SearchPublicStoriesByVenue do
+  @moduledoc  """
+  Searches for public stories from the given venue. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit.
+  Returns object_ptr<FoundStories>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | venue_provider | string | Provider of the venue. |
+  | venue_id | string | Identifier of the venue in the provider database. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of stories to be returned; up to 100. For optimal performance, the number of returned stories is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_public_stories_by_venue.html).
+  """
+
+  defstruct "@type": "searchPublicStoriesByVenue", "@extra": nil, venue_provider: nil, venue_id: nil, offset: nil, limit: nil
 end
 defmodule SetBotUpdatesStatus do
   @moduledoc  """
@@ -4895,7 +7389,7 @@ defmodule GetPremiumLimit do
 end
 defmodule PinChatMessage do
   @moduledoc  """
-  Pins a message in a chat; requires can_pin_messages rights or can_edit_messages rights in the channel.
+  Pins a message in a chat; requires can_pin_messages member right if the chat is a basic group or supergroup, or can_edit_messages administrator right if the chat is a channel.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -4923,20 +7417,6 @@ defmodule TestCallVectorIntObject do
   """
 
   defstruct "@type": "testCallVectorIntObject", "@extra": nil, x: nil
-end
-defmodule RemoveBackground do
-  @moduledoc  """
-  Removes background from the list of installed backgrounds.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | background_id | int64 | The background identifier. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_background.html).
-  """
-
-  defstruct "@type": "removeBackground", "@extra": nil, background_id: nil
 end
 defmodule ToggleGroupCallIsMyVideoPaused do
   @moduledoc  """
@@ -4984,14 +7464,17 @@ defmodule AnswerPreCheckoutQuery do
 end
 defmodule ResendAuthenticationCode do
   @moduledoc  """
-  Re-sends an authentication code to the user. Works only when the current authorization state is authorizationStateWaitCode, the next_code_type of the result is not null and the server-specified timeout has passed.
+  Resends an authentication code to the user. Works only when the current authorization state is authorizationStateWaitCode, the next_code_type of the result is not null and the server-specified timeout has passed, or when the current authorization state is authorizationStateWaitEmailCode.
   Returns object_ptr<Ok>.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reason | ResendCodeReason | Reason of code resending; pass null if unknown. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_authentication_code.html).
   """
 
-  defstruct "@type": "resendAuthenticationCode", "@extra": nil
+  defstruct "@type": "resendAuthenticationCode", "@extra": nil, reason: nil
 end
 defmodule GetCallbackQueryMessage do
   @moduledoc  """
@@ -5011,7 +7494,7 @@ defmodule GetCallbackQueryMessage do
 end
 defmodule GetContacts do
   @moduledoc  """
-  Returns all user contacts.
+  Returns all contacts of the user.
   Returns object_ptr<Users>.
 
 
@@ -5019,6 +7502,21 @@ defmodule GetContacts do
   """
 
   defstruct "@type": "getContacts", "@extra": nil
+end
+defmodule SetMessageSenderBlockList do
+  @moduledoc  """
+  Changes the block list of a message sender. Currently, only users and supergroup chats can be blocked.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_id | MessageSender | Identifier of a message sender to block/unblock. |
+  | block_list | BlockList | New block list for the message sender; pass null to unblock the message sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_message_sender_block_list.html).
+  """
+
+  defstruct "@type": "setMessageSenderBlockList", "@extra": nil, sender_id: nil, block_list: nil
 end
 defmodule SetInactiveSessionTtl do
   @moduledoc  """
@@ -5049,44 +7547,74 @@ defmodule GetChatInviteLink do
 
   defstruct "@type": "getChatInviteLink", "@extra": nil, chat_id: nil, invite_link: nil
 end
-defmodule CheckAuthenticationPassword do
+defmodule ReportMessageReactions do
   @moduledoc  """
-  Checks the authentication password for correctness. Works only when the current authorization state is authorizationStateWaitPassword.
+  Reports reactions set on a message to the Telegram moderators. Reactions on a message can be reported only if message.can_report_reactions.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | The password to check. |
+  | chat_id | int53 | Chat identifier. |
+  | message_id | int53 | Message identifier. |
+  | sender_id | MessageSender | Identifier of the sender, which added the reaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_message_reactions.html).
+  """
+
+  defstruct "@type": "reportMessageReactions", "@extra": nil, chat_id: nil, message_id: nil, sender_id: nil
+end
+defmodule CanPurchaseFromStore do
+  @moduledoc  """
+  Checks whether an in-store purchase is possible. Must be called before any in-store purchase.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | purpose | StorePaymentPurpose | Transaction purpose. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_purchase_from_store.html).
+  """
+
+  defstruct "@type": "canPurchaseFromStore", "@extra": nil, purpose: nil
+end
+defmodule CheckAuthenticationPassword do
+  @moduledoc  """
+  Checks the 2-step verification password for correctness. Works only when the current authorization state is authorizationStateWaitPassword.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | password | string | The 2-step verification password to check. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_authentication_password.html).
   """
 
   defstruct "@type": "checkAuthenticationPassword", "@extra": nil, password: nil
 end
-defmodule GetBackgrounds do
+defmodule GetDefaultMessageAutoDeleteTime do
   @moduledoc  """
-  Returns backgrounds installed by the user.
-  Returns object_ptr<Backgrounds>.
+  Returns default message auto-delete time setting for new chats.
+  Returns object_ptr<MessageAutoDeleteTime>.
 
-  | Name | Type | Description |
-  |------|------| ------------|
-  | for_dark_theme | bool | Pass true to order returned backgrounds for a dark theme. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_backgrounds.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_message_auto_delete_time.html).
   """
 
-  defstruct "@type": "getBackgrounds", "@extra": nil, for_dark_theme: nil
+  defstruct "@type": "getDefaultMessageAutoDeleteTime", "@extra": nil
 end
 defmodule GetPremiumStickers do
   @moduledoc  """
-  Returns examples of premium stickers for demonstration purposes.
+  Returns premium stickers from regular sticker sets.
   Returns object_ptr<Stickers>.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | limit | int32 | The maximum number of stickers to be returned; 0-100. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_premium_stickers.html).
   """
 
-  defstruct "@type": "getPremiumStickers", "@extra": nil
+  defstruct "@type": "getPremiumStickers", "@extra": nil, limit: nil
 end
 defmodule ToggleAllDownloadsArePaused do
   @moduledoc  """
@@ -5102,6 +7630,21 @@ defmodule ToggleAllDownloadsArePaused do
 
   defstruct "@type": "toggleAllDownloadsArePaused", "@extra": nil, are_paused: nil
 end
+defmodule SearchRecentlyFoundChats do
+  @moduledoc  """
+  Searches for the specified query in the title and username of up to 50 recently found chats; this is an offline request.
+  Returns object_ptr<Chats>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | query | string | Query to search for. |
+  | limit | int32 | The maximum number of chats to be returned. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_recently_found_chats.html).
+  """
+
+  defstruct "@type": "searchRecentlyFoundChats", "@extra": nil, query: nil, limit: nil
+end
 defmodule GetChatScheduledMessages do
   @moduledoc  """
   Returns all scheduled messages in a chat. The messages are returned in a reverse chronological order (i.e., in order of decreasing message_id).
@@ -5115,6 +7658,20 @@ defmodule GetChatScheduledMessages do
   """
 
   defstruct "@type": "getChatScheduledMessages", "@extra": nil, chat_id: nil
+end
+defmodule SetBusinessConnectedBot do
+  @moduledoc  """
+  Adds or changes business bot that is connected to the current user account.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot | businessConnectedBot | Connection settings for the bot. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_connected_bot.html).
+  """
+
+  defstruct "@type": "setBusinessConnectedBot", "@extra": nil, bot: nil
 end
 defmodule GetMessages do
   @moduledoc  """
@@ -5141,16 +7698,41 @@ defmodule GetSupergroupMembers do
   | supergroup_id | int53 | Identifier of the supergroup or channel. |
   | filter | SupergroupMembersFilter | The type of users to return; pass null to use <a class="el" href="classtd_1_1td__api_1_1supergroup_members_filter_recent.html">supergroupMembersFilterRecent</a>. |
   | offset | int32 | Number of users to skip. |
-  | limit | int32 | The maximum number of users be returned; up to 200. |
+  | limit | int32 | The maximum number of users to be returned; up to 200. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_supergroup_members.html).
   """
 
   defstruct "@type": "getSupergroupMembers", "@extra": nil, supergroup_id: nil, filter: nil, offset: nil, limit: nil
 end
+defmodule GetCustomEmojiReactionAnimations do
+  @moduledoc  """
+  Returns TGS stickers with generic animations for custom emoji reactions.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_custom_emoji_reaction_animations.html).
+  """
+
+  defstruct "@type": "getCustomEmojiReactionAnimations", "@extra": nil
+end
+defmodule DeleteQuickReplyShortcut do
+  @moduledoc  """
+  Deletes a quick reply shortcut.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_quick_reply_shortcut.html).
+  """
+
+  defstruct "@type": "deleteQuickReplyShortcut", "@extra": nil, shortcut_id: nil
+end
 defmodule GetInternalLinkType do
   @moduledoc  """
-  Returns information about the type of an internal link. Returns a 404 error if the link is not internal. Can be called before authorization.
+  Returns information about the type of internal link. Returns a 404 error if the link is not internal. Can be called before authorization.
   Returns object_ptr<InternalLinkType>.
 
   | Name | Type | Description |
@@ -5190,6 +7772,64 @@ defmodule GetFileExtension do
 
   defstruct "@type": "getFileExtension", "@extra": nil, mime_type: nil
 end
+defmodule GetReadDatePrivacySettings do
+  @moduledoc  """
+  Returns privacy settings for message read date.
+  Returns object_ptr<ReadDatePrivacySettings>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_read_date_privacy_settings.html).
+  """
+
+  defstruct "@type": "getReadDatePrivacySettings", "@extra": nil
+end
+defmodule GetChatRevenueWithdrawalUrl do
+  @moduledoc  """
+  Returns URL for chat revenue withdrawal; requires owner privileges in the chat. Currently, this method can be used only for channels if supergroupFullInfo.can_get_revenue_statistics == true and getOption("can_withdraw_chat_revenue").
+  Returns object_ptr<HttpUrl>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | password | string | The 2-step verification password of the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_revenue_withdrawal_url.html).
+  """
+
+  defstruct "@type": "getChatRevenueWithdrawalUrl", "@extra": nil, chat_id: nil, password: nil
+end
+defmodule GetStarWithdrawalUrl do
+  @moduledoc  """
+  Returns URL for Telegram star withdrawal.
+  Returns object_ptr<HttpUrl>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | owner_id | MessageSender | Identifier of the owner of the Telegram stars; can be identifier of an owned bot, or identifier of a channel chat with supergroupFullInfo.can_get_revenue_statistics == true. |
+  | star_count | int53 | The number of Telegram stars to withdraw. Must be at least <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("star_withdrawal_count_min"). |
+  | password | string | The 2-step verification password of the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_star_withdrawal_url.html).
+  """
+
+  defstruct "@type": "getStarWithdrawalUrl", "@extra": nil, owner_id: nil, star_count: nil, password: nil
+end
+defmodule ReportChatSponsoredMessage do
+  @moduledoc  """
+  Reports a sponsored message to Telegram moderators.
+  Returns object_ptr<ReportChatSponsoredMessageResult>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier of the sponsored message. |
+  | message_id | int53 | Identifier of the sponsored message. |
+  | option_id | bytes | Option identifier chosen by the user; leave empty for the initial request. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessage", "@extra": nil, chat_id: nil, message_id: nil, option_id: nil
+end
 defmodule SetNetworkType do
   @moduledoc  """
   Sets the current network type. Can be called before authorization. Calling this method forces all network connections to reopen, mitigating the delay in switching between different networks, so it must be called whenever the network is changed, even if the network type remains the same. Network type is used to check whether the library can use the network at all and also for collecting detailed network data usage statistics.
@@ -5204,16 +7844,19 @@ defmodule SetNetworkType do
 
   defstruct "@type": "setNetworkType", "@extra": nil, type: nil
 end
-defmodule GetAllAnimatedEmojis do
+defmodule ToggleChatFolderTags do
   @moduledoc  """
-  Returns all emojis, which has a corresponding animated emoji.
-  Returns object_ptr<Emojis>.
+  Toggles whether chat folder tags are enabled.
+  Returns object_ptr<Ok>.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | are_tags_enabled | bool | Pass true to enable folder tags; pass false to disable them. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_all_animated_emojis.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_chat_folder_tags.html).
   """
 
-  defstruct "@type": "getAllAnimatedEmojis", "@extra": nil
+  defstruct "@type": "toggleChatFolderTags", "@extra": nil, are_tags_enabled: nil
 end
 defmodule GetChatInviteLinks do
   @moduledoc  """
@@ -5248,6 +7891,20 @@ defmodule GetMenuButton do
 
   defstruct "@type": "getMenuButton", "@extra": nil, user_id: nil
 end
+defmodule SetBusinessGreetingMessageSettings do
+  @moduledoc  """
+  Changes the business greeting message settings of the current user. Requires Telegram Business subscription.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | greeting_message_settings | businessGreetingMessageSettings | The new settings for the greeting message of the business; pass null to disable the greeting message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_greeting_message_settings.html).
+  """
+
+  defstruct "@type": "setBusinessGreetingMessageSettings", "@extra": nil, greeting_message_settings: nil
+end
 defmodule GetPushReceiverId do
   @moduledoc  """
   Returns a globally unique push notification subscription identifier for identification of an account, which has received a push notification. Can be called synchronously.
@@ -5270,12 +7927,13 @@ defmodule UploadStickerFile do
   | Name | Type | Description |
   |------|------| ------------|
   | user_id | int53 | Sticker file owner; ignored for regular users. |
-  | sticker | inputSticker | Sticker file to upload. |
+  | sticker_format | StickerFormat | Sticker format. |
+  | sticker | InputFile | File file to upload; must fit in a 512x512 square. For WEBP stickers the file must be in WEBP or PNG format, which will be converted to WEBP server-side. See <a href="https://core.telegram.org/animated_stickers">https://core.telegram.org/animated_stickers</a>#technical-requirements for technical requirements. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1upload_sticker_file.html).
   """
 
-  defstruct "@type": "uploadStickerFile", "@extra": nil, user_id: nil, sticker: nil
+  defstruct "@type": "uploadStickerFile", "@extra": nil, user_id: nil, sticker_format: nil, sticker: nil
 end
 defmodule ReorderInstalledStickerSets do
   @moduledoc  """
@@ -5284,13 +7942,13 @@ defmodule ReorderInstalledStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_masks | bool | Pass true to change the order of mask sticker sets; pass false to change the order of ordinary sticker sets. |
+  | sticker_type | StickerType | Type of the sticker sets to reorder. |
   | sticker_set_ids | int64 | Identifiers of installed sticker sets in the new correct order. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_installed_sticker_sets.html).
   """
 
-  defstruct "@type": "reorderInstalledStickerSets", "@extra": nil, is_masks: nil, sticker_set_ids: nil
+  defstruct "@type": "reorderInstalledStickerSets", "@extra": nil, sticker_type: nil, sticker_set_ids: nil
 end
 defmodule RemoveFavoriteSticker do
   @moduledoc  """
@@ -5305,6 +7963,21 @@ defmodule RemoveFavoriteSticker do
   """
 
   defstruct "@type": "removeFavoriteSticker", "@extra": nil, sticker: nil
+end
+defmodule ReadAllMessageThreadReactions do
+  @moduledoc  """
+  Marks all reactions in a forum topic as read.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_thread_id | int53 | Message thread identifier in which reactions are marked as read. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1read_all_message_thread_reactions.html).
+  """
+
+  defstruct "@type": "readAllMessageThreadReactions", "@extra": nil, chat_id: nil, message_thread_id: nil
 end
 defmodule SetPollAnswer do
   @moduledoc  """
@@ -5331,16 +8004,15 @@ defmodule AnswerInlineQuery do
   |------|------| ------------|
   | inline_query_id | int64 | Identifier of the inline query. |
   | is_personal | bool | Pass true if results may be cached and returned only for the user that sent the query. By default, results may be returned to any user who sends the same query. |
+  | button | inlineQueryResultsButton | Button to be shown above inline query results; pass null if none. |
   | results | InputInlineQueryResult | The results of the query. |
   | cache_time | int32 | Allowed time to cache the results of the query, in seconds. |
   | next_offset | string | Offset for the next inline query; pass an empty string if there are no more results. |
-  | switch_pm_text | string | If non-empty, this text must be shown on the button that opens a private chat with the bot and sends a start message to the bot with the parameter switch_pm_parameter. |
-  | switch_pm_parameter | string | The parameter for the bot start message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1answer_inline_query.html).
   """
 
-  defstruct "@type": "answerInlineQuery", "@extra": nil, inline_query_id: nil, is_personal: nil, results: nil, cache_time: nil, next_offset: nil, switch_pm_text: nil, switch_pm_parameter: nil
+  defstruct "@type": "answerInlineQuery", "@extra": nil, inline_query_id: nil, is_personal: nil, button: nil, results: nil, cache_time: nil, next_offset: nil
 end
 defmodule DeleteAllCallMessages do
   @moduledoc  """
@@ -5375,18 +8047,20 @@ defmodule GetLanguagePackString do
 end
 defmodule GetStickers do
   @moduledoc  """
-  Returns stickers from the installed sticker sets that correspond to a given emoji. If the emoji is non-empty, favorite and recently used stickers may also be returned.
+  Returns stickers from the installed sticker sets that correspond to any of the given emoji or can be found by sticker-specific keywords. If the query is non-empty, then favorite, recently used or trending stickers may also be returned.
   Returns object_ptr<Stickers>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | emoji | string | String representation of emoji. If empty, returns all known installed stickers. |
+  | sticker_type | StickerType | Type of the stickers to return. |
+  | query | string | Search query; a space-separated list of emojis or a keyword prefix. If empty, returns all known installed stickers. |
   | limit | int32 | The maximum number of stickers to be returned. |
+  | chat_id | int53 | Chat identifier for which to return stickers. Available custom emoji stickers may be different for different chats. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_stickers.html).
   """
 
-  defstruct "@type": "getStickers", "@extra": nil, emoji: nil, limit: nil
+  defstruct "@type": "getStickers", "@extra": nil, sticker_type: nil, query: nil, limit: nil, chat_id: nil
 end
 defmodule CheckChatUsername do
   @moduledoc  """
@@ -5395,7 +8069,7 @@ defmodule CheckChatUsername do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Chat identifier; must be identifier of a supergroup chat, or a channel chat, or a private chat with self, or zero if the chat is being created. |
+  | chat_id | int53 | Chat identifier; must be identifier of a supergroup chat, or a channel chat, or a private chat with self, or 0 if the chat is being created. |
   | username | string | Username to be checked. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_chat_username.html).
@@ -5417,6 +8091,33 @@ defmodule SearchPublicChats do
 
   defstruct "@type": "searchPublicChats", "@extra": nil, query: nil
 end
+defmodule GetDisallowedChatEmojiStatuses do
+  @moduledoc  """
+  Returns the list of emoji statuses, which can't be used as chat emoji status, even they are from a sticker set with is_allowed_as_chat_emoji_status == true.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_disallowed_chat_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getDisallowedChatEmojiStatuses", "@extra": nil
+end
+defmodule SearchPublicMessagesByTag do
+  @moduledoc  """
+  Searches for public channel posts containing the given hashtag or cashtag. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit.
+  Returns object_ptr<FoundMessages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tag | string | Hashtag or cashtag to search for. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of messages to be returned; up to 100. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_public_messages_by_tag.html).
+  """
+
+  defstruct "@type": "searchPublicMessagesByTag", "@extra": nil, tag: nil, offset: nil, limit: nil
+end
 defmodule SetName do
   @moduledoc  """
   Changes the first and last name of the current user.
@@ -5431,6 +8132,17 @@ defmodule SetName do
   """
 
   defstruct "@type": "setName", "@extra": nil, first_name: nil, last_name: nil
+end
+defmodule GetRecommendedChats do
+  @moduledoc  """
+  Returns a list of channel chats recommended to the current user.
+  Returns object_ptr<Chats>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_recommended_chats.html).
+  """
+
+  defstruct "@type": "getRecommendedChats", "@extra": nil
 end
 defmodule LeaveChat do
   @moduledoc  """
@@ -5462,6 +8174,20 @@ defmodule GetGroupsInCommon do
 
   defstruct "@type": "getGroupsInCommon", "@extra": nil, user_id: nil, offset_chat_id: nil, limit: nil
 end
+defmodule SendPhoneNumberFirebaseSms do
+  @moduledoc  """
+  Sends Firebase Authentication SMS to the specified phone number. Works only when received a code of the type authenticationCodeTypeFirebaseAndroid or authenticationCodeTypeFirebaseIos.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | Play Integrity API or SafetyNet Attestation API token for the Android application, or secret from push notification for the iOS application. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_phone_number_firebase_sms.html).
+  """
+
+  defstruct "@type": "sendPhoneNumberFirebaseSms", "@extra": nil, token: nil
+end
 defmodule ImportContacts do
   @moduledoc  """
   Adds new contacts or edits existing contacts by their phone numbers; contacts' user identifiers are ignored.
@@ -5486,7 +8212,7 @@ defmodule GetMessageThreadHistory do
   | chat_id | int53 | Chat identifier. |
   | message_id | int53 | Message identifier, which thread history needs to be returned. |
   | from_message_id | int53 | Identifier of the message starting from which history must be fetched; use 0 to get results from the last message. |
-  | offset | int32 | Specify 0 to get results from exactly the from_message_id or a negative offset up to 99 to get additionally some newer messages. |
+  | offset | int32 | Specify 0 to get results from exactly the message from_message_id or a negative offset up to 99 to get additionally some newer messages. |
   | limit | int32 | The maximum number of messages to be returned; must be positive and can't be greater than 100. If the offset is negative, the limit must be greater than or equal to -offset. For optimal performance, the number of returned messages is chosen by TDLib and can be smaller than the specified limit. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_thread_history.html).
@@ -5530,11 +8256,23 @@ defmodule DeleteAccount do
   | Name | Type | Description |
   |------|------| ------------|
   | reason | string | The reason why the account was deleted; optional. |
+  | password | string | The 2-step verification password of the current user. If the current user isn't authorized, then an empty string can be passed and account deletion can be canceled within one week. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_account.html).
   """
 
-  defstruct "@type": "deleteAccount", "@extra": nil, reason: nil
+  defstruct "@type": "deleteAccount", "@extra": nil, reason: nil, password: nil
+end
+defmodule LoadQuickReplyShortcuts do
+  @moduledoc  """
+  Loads quick reply shortcuts created by the current user. The loaded topics will be sent through updateQuickReplyShortcuts.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1load_quick_reply_shortcuts.html).
+  """
+
+  defstruct "@type": "loadQuickReplyShortcuts", "@extra": nil
 end
 defmodule DiscardCall do
   @moduledoc  """
@@ -5553,6 +8291,21 @@ defmodule DiscardCall do
   """
 
   defstruct "@type": "discardCall", "@extra": nil, call_id: nil, is_disconnected: nil, duration: nil, is_video: nil, connection_id: nil
+end
+defmodule RefundStarPayment do
+  @moduledoc  """
+  Refunds a previously done payment in Telegram Stars.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of the user that did the payment. |
+  | telegram_payment_charge_id | string | Telegram payment identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1refund_star_payment.html).
+  """
+
+  defstruct "@type": "refundStarPayment", "@extra": nil, user_id: nil, telegram_payment_charge_id: nil
 end
 defmodule CheckChatInviteLink do
   @moduledoc  """
@@ -5597,9 +8350,23 @@ defmodule ProcessPushNotification do
 
   defstruct "@type": "processPushNotification", "@extra": nil, payload: nil
 end
+defmodule SetBusinessOpeningHours do
+  @moduledoc  """
+  Changes the business opening hours of the current user. Requires Telegram Business subscription.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | opening_hours | businessOpeningHours | The new opening hours of the business; pass null to remove the opening hours; up to 28 time intervals can be specified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_business_opening_hours.html).
+  """
+
+  defstruct "@type": "setBusinessOpeningHours", "@extra": nil, opening_hours: nil
+end
 defmodule BanChatMember do
   @moduledoc  """
-  Bans a member in a chat. Members can't be banned in private or secret chats. In supergroups and channels, the user will not be able to return to the group on their own using invite links, etc., unless unbanned first.
+  Bans a member in a chat; requires can_restrict_members administrator right. Members can't be banned in private or secret chats. In supergroups and channels, the user will not be able to return to the group on their own using invite links, etc., unless unbanned first.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -5623,7 +8390,7 @@ defmodule ReportChat do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | message_ids | int53 | Identifiers of reported messages; may be empty to report the whole chat. |
-  | reason | ChatReportReason | The reason for reporting the chat. |
+  | reason | ReportReason | The reason for reporting the chat. |
   | text | string | Additional report details; 0-1024 characters. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat.html).
@@ -5644,7 +8411,7 @@ defmodule GetActiveLiveLocationMessages do
 end
 defmodule ParseTextEntities do
   @moduledoc  """
-  Parses Bold, Italic, Underline, Strikethrough, Spoiler, Code, Pre, PreCode, TextUrl and MentionName entities contained in the text. Can be called synchronously.
+  Parses Bold, Italic, Underline, Strikethrough, Spoiler, CustomEmoji, BlockQuote, ExpandableBlockQuote, Code, Pre, PreCode, TextUrl and MentionName entities from a marked-up text. Can be called synchronously.
   Returns object_ptr<FormattedText>.
 
   | Name | Type | Description |
@@ -5656,6 +8423,39 @@ defmodule ParseTextEntities do
   """
 
   defstruct "@type": "parseTextEntities", "@extra": nil, text: nil, parse_mode: nil
+end
+defmodule GetChatBoosts do
+  @moduledoc  """
+  Returns the list of boosts applied to a chat; requires administrator rights in the chat.
+  Returns object_ptr<FoundChatBoosts>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | only_gift_codes | bool | Pass true to receive only boosts received from gift codes and giveaways created by the chat. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of boosts to be returned; up to 100. For optimal performance, the number of returned boosts can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_boosts.html).
+  """
+
+  defstruct "@type": "getChatBoosts", "@extra": nil, chat_id: nil, only_gift_codes: nil, offset: nil, limit: nil
+end
+defmodule EditQuickReplyMessage do
+  @moduledoc  """
+  Asynchronously edits the text, media or caption of a quick reply message. Use quickReplyMessage.can_be_edited to check whether a message can be edited. Text message can be edited only to a text message. The type of message content in an album can't be changed with exception of replacing a photo with a video or vice versa.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut with the message. |
+  | message_id | int53 | Identifier of the message. |
+  | input_message_content | InputMessageContent | New content of the message. Must be one of the following types: <a class="el" href="classtd_1_1td__api_1_1input_message_text.html">inputMessageText</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_animation.html">inputMessageAnimation</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_audio.html">inputMessageAudio</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_document.html">inputMessageDocument</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_photo.html">inputMessagePhoto</a> or <a class="el" href="classtd_1_1td__api_1_1input_message_video.html">inputMessageVideo</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_quick_reply_message.html).
+  """
+
+  defstruct "@type": "editQuickReplyMessage", "@extra": nil, shortcut_id: nil, message_id: nil, input_message_content: nil
 end
 defmodule RemoveFileFromDownloads do
   @moduledoc  """
@@ -5674,19 +8474,32 @@ defmodule RemoveFileFromDownloads do
 end
 defmodule TranslateText do
   @moduledoc  """
-  Translates a text to the given language. Returns a 404 error if the translation can't be performed.
-  Returns object_ptr<Text>.
+  Translates a text to the given language. If the current user is a Telegram Premium user, then text formatting is preserved.
+  Returns object_ptr<FormattedText>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | text | string | Text to translate. |
-  | from_language_code | string | A two-letter ISO 639-1 language code of the language from which the message is translated. If empty, the language will be detected automatically. |
-  | to_language_code | string | A two-letter ISO 639-1 language code of the language to which the message is translated. |
+  | text | formattedText | Text to translate. |
+  | to_language_code | string | Language code of the language to which the message is translated. Must be one of "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg", "ca", "ceb", "zh-CN", "zh", "zh-Hans", "zh-TW", "zh-Hant", "co", "hr", "cs", "da", "nl", "en", "eo", "et", "fi", "fr", "fy", "gl", "ka", "de", "el", "gu", "ht", "ha", "haw", "he", "iw", "hi", "hmn", "hu", "is", "ig", "id", "in", "ga", "it", "ja", "jv", "kn", "kk", "km", "rw", "ko", "ku", "ky", "lo", "la", "lv", "lt", "lb", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mn", "my", "ne", "no", "ny", "or", "ps", "fa", "pl", "pt", "pa", "ro", "ru", "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so", "es", "su", "sw", "sv", "tl", "tg", "ta", "tt", "te", "th", "tr", "tk", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi", "ji", "yo", "zu". |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1translate_text.html).
   """
 
-  defstruct "@type": "translateText", "@extra": nil, text: nil, from_language_code: nil, to_language_code: nil
+  defstruct "@type": "translateText", "@extra": nil, text: nil, to_language_code: nil
+end
+defmodule CancelPreliminaryUploadFile do
+  @moduledoc  """
+  Stops the preliminary uploading of a file. Supported only for files uploaded by using preliminaryUploadFile. For other files the behavior is undefined.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | file_id | int32 | Identifier of the file to stop uploading. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1cancel_preliminary_upload_file.html).
+  """
+
+  defstruct "@type": "cancelPreliminaryUploadFile", "@extra": nil, file_id: nil
 end
 defmodule GetMessageLocally do
   @moduledoc  """
@@ -5705,7 +8518,7 @@ defmodule GetMessageLocally do
 end
 defmodule InviteGroupCallParticipants do
   @moduledoc  """
-  Invites users to an active group call. Sends a service message of type messageInviteToGroupCall for video chats.
+  Invites users to an active group call. Sends a service message of type messageInviteVideoChatParticipants for video chats.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -5717,6 +8530,17 @@ defmodule InviteGroupCallParticipants do
   """
 
   defstruct "@type": "inviteGroupCallParticipants", "@extra": nil, group_call_id: nil, user_ids: nil
+end
+defmodule ClearRecentEmojiStatuses do
+  @moduledoc  """
+  Clears the list of recently used emoji statuses for self status.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1clear_recent_emoji_statuses.html).
+  """
+
+  defstruct "@type": "clearRecentEmojiStatuses", "@extra": nil
 end
 defmodule GetSupergroup do
   @moduledoc  """
@@ -5754,11 +8578,12 @@ defmodule SearchUserByPhoneNumber do
   | Name | Type | Description |
   |------|------| ------------|
   | phone_number | string | Phone number to search for. |
+  | only_local | bool | Pass true to get only locally available information without sending network requests. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1search_user_by_phone_number.html).
   """
 
-  defstruct "@type": "searchUserByPhoneNumber", "@extra": nil, phone_number: nil
+  defstruct "@type": "searchUserByPhoneNumber", "@extra": nil, phone_number: nil, only_local: nil
 end
 defmodule CreateNewSecretChat do
   @moduledoc  """
@@ -5776,21 +8601,36 @@ defmodule CreateNewSecretChat do
 end
 defmodule GetWebPagePreview do
   @moduledoc  """
-  Returns a web page preview by the text of the message. Do not call this function too often. Returns a 404 error if the web page has no preview.
+  Returns a link preview by the text of a message. Do not call this function too often. Returns a 404 error if the text has no link preview.
   Returns object_ptr<WebPage>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | text | formattedText | Message text with formatting. |
+  | link_preview_options | linkPreviewOptions | Options to be used for generation of the link preview; pass null to use default link preview options. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_web_page_preview.html).
   """
 
-  defstruct "@type": "getWebPagePreview", "@extra": nil, text: nil
+  defstruct "@type": "getWebPagePreview", "@extra": nil, text: nil, link_preview_options: nil
+end
+defmodule DeleteStickerSet do
+  @moduledoc  """
+  Completely deletes a sticker set.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | Sticker set name. The sticker set must be owned by the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_sticker_set.html).
+  """
+
+  defstruct "@type": "deleteStickerSet", "@extra": nil, name: nil
 end
 defmodule GetChat do
   @moduledoc  """
-  Returns information about a chat by its identifier, this is an offline request if the current user is not a bot.
+  Returns information about a chat by its identifier; this is an offline request if the current user is not a bot.
   Returns object_ptr<Chat>.
 
   | Name | Type | Description |
@@ -5815,6 +8655,64 @@ defmodule GetGroupCall do
   """
 
   defstruct "@type": "getGroupCall", "@extra": nil, group_call_id: nil
+end
+defmodule DeleteStory do
+  @moduledoc  """
+  Deletes a previously sent story. Can be called only if story.can_be_deleted == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Identifier of the story to delete. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_story.html).
+  """
+
+  defstruct "@type": "deleteStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
+end
+defmodule RemoveInstalledBackground do
+  @moduledoc  """
+  Removes background from the list of installed backgrounds.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | background_id | int64 | The background identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_installed_background.html).
+  """
+
+  defstruct "@type": "removeInstalledBackground", "@extra": nil, background_id: nil
+end
+defmodule GetForumTopic do
+  @moduledoc  """
+  Returns information about a forum topic.
+  Returns object_ptr<ForumTopic>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_forum_topic.html).
+  """
+
+  defstruct "@type": "getForumTopic", "@extra": nil, chat_id: nil, message_thread_id: nil
+end
+defmodule SetPinnedSavedMessagesTopics do
+  @moduledoc  """
+  Changes the order of pinned Saved Messages topics.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_ids | int53 | Identifiers of the new pinned Saved Messages topics. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_pinned_saved_messages_topics.html).
+  """
+
+  defstruct "@type": "setPinnedSavedMessagesTopics", "@extra": nil, saved_messages_topic_ids: nil
 end
 defmodule GetMessageThread do
   @moduledoc  """
@@ -5845,21 +8743,65 @@ defmodule ChangeImportedContacts do
 
   defstruct "@type": "changeImportedContacts", "@extra": nil, contacts: nil
 end
-defmodule AddStickerToSet do
+defmodule SetAutosaveSettings do
   @moduledoc  """
-  Adds a new sticker to a set; for bots only. Returns the sticker set.
-  Returns object_ptr<StickerSet>.
+  Sets autosave settings for the given scope. The method is guaranteed to work only after at least one call to getAutosaveSettings.
+  Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | user_id | int53 | Sticker set owner. |
-  | name | string | Sticker set name. |
+  | scope | AutosaveSettingsScope | Autosave settings scope. |
+  | settings | scopeAutosaveSettings | New autosave settings for the scope; pass null to set autosave settings to default. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_autosave_settings.html).
+  """
+
+  defstruct "@type": "setAutosaveSettings", "@extra": nil, scope: nil, settings: nil
+end
+defmodule AddStickerToSet do
+  @moduledoc  """
+  Adds a new sticker to a set.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Sticker set owner; ignored for regular users. |
+  | name | string | Sticker set name. The sticker set must be owned by the current user, and contain less than 200 stickers for custom emoji sticker sets and less than 120 otherwise. |
   | sticker | inputSticker | Sticker to add to the set. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_sticker_to_set.html).
   """
 
   defstruct "@type": "addStickerToSet", "@extra": nil, user_id: nil, name: nil, sticker: nil
+end
+defmodule ReaddQuickReplyShortcutMessages do
+  @moduledoc  """
+  Readds quick reply messages which failed to add. Can be called only for messages for which messageSendingStateFailed.can_retry is true and after specified in messageSendingStateFailed.retry_after time passed. If a message is readded, the corresponding failed to send message is deleted. Returns the sent messages in the same order as the message identifiers passed in message_ids. If a message can't be readded, null will be returned instead of the message.
+  Returns object_ptr<QuickReplyMessages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_name | string | Name of the target shortcut. |
+  | message_ids | int53 | Identifiers of the quick reply messages to readd. Message identifiers must be in a strictly increasing order. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1readd_quick_reply_shortcut_messages.html).
+  """
+
+  defstruct "@type": "readdQuickReplyShortcutMessages", "@extra": nil, shortcut_name: nil, message_ids: nil
+end
+defmodule CreateBusinessChatLink do
+  @moduledoc  """
+  Creates a business chat link for the current account. Requires Telegram Business subscription. There can be up to getOption("business_chat_link_count_max") links created. Returns the created link.
+  Returns object_ptr<BusinessChatLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link_info | inputBusinessChatLink | Information about the link to create. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_business_chat_link.html).
+  """
+
+  defstruct "@type": "createBusinessChatLink", "@extra": nil, link_info: nil
 end
 defmodule AnswerShippingQuery do
   @moduledoc  """
@@ -5879,17 +8821,33 @@ defmodule AnswerShippingQuery do
 end
 defmodule SetUsername do
   @moduledoc  """
-  Changes the username of the current user.
+  Changes the editable username of the current user.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | username | string | The new value of the username. Use an empty string to remove the username. |
+  | username | string | The new value of the username. Use an empty string to remove the username. The username can't be completely removed if there is another active or disabled username. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_username.html).
   """
 
   defstruct "@type": "setUsername", "@extra": nil, username: nil
+end
+defmodule SetBotInfoDescription do
+  @moduledoc  """
+  Sets the text shown in the chat with a bot if the chat is empty. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code. If empty, the description will be shown to all users for whose languages there is no dedicated description. |
+  | description | string | New bot's description on the specified language. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_bot_info_description.html).
+  """
+
+  defstruct "@type": "setBotInfoDescription", "@extra": nil, bot_user_id: nil, language_code: nil, description: nil
 end
 defmodule CloseSecretChat do
   @moduledoc  """
@@ -5907,7 +8865,7 @@ defmodule CloseSecretChat do
 end
 defmodule GetProxies do
   @moduledoc  """
-  Returns list of proxies that are currently set up. Can be called before authorization.
+  Returns the list of proxies that are currently set up. Can be called before authorization.
   Returns object_ptr<Proxies>.
 
 
@@ -5918,7 +8876,7 @@ defmodule GetProxies do
 end
 defmodule RequestAuthenticationPasswordRecovery do
   @moduledoc  """
-  Requests to send a password recovery code to an email address that was previously set up. Works only when the current authorization state is authorizationStateWaitPassword.
+  Requests to send a 2-step verification password recovery code to an email address that was previously set up. Works only when the current authorization state is authorizationStateWaitPassword.
   Returns object_ptr<Ok>.
 
 
@@ -5938,34 +8896,9 @@ defmodule TestNetwork do
 
   defstruct "@type": "testNetwork", "@extra": nil
 end
-defmodule ResendPhoneNumberConfirmationCode do
-  @moduledoc  """
-  Resends phone number confirmation code.
-  Returns object_ptr<AuthenticationCodeInfo>.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_phone_number_confirmation_code.html).
-  """
-
-  defstruct "@type": "resendPhoneNumberConfirmationCode", "@extra": nil
-end
-defmodule CheckDatabaseEncryptionKey do
-  @moduledoc  """
-  Checks the database encryption key for correctness. Works only when the current authorization state is authorizationStateWaitEncryptionKey.
-  Returns object_ptr<Ok>.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | encryption_key | bytes | Encryption key to check or set up. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_database_encryption_key.html).
-  """
-
-  defstruct "@type": "checkDatabaseEncryptionKey", "@extra": nil, encryption_key: nil
-end
 defmodule CreateVideoChat do
   @moduledoc  """
-  Creates a video chat (a group call bound to a chat). Available only for basic groups, supergroups and channels; requires can_manage_video_chats rights.
+  Creates a video chat (a group call bound to a chat). Available only for basic groups, supergroups and channels; requires can_manage_video_chats administrator right.
   Returns object_ptr<GroupCallId>.
 
   | Name | Type | Description |
@@ -5973,16 +8906,57 @@ defmodule CreateVideoChat do
   | chat_id | int53 | Identifier of a chat in which the video chat will be created. |
   | title | string | Group call title; if empty, chat title will be used. |
   | start_date | int32 | Point in time (Unix timestamp) when the group call is supposed to be started by an administrator; 0 to start the video chat immediately. The date must be at least 10 seconds and at most 8 days in the future. |
-  | is_rtmp_stream | bool | Pass true to create an RTMP stream instead of an ordinary video chat; requires creator privileges. |
+  | is_rtmp_stream | bool | Pass true to create an RTMP stream instead of an ordinary video chat; requires owner privileges. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_video_chat.html).
   """
 
   defstruct "@type": "createVideoChat", "@extra": nil, chat_id: nil, title: nil, start_date: nil, is_rtmp_stream: nil
 end
+defmodule ReorderQuickReplyShortcuts do
+  @moduledoc  """
+  Changes the order of quick reply shortcuts.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_ids | int32 | The new order of quick reply shortcuts. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reorder_quick_reply_shortcuts.html).
+  """
+
+  defstruct "@type": "reorderQuickReplyShortcuts", "@extra": nil, shortcut_ids: nil
+end
+defmodule DeleteSavedMessagesTopicMessagesByDate do
+  @moduledoc  """
+  Deletes all messages between the specified dates in a Saved Messages topic. Messages sent in the last 30 seconds will not be deleted.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which messages will be deleted. |
+  | min_date | int32 | The minimum date of the messages to delete. |
+  | max_date | int32 | The maximum date of the messages to delete. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_saved_messages_topic_messages_by_date.html).
+  """
+
+  defstruct "@type": "deleteSavedMessagesTopicMessagesByDate", "@extra": nil, saved_messages_topic_id: nil, min_date: nil, max_date: nil
+end
+defmodule GetSuitablePersonalChats do
+  @moduledoc  """
+  Returns a list of channel chats, which can be used as a personal chat.
+  Returns object_ptr<Chats>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_suitable_personal_chats.html).
+  """
+
+  defstruct "@type": "getSuitablePersonalChats", "@extra": nil
+end
 defmodule SearchPublicChat do
   @moduledoc  """
-  Searches a public chat by its username. Currently, only private chats, supergroups and channels can be public. Returns the chat if found; otherwise an error is returned.
+  Searches a public chat by its username. Currently, only private chats, supergroups and channels can be public. Returns the chat if found; otherwise, an error is returned.
   Returns object_ptr<Chat>.
 
   | Name | Type | Description |
@@ -6041,21 +9015,49 @@ defmodule SearchOutgoingDocumentMessages do
 end
 defmodule OpenWebApp do
   @moduledoc  """
-  Informs TDLib that a Web App is being opened from attachment menu, a botMenuButton button, an internalLinkTypeAttachmentMenuBot link, or an inlineKeyboardButtonTypeWebApp button. For each bot, a confirmation alert about data sent to the bot must be shown once.
+  Informs TDLib that a Web App is being opened from the attachment menu, a botMenuButton button, an internalLinkTypeAttachmentMenuBot link, or an inlineKeyboardButtonTypeWebApp button. For each bot, a confirmation alert about data sent to the bot must be shown once.
   Returns object_ptr<WebAppInfo>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Identifier of the chat in which the Web App is opened. |
+  | chat_id | int53 | Identifier of the chat in which the Web App is opened. The Web App can't be opened in secret chats. |
   | bot_user_id | int53 | Identifier of the bot, providing the Web App. |
-  | url | string | The URL from an <a class="el" href="classtd_1_1td__api_1_1inline_keyboard_button_type_web_app.html">inlineKeyboardButtonTypeWebApp</a> button, a <a class="el" href="classtd_1_1td__api_1_1bot_menu_button.html">botMenuButton</a> button, or an <a class="el" href="classtd_1_1td__api_1_1internal_link_type_attachment_menu_bot.html">internalLinkTypeAttachmentMenuBot</a> link, or an empty string otherwise. |
+  | url | string | The URL from an <a class="el" href="classtd_1_1td__api_1_1inline_keyboard_button_type_web_app.html">inlineKeyboardButtonTypeWebApp</a> button, a <a class="el" href="classtd_1_1td__api_1_1bot_menu_button.html">botMenuButton</a> button, an <a class="el" href="classtd_1_1td__api_1_1internal_link_type_attachment_menu_bot.html">internalLinkTypeAttachmentMenuBot</a> link, or an empty string otherwise. |
   | theme | themeParameters | Preferred Web App theme; pass null to use the default theme. |
-  | reply_to_message_id | int53 | Identifier of the replied message for the message sent by the Web App; 0 if none. |
+  | application_name | string | Short name of the application; 0-64 English letters, digits, and underscores. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the message will be sent. |
+  | reply_to | InputMessageReplyTo | Information about the message or story to be replied in the message sent by the Web App; pass null if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1open_web_app.html).
   """
 
-  defstruct "@type": "openWebApp", "@extra": nil, chat_id: nil, bot_user_id: nil, url: nil, theme: nil, reply_to_message_id: nil
+  defstruct "@type": "openWebApp", "@extra": nil, chat_id: nil, bot_user_id: nil, url: nil, theme: nil, application_name: nil, message_thread_id: nil, reply_to: nil
+end
+defmodule GetBusinessConnectedBot do
+  @moduledoc  """
+  Returns the business bot that is connected to the current user account. Returns a 404 error if there is no connected bot.
+  Returns object_ptr<BusinessConnectedBot>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_business_connected_bot.html).
+  """
+
+  defstruct "@type": "getBusinessConnectedBot", "@extra": nil
+end
+defmodule LaunchPrepaidPremiumGiveaway do
+  @moduledoc  """
+  Launches a prepaid Telegram Premium giveaway.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | giveaway_id | int64 | Unique identifier of the prepaid giveaway. |
+  | parameters | premiumGiveawayParameters | Giveaway parameters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1launch_prepaid_premium_giveaway.html).
+  """
+
+  defstruct "@type": "launchPrepaidPremiumGiveaway", "@extra": nil, giveaway_id: nil, parameters: nil
 end
 defmodule SetCommands do
   @moduledoc  """
@@ -6075,19 +9077,31 @@ defmodule SetCommands do
 end
 defmodule GetWebAppUrl do
   @moduledoc  """
-  Returns an HTTPS URL of a Web App to open after keyboardButtonTypeWebApp button is pressed.
+  Returns an HTTPS URL of a Web App to open from the side menu, a keyboardButtonTypeWebApp button, an inlineQueryResultsButtonTypeWebApp button, or an internalLinkTypeSideMenuBot link.
   Returns object_ptr<HttpUrl>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | bot_user_id | int53 | Identifier of the target bot. |
-  | url | string | The URL from the <a class="el" href="classtd_1_1td__api_1_1keyboard_button_type_web_app.html">keyboardButtonTypeWebApp</a> button. |
+  | url | string | The URL from a <a class="el" href="classtd_1_1td__api_1_1keyboard_button_type_web_app.html">keyboardButtonTypeWebApp</a> button, <a class="el" href="classtd_1_1td__api_1_1inline_query_results_button_type_web_app.html">inlineQueryResultsButtonTypeWebApp</a> button, an <a class="el" href="classtd_1_1td__api_1_1internal_link_type_side_menu_bot.html">internalLinkTypeSideMenuBot</a> link, or an empty when the bot is opened from the side menu. |
   | theme | themeParameters | Preferred Web App theme; pass null to use the default theme. |
+  | application_name | string | Short name of the application; 0-64 English letters, digits, and underscores. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_web_app_url.html).
   """
 
-  defstruct "@type": "getWebAppUrl", "@extra": nil, bot_user_id: nil, url: nil, theme: nil
+  defstruct "@type": "getWebAppUrl", "@extra": nil, bot_user_id: nil, url: nil, theme: nil, application_name: nil
+end
+defmodule GetGreetingStickers do
+  @moduledoc  """
+  Returns greeting stickers from regular sticker sets that can be used for the start page of other users.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_greeting_stickers.html).
+  """
+
+  defstruct "@type": "getGreetingStickers", "@extra": nil
 end
 defmodule GetMessageEmbeddingCode do
   @moduledoc  """
@@ -6121,18 +9135,19 @@ defmodule ToggleSupergroupIsBroadcastGroup do
 end
 defmodule GetMessageAvailableReactions do
   @moduledoc  """
-  Returns reactions, which can be added to a message. The list can change after updateReactions, updateChatAvailableReactions for the chat, or updateMessageInteractionInfo for the message. The method will return Premium reactions, even the current user has no Premium subscription.
+  Returns reactions, which can be added to a message. The list can change after updateActiveEmojiReactions, updateChatAvailableReactions for the chat, or updateMessageInteractionInfo for the message.
   Returns object_ptr<AvailableReactions>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which the message belongs. |
   | message_id | int53 | Identifier of the message. |
+  | row_size | int32 | Number of reaction per row, 5-25. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_available_reactions.html).
   """
 
-  defstruct "@type": "getMessageAvailableReactions", "@extra": nil, chat_id: nil, message_id: nil
+  defstruct "@type": "getMessageAvailableReactions", "@extra": nil, chat_id: nil, message_id: nil, row_size: nil
 end
 defmodule CloseChat do
   @moduledoc  """
@@ -6172,7 +9187,7 @@ defmodule DeleteSavedCredentials do
 end
 defmodule RateSpeechRecognition do
   @moduledoc  """
-  Rates recognized speech in a voice note message.
+  Rates recognized speech in a video note or a voice note message.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -6185,6 +9200,21 @@ defmodule RateSpeechRecognition do
   """
 
   defstruct "@type": "rateSpeechRecognition", "@extra": nil, chat_id: nil, message_id: nil, is_good: nil
+end
+defmodule BoostChat do
+  @moduledoc  """
+  Boosts a chat and returns the list of available chat boost slots for the current user after the boost.
+  Returns object_ptr<ChatBoostSlots>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | slot_ids | int32 | Identifiers of boost slots of the current user from which to apply boosts to the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1boost_chat.html).
+  """
+
+  defstruct "@type": "boostChat", "@extra": nil, chat_id: nil, slot_ids: nil
 end
 defmodule GetChatListsToAddChat do
   @moduledoc  """
@@ -6279,6 +9309,20 @@ defmodule RemoveSavedNotificationSound do
 
   defstruct "@type": "removeSavedNotificationSound", "@extra": nil, notification_sound_id: nil
 end
+defmodule SetArchiveChatListSettings do
+  @moduledoc  """
+  Changes settings for automatic moving of chats to and from the Archive chat lists.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | settings | archiveChatListSettings | New settings. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_archive_chat_list_settings.html).
+  """
+
+  defstruct "@type": "setArchiveChatListSettings", "@extra": nil, settings: nil
+end
 defmodule GetJsonValue do
   @moduledoc  """
   Converts a JSON-serialized string to corresponding JsonValue object. Can be called synchronously.
@@ -6292,6 +9336,21 @@ defmodule GetJsonValue do
   """
 
   defstruct "@type": "getJsonValue", "@extra": nil, json: nil
+end
+defmodule SetStoryPrivacySettings do
+  @moduledoc  """
+  Changes privacy settings of a story. The method can be called only for stories posted on behalf of the current user and if story.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_id | int32 | Identifier of the story. |
+  | privacy_settings | StoryPrivacySettings | The new privacy settigs for the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_story_privacy_settings.html).
+  """
+
+  defstruct "@type": "setStoryPrivacySettings", "@extra": nil, story_id: nil, privacy_settings: nil
 end
 defmodule BlockMessageSenderFromReplies do
   @moduledoc  """
@@ -6317,7 +9376,7 @@ defmodule GetRecoveryEmailAddress do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | The password for the current user. |
+  | password | string | The 2-step verification password for the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_recovery_email_address.html).
   """
@@ -6337,6 +9396,17 @@ defmodule DeletePassportElement do
   """
 
   defstruct "@type": "deletePassportElement", "@extra": nil, type: nil
+end
+defmodule GetThemedEmojiStatuses do
+  @moduledoc  """
+  Returns up to 8 emoji statuses, which must be shown right after the default Premium Badge in the emoji status list for self status.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_themed_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getThemedEmojiStatuses", "@extra": nil
 end
 defmodule GetNetworkStatistics do
   @moduledoc  """
@@ -6378,7 +9448,7 @@ defmodule SendPaymentForm do
   | payment_form_id | int64 | Payment form identifier returned by <a class="el" href="classtd_1_1td__api_1_1get_payment_form.html">getPaymentForm</a>. |
   | order_info_id | string | Identifier returned by <a class="el" href="classtd_1_1td__api_1_1validate_order_info.html">validateOrderInfo</a>, or an empty string. |
   | shipping_option_id | string | Identifier of a chosen shipping option, if applicable. |
-  | credentials | InputCredentials | The credentials chosen by user for payment. |
+  | credentials | InputCredentials | The credentials chosen by user for payment; pass null for a payment in Telegram stars. |
   | tip_amount | int53 | Chosen by the user amount of tip in the smallest units of the currency. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_payment_form.html).
@@ -6386,19 +9456,36 @@ defmodule SendPaymentForm do
 
   defstruct "@type": "sendPaymentForm", "@extra": nil, input_invoice: nil, payment_form_id: nil, order_info_id: nil, shipping_option_id: nil, credentials: nil, tip_amount: nil
 end
-defmodule SendChatScreenshotTakenNotification do
+defmodule SetSavedMessagesTagLabel do
   @moduledoc  """
-  Sends a notification about a screenshot taken in a chat. Supported only in private and secret chats.
+  Changes label of a Saved Messages tag; for Telegram Premium users only.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_id | int53 | Chat identifier. |
+  | tag | ReactionType | The tag which label will be changed. |
+  | label | string | New label for the tag; 0-12 characters. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_chat_screenshot_taken_notification.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_saved_messages_tag_label.html).
   """
 
-  defstruct "@type": "sendChatScreenshotTakenNotification", "@extra": nil, chat_id: nil
+  defstruct "@type": "setSavedMessagesTagLabel", "@extra": nil, tag: nil, label: nil
+end
+defmodule GetStory do
+  @moduledoc  """
+  Returns a story.
+  Returns object_ptr<Story>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Story identifier. |
+  | only_local | bool | Pass true to get only locally available information without sending network requests. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story.html).
+  """
+
+  defstruct "@type": "getStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil, only_local: nil
 end
 defmodule GetChatMember do
   @moduledoc  """
@@ -6415,6 +9502,17 @@ defmodule GetChatMember do
 
   defstruct "@type": "getChatMember", "@extra": nil, chat_id: nil, member_id: nil
 end
+defmodule ClearRecentReactions do
+  @moduledoc  """
+  Clears the list of recently used reactions.
+  Returns object_ptr<Ok>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1clear_recent_reactions.html).
+  """
+
+  defstruct "@type": "clearRecentReactions", "@extra": nil
+end
 defmodule ForwardMessages do
   @moduledoc  """
   Forwards previously sent messages. Returns the forwarded messages in the same order as the message identifiers passed in message_ids. If a message can't be forwarded, null will be returned instead of the message.
@@ -6423,17 +9521,17 @@ defmodule ForwardMessages do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which to forward messages. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the message will be sent; for forum threads only. |
   | from_chat_id | int53 | Identifier of the chat from which to forward messages. |
-  | message_ids | int53 | Identifiers of the messages to forward. Message identifiers must be in a strictly increasing order. At most 100 messages can be forwarded simultaneously. |
+  | message_ids | int53 | Identifiers of the messages to forward. Message identifiers must be in a strictly increasing order. At most 100 messages can be forwarded simultaneously. A message can be forwarded only if message.can_be_forwarded. |
   | options | messageSendOptions | Options to be used to send the messages; pass null to use default options. |
   | send_copy | bool | Pass true to copy content of the messages without reference to the original sender. Always true if the messages are forwarded to a secret chat or are local. |
   | remove_caption | bool | Pass true to remove media captions of message copies. Ignored if send_copy is false. |
-  | only_preview | bool | Pass true to get fake messages instead of actually forwarding them. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forward_messages.html).
   """
 
-  defstruct "@type": "forwardMessages", "@extra": nil, chat_id: nil, from_chat_id: nil, message_ids: nil, options: nil, send_copy: nil, remove_caption: nil, only_preview: nil
+  defstruct "@type": "forwardMessages", "@extra": nil, chat_id: nil, message_thread_id: nil, from_chat_id: nil, message_ids: nil, options: nil, send_copy: nil, remove_caption: nil
 end
 defmodule GetInlineGameHighScores do
   @moduledoc  """
@@ -6490,6 +9588,20 @@ defmodule GetChatJoinRequests do
 
   defstruct "@type": "getChatJoinRequests", "@extra": nil, chat_id: nil, invite_link: nil, query: nil, offset_request: nil, limit: nil
 end
+defmodule DeleteSavedMessagesTopicHistory do
+  @moduledoc  """
+  Deletes all messages in a Saved Messages topic.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which messages will be deleted. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_saved_messages_topic_history.html).
+  """
+
+  defstruct "@type": "deleteSavedMessagesTopicHistory", "@extra": nil, saved_messages_topic_id: nil
+end
 defmodule CheckRecoveryEmailAddressCode do
   @moduledoc  """
   Checks the 2-step verification recovery email address verification code.
@@ -6533,6 +9645,17 @@ defmodule CreateInvoiceLink do
 
   defstruct "@type": "createInvoiceLink", "@extra": nil, invoice: nil
 end
+defmodule GetDefaultProfilePhotoCustomEmojiStickers do
+  @moduledoc  """
+  Returns default list of custom emoji stickers for placing on a profile photo.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_profile_photo_custom_emoji_stickers.html).
+  """
+
+  defstruct "@type": "getDefaultProfilePhotoCustomEmojiStickers", "@extra": nil
+end
 defmodule SetChatTheme do
   @moduledoc  """
   Changes the chat theme. Supported only in private and secret chats.
@@ -6548,6 +9671,34 @@ defmodule SetChatTheme do
 
   defstruct "@type": "setChatTheme", "@extra": nil, chat_id: nil, theme_name: nil
 end
+defmodule GetStoryPublicForwards do
+  @moduledoc  """
+  Returns forwards of a story as a message to public chats and reposts by public channels. Can be used only if the story is posted on behalf of the current user or story.can_get_statistics == true. For optimal performance, the number of returned messages and stories is chosen by TDLib.
+  Returns object_ptr<PublicForwards>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story. |
+  | story_id | int32 | The identifier of the story. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of messages and stories to be returned; must be positive and can't be greater than 100. For optimal performance, the number of returned objects is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story_public_forwards.html).
+  """
+
+  defstruct "@type": "getStoryPublicForwards", "@extra": nil, story_sender_chat_id: nil, story_id: nil, offset: nil, limit: nil
+end
+defmodule GetThemedChatEmojiStatuses do
+  @moduledoc  """
+  Returns up to 8 emoji statuses, which must be shown in the emoji status list for chats.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_themed_chat_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getThemedChatEmojiStatuses", "@extra": nil
+end
 defmodule ToggleChatIsMarkedAsUnread do
   @moduledoc  """
   Changes the marked as unread state of a chat.
@@ -6562,6 +9713,24 @@ defmodule ToggleChatIsMarkedAsUnread do
   """
 
   defstruct "@type": "toggleChatIsMarkedAsUnread", "@extra": nil, chat_id: nil, is_marked_as_unread: nil
+end
+defmodule GetChatMessagePosition do
+  @moduledoc  """
+  Returns approximate 1-based position of a message among messages, which can be found by the specified filter in the chat. Cannot be used in secret chats.
+  Returns object_ptr<Count>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat in which to find message position. |
+  | message_id | int53 | Message identifier. |
+  | filter | SearchMessagesFilter | Filter for message content; <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_empty.html">searchMessagesFilterEmpty</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_mention.html">searchMessagesFilterUnreadMention</a>, <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_unread_reaction.html">searchMessagesFilterUnreadReaction</a>, and <a class="el" href="classtd_1_1td__api_1_1search_messages_filter_failed_to_send.html">searchMessagesFilterFailedToSend</a> are unsupported in this function. |
+  | message_thread_id | int53 | If not 0, only messages in the specified thread will be considered; supergroups only. |
+  | saved_messages_topic_id | int53 | If not 0, only messages in the specified Saved Messages topic will be considered; pass 0 to consider all relevant messages, or for chats other than Saved Messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_message_position.html).
+  """
+
+  defstruct "@type": "getChatMessagePosition", "@extra": nil, chat_id: nil, message_id: nil, filter: nil, message_thread_id: nil, saved_messages_topic_id: nil
 end
 defmodule SearchChatsOnServer do
   @moduledoc  """
@@ -6585,12 +9754,57 @@ defmodule AddCustomServerLanguagePack do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | language_pack_id | string | Identifier of a language pack to be added; may be different from a name that is used in an "<a href="https://t.me/setlanguage/">https://t.me/setlanguage/</a>" link. |
+  | language_pack_id | string | Identifier of a language pack to be added. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1add_custom_server_language_pack.html).
   """
 
   defstruct "@type": "addCustomServerLanguagePack", "@extra": nil, language_pack_id: nil
+end
+defmodule DeleteForumTopic do
+  @moduledoc  """
+  Deletes all messages in a forum topic; requires can_delete_messages administrator right in the supergroup unless the user is creator of the topic, the topic has no messages from other users and has at most 11 messages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | message_thread_id | int53 | Message thread identifier of the forum topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_forum_topic.html).
+  """
+
+  defstruct "@type": "deleteForumTopic", "@extra": nil, chat_id: nil, message_thread_id: nil
+end
+defmodule SetBotInfoShortDescription do
+  @moduledoc  """
+  Sets the text shown on a bot's profile page and sent together with the link when users share the bot. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code. If empty, the short description will be shown to all users for whose languages there is no dedicated description. |
+  | short_description | string | New bot's short description on the specified language. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_bot_info_short_description.html).
+  """
+
+  defstruct "@type": "setBotInfoShortDescription", "@extra": nil, bot_user_id: nil, language_code: nil, short_description: nil
+end
+defmodule CheckQuickReplyShortcutName do
+  @moduledoc  """
+  Checks validness of a name for a quick reply shortcut. Can be called synchronously.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | The name of the shortcut; 1-32 characters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_quick_reply_shortcut_name.html).
+  """
+
+  defstruct "@type": "checkQuickReplyShortcutName", "@extra": nil, name: nil
 end
 defmodule GetMapThumbnailFile do
   @moduledoc  """
@@ -6642,19 +9856,36 @@ defmodule GetGroupCallInviteLink do
 
   defstruct "@type": "getGroupCallInviteLink", "@extra": nil, group_call_id: nil, can_self_unmute: nil
 end
-defmodule CreateChatFilter do
+defmodule GetMessageReadDate do
   @moduledoc  """
-  Creates new chat filter. Returns information about the created chat filter. There can be up to GetOption("chat_filter_count_max") chat filters, but the limit can be increased with Telegram Premium.
-  Returns object_ptr<ChatFilterInfo>.
+  Returns read date of a recent outgoing message in a private chat. The method can be called if message.can_get_read_date == true and the message is read.
+  Returns object_ptr<MessageReadDate>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | filter | chatFilter | Chat filter. |
+  | chat_id | int53 | Chat identifier. |
+  | message_id | int53 | Identifier of the message. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_chat_filter.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_message_read_date.html).
   """
 
-  defstruct "@type": "createChatFilter", "@extra": nil, filter: nil
+  defstruct "@type": "getMessageReadDate", "@extra": nil, chat_id: nil, message_id: nil
+end
+defmodule ToggleSupergroupUsernameIsActive do
+  @moduledoc  """
+  Changes active state for a username of a supergroup or channel, requires owner privileges in the supergroup or channel. The editable username can't be disabled. May return an error with a message "USERNAMES_ACTIVE_TOO_MUCH" if the maximum number of active usernames has been reached.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup or channel. |
+  | username | string | The username to change. |
+  | is_active | bool | Pass true to activate the username; pass false to disable it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_supergroup_username_is_active.html).
+  """
+
+  defstruct "@type": "toggleSupergroupUsernameIsActive", "@extra": nil, supergroup_id: nil, username: nil, is_active: nil
 end
 defmodule TestCallVectorString do
   @moduledoc  """
@@ -6670,9 +9901,25 @@ defmodule TestCallVectorString do
 
   defstruct "@type": "testCallVectorString", "@extra": nil, x: nil
 end
+defmodule CreateChatFolderInviteLink do
+  @moduledoc  """
+  Creates a new invite link for a chat folder. A link can be created for a chat folder if it has only pinned and included chats.
+  Returns object_ptr<ChatFolderInviteLink>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+  | name | string | Name of the link; 0-32 characters. |
+  | chat_ids | int53 | Identifiers of chats to be accessible by the invite link. Use <a class="el" href="classtd_1_1td__api_1_1get_chats_for_chat_folder_invite_link.html">getChatsForChatFolderInviteLink</a> to get suitable chats. Basic groups will be automatically converted to supergroups before link creation. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "createChatFolderInviteLink", "@extra": nil, chat_folder_id: nil, name: nil, chat_ids: nil
+end
 defmodule SetChatTitle do
   @moduledoc  """
-  Changes the chat title. Supported only for basic groups, supergroups and channels. Requires can_change_info administrator right.
+  Changes the chat title. Supported only for basic groups, supergroups and channels. Requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -6693,17 +9940,17 @@ defmodule SendInlineQueryResultMessage do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Target chat. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the message will be sent. |
-  | reply_to_message_id | int53 | Identifier of a replied message; 0 if none. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the message will be sent. |
+  | reply_to | InputMessageReplyTo | Information about the message or story to be replied; pass null if none. |
   | options | messageSendOptions | Options to be used to send the message; pass null to use default options. |
   | query_id | int64 | Identifier of the inline query. |
-  | result_id | string | Identifier of the inline result. |
-  | hide_via_bot | bool | Pass true to hide the bot, via which the message is sent. Can be used only for bots GetOption("animation_search_bot_username"), GetOption("photo_search_bot_username"), and GetOption("venue_search_bot_username"). |
+  | result_id | string | Identifier of the inline query result. |
+  | hide_via_bot | bool | Pass true to hide the bot, via which the message is sent. Can be used only for bots <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("animation_search_bot_username"), <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("photo_search_bot_username"), and <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("venue_search_bot_username"). |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_inline_query_result_message.html).
   """
 
-  defstruct "@type": "sendInlineQueryResultMessage", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to_message_id: nil, options: nil, query_id: nil, result_id: nil, hide_via_bot: nil
+  defstruct "@type": "sendInlineQueryResultMessage", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to: nil, options: nil, query_id: nil, result_id: nil, hide_via_bot: nil
 end
 defmodule GetMessageStatistics do
   @moduledoc  """
@@ -6723,7 +9970,7 @@ defmodule GetMessageStatistics do
 end
 defmodule SetChatSlowModeDelay do
   @moduledoc  """
-  Changes the slow mode delay of a chat. Available only for supergroups; requires can_restrict_members rights.
+  Changes the slow mode delay of a chat. Available only for supergroups; requires can_restrict_members right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -6735,6 +9982,32 @@ defmodule SetChatSlowModeDelay do
   """
 
   defstruct "@type": "setChatSlowModeDelay", "@extra": nil, chat_id: nil, slow_mode_delay: nil
+end
+defmodule CanSendMessageToUser do
+  @moduledoc  """
+  Check whether the current user can message another user or try to create a chat with them.
+  Returns object_ptr<CanSendMessageToUserResult>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of the other user. |
+  | only_local | bool | Pass true to get only locally available information without sending network requests. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_message_to_user.html).
+  """
+
+  defstruct "@type": "canSendMessageToUser", "@extra": nil, user_id: nil, only_local: nil
+end
+defmodule GetNewChatPrivacySettings do
+  @moduledoc  """
+  Returns privacy settings for new chat creation.
+  Returns object_ptr<NewChatPrivacySettings>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_new_chat_privacy_settings.html).
+  """
+
+  defstruct "@type": "getNewChatPrivacySettings", "@extra": nil
 end
 defmodule DisconnectWebsite do
   @moduledoc  """
@@ -6749,6 +10022,20 @@ defmodule DisconnectWebsite do
   """
 
   defstruct "@type": "disconnectWebsite", "@extra": nil, website_id: nil
+end
+defmodule LoadActiveStories do
+  @moduledoc  """
+  Loads more active stories from a story list. The loaded stories will be sent through updates. Active stories are sorted by the pair (active_stories.order, active_stories.story_sender_chat_id) in descending order. Returns a 404 error if all active stories have been loaded.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_list | StoryList | The story list in which to load active stories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1load_active_stories.html).
+  """
+
+  defstruct "@type": "loadActiveStories", "@extra": nil, story_list: nil
 end
 defmodule SetCustomLanguagePackString do
   @moduledoc  """
@@ -6795,10 +10082,24 @@ defmodule EditMessageSchedulingState do
 
   defstruct "@type": "editMessageSchedulingState", "@extra": nil, chat_id: nil, message_id: nil, scheduling_state: nil
 end
+defmodule CheckPremiumGiftCode do
+  @moduledoc  """
+  Return information about a Telegram Premium gift code.
+  Returns object_ptr<PremiumGiftCodeInfo>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | string | The code to check. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_premium_gift_code.html).
+  """
+
+  defstruct "@type": "checkPremiumGiftCode", "@extra": nil, code: nil
+end
 defmodule AddChatMember do
   @moduledoc  """
-  Adds a new member to a chat. Members can't be added to private or secret chats.
-  Returns object_ptr<Ok>.
+  Adds a new member to a chat; requires can_invite_users member right. Members can't be added to private or secret chats. Returns information about members that weren't added.
+  Returns object_ptr<FailedToAddMembers>.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -6818,7 +10119,7 @@ defmodule SetBio do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | bio | string | The new value of the user bio; 0-GetOption("bio_length_max") characters without line feeds. |
+  | bio | string | The new value of the user bio; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("bio_length_max") characters without line feeds. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_bio.html).
   """
@@ -6827,7 +10128,7 @@ defmodule SetBio do
 end
 defmodule SetChatDescription do
   @moduledoc  """
-  Changes information about a chat. Available for basic groups, supergroups, and channels. Requires can_change_info administrator right.
+  Changes information about a chat. Available for basic groups, supergroups, and channels. Requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -6840,6 +10141,20 @@ defmodule SetChatDescription do
 
   defstruct "@type": "setChatDescription", "@extra": nil, chat_id: nil, description: nil
 end
+defmodule CheckPhoneNumberCode do
+  @moduledoc  """
+  Check the authentication code and completes the request for which the code was sent if appropriate.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | string | Authentication code to check. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_phone_number_code.html).
+  """
+
+  defstruct "@type": "checkPhoneNumberCode", "@extra": nil, code: nil
+end
 defmodule TestProxy do
   @moduledoc  """
   Sends a simple network request to the Telegram servers via proxy; for testing only. Can be called before authorization.
@@ -6847,7 +10162,7 @@ defmodule TestProxy do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | server | string | Proxy server IP address. |
+  | server | string | Proxy server domain or IP address. |
   | port | int32 | Proxy server port. |
   | type | ProxyType | Proxy type. |
   | dc_id | int32 | Identifier of a datacenter with which to test connection. |
@@ -6890,6 +10205,17 @@ defmodule DownloadFile do
 
   defstruct "@type": "downloadFile", "@extra": nil, file_id: nil, priority: nil, offset: nil, limit: nil, synchronous: nil
 end
+defmodule GetTimeZones do
+  @moduledoc  """
+  Returns the list of supported time zones.
+  Returns object_ptr<TimeZones>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_time_zones.html).
+  """
+
+  defstruct "@type": "getTimeZones", "@extra": nil
+end
 defmodule SetOption do
   @moduledoc  """
   Sets the value of an option. (Check the list of available options on https://core.telegram.org/tdlib/options.) Only writable options can be set. Can be called before authorization.
@@ -6905,6 +10231,88 @@ defmodule SetOption do
 
   defstruct "@type": "setOption", "@extra": nil, name: nil, value: nil
 end
+defmodule SetCloseFriends do
+  @moduledoc  """
+  Changes the list of close friends of the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_ids | int53 | User identifiers of close friends; the users must be contacts of the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_close_friends.html).
+  """
+
+  defstruct "@type": "setCloseFriends", "@extra": nil, user_ids: nil
+end
+defmodule SuggestUserProfilePhoto do
+  @moduledoc  """
+  Suggests a profile photo to another regular user with common messages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | photo | InputChatPhoto | Profile photo to suggest; <a class="el" href="classtd_1_1td__api_1_1input_chat_photo_previous.html">inputChatPhotoPrevious</a> isn't supported in this function. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggest_user_profile_photo.html).
+  """
+
+  defstruct "@type": "suggestUserProfilePhoto", "@extra": nil, user_id: nil, photo: nil
+end
+defmodule GetStoryNotificationSettingsExceptions do
+  @moduledoc  """
+  Returns the list of chats with non-default notification settings for stories.
+  Returns object_ptr<Chats>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story_notification_settings_exceptions.html).
+  """
+
+  defstruct "@type": "getStoryNotificationSettingsExceptions", "@extra": nil
+end
+defmodule ToggleStoryIsPostedToChatPage do
+  @moduledoc  """
+  Toggles whether a story is accessible after expiration. Can be called only if story.can_toggle_is_posted_to_chat_page == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Identifier of the story. |
+  | is_posted_to_chat_page | bool | Pass true to make the story accessible after expiration; pass false to make it private. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_story_is_posted_to_chat_page.html).
+  """
+
+  defstruct "@type": "toggleStoryIsPostedToChatPage", "@extra": nil, story_sender_chat_id: nil, story_id: nil, is_posted_to_chat_page: nil
+end
+defmodule GetStarRevenueStatistics do
+  @moduledoc  """
+  Returns detailed Telegram star revenue statistics.
+  Returns object_ptr<StarRevenueStatistics>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | owner_id | MessageSender | Identifier of the owner of the Telegram stars; can be identifier of an owned bot, or identifier of a channel chat with supergroupFullInfo.can_get_revenue_statistics == true. |
+  | is_dark | bool | Pass true if a dark theme is used by the application. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_star_revenue_statistics.html).
+  """
+
+  defstruct "@type": "getStarRevenueStatistics", "@extra": nil, owner_id: nil, is_dark: nil
+end
+defmodule CancelRecoveryEmailAddressVerification do
+  @moduledoc  """
+  Cancels verification of the 2-step verification recovery email address.
+  Returns object_ptr<PasswordState>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1cancel_recovery_email_address_verification.html).
+  """
+
+  defstruct "@type": "cancelRecoveryEmailAddressVerification", "@extra": nil
+end
 defmodule AddProxy do
   @moduledoc  """
   Adds a proxy server for network requests. Can be called before authorization.
@@ -6912,7 +10320,7 @@ defmodule AddProxy do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | server | string | Proxy server IP address. |
+  | server | string | Proxy server domain or IP address. |
   | port | int32 | Proxy server port. |
   | enable | bool | Pass true to immediately enable the proxy. |
   | type | ProxyType | Proxy type. |
@@ -6924,14 +10332,14 @@ defmodule AddProxy do
 end
 defmodule TransferChatOwnership do
   @moduledoc  """
-  Changes the owner of a chat. The current user must be a current owner of the chat. Use the method canTransferOwnership to check whether the ownership can be transferred from the current session. Available only for supergroups and channel chats.
+  Changes the owner of a chat; requires owner privileges in the chat. Use the method canTransferOwnership to check whether the ownership can be transferred from the current session. Available only for supergroups and channel chats.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | user_id | int53 | Identifier of the user to which transfer the ownership. The ownership can't be transferred to a bot or to a deleted user. |
-  | password | string | The password of the current user. |
+  | password | string | The 2-step verification password of the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1transfer_chat_ownership.html).
   """
@@ -7002,7 +10410,7 @@ defmodule SetCustomLanguagePack do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | info | languagePackInfo | Information about the language pack. Language pack ID must start with 'X', consist only of English letters, digits and hyphens, and must not exceed 64 characters. Can be called before authorization. |
+  | info | languagePackInfo | Information about the language pack. Language pack identifier must start with 'X', consist only of English letters, digits and hyphens, and must not exceed 64 characters. Can be called before authorization. |
   | strings | languagePackString | Strings of the new language pack. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_custom_language_pack.html).
@@ -7012,13 +10420,13 @@ defmodule SetCustomLanguagePack do
 end
 defmodule SetPassword do
   @moduledoc  """
-  Changes the password for the current user. If a new recovery email address is specified, then the change will not be applied until the new recovery email address is confirmed.
+  Changes the 2-step verification password for the current user. If a new recovery email address is specified, then the change will not be applied until the new recovery email address is confirmed.
   Returns object_ptr<PasswordState>.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | old_password | string | Previous password of the user. |
-  | new_password | string | New password of the user; may be empty to remove the password. |
+  | old_password | string | Previous 2-step verification password of the user. |
+  | new_password | string | New 2-step verification password of the user; may be empty to remove the password. |
   | new_hint | string | New password hint; may be empty. |
   | set_recovery_email_address | bool | Pass true to change also the recovery email address. |
   | new_recovery_email_address | string | New recovery email address; may be empty. |
@@ -7030,7 +10438,7 @@ defmodule SetPassword do
 end
 defmodule GetVideoChatAvailableParticipants do
   @moduledoc  """
-  Returns list of participant identifiers, on whose behalf a video chat in the chat can be joined.
+  Returns the list of participant identifiers, on whose behalf a video chat in the chat can be joined.
   Returns object_ptr<MessageSenders>.
 
   | Name | Type | Description |
@@ -7056,6 +10464,38 @@ defmodule LeaveGroupCall do
 
   defstruct "@type": "leaveGroupCall", "@extra": nil, group_call_id: nil
 end
+defmodule SetStoryReaction do
+  @moduledoc  """
+  Changes chosen reaction on a story that has already been sent.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story. |
+  | story_id | int32 | The identifier of the story. |
+  | reaction_type | ReactionType | Type of the reaction to set; pass null to remove the reaction. <code><a class="el" href="classtd_1_1td__api_1_1reaction_type_custom_emoji.html">reactionTypeCustomEmoji</a></code> reactions can be used only by Telegram Premium users. |
+  | update_recent_reactions | bool | Pass true if the reaction needs to be added to recent reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_story_reaction.html).
+  """
+
+  defstruct "@type": "setStoryReaction", "@extra": nil, story_sender_chat_id: nil, story_id: nil, reaction_type: nil, update_recent_reactions: nil
+end
+defmodule GetOwnedStickerSets do
+  @moduledoc  """
+  Returns sticker sets owned by the current user.
+  Returns object_ptr<StickerSets>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | offset_sticker_set_id | int64 | Identifier of the sticker set from which to return owned sticker sets; use 0 to get results from the beginning. |
+  | limit | int32 | The maximum number of sticker sets to be returned; must be positive and can't be greater than 100. For optimal performance, the number of returned objects is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_owned_sticker_sets.html).
+  """
+
+  defstruct "@type": "getOwnedStickerSets", "@extra": nil, offset_sticker_set_id: nil, limit: nil
+end
 defmodule SetDefaultGroupAdministratorRights do
   @moduledoc  """
   Sets default administrator rights for adding the bot to basic group and supergroup chats; for bots only.
@@ -7063,7 +10503,7 @@ defmodule SetDefaultGroupAdministratorRights do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | default_group_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to basic group and supergroup chats; may be null. |
+  | default_group_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to basic group and supergroup chats; pass null to remove default rights. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_default_group_administrator_rights.html).
   """
@@ -7092,8 +10532,8 @@ defmodule SetChatDraftMessage do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the draft was changed. |
-  | draft_message | draftMessage | New draft message; pass null to remove the draft. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the draft was changed. |
+  | draft_message | draftMessage | New draft message; pass null to remove the draft. All files in draft message content must be of the type <a class="el" href="classtd_1_1td__api_1_1input_file_local.html">inputFileLocal</a>. Media thumbnails and captions are ignored. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_draft_message.html).
   """
@@ -7109,18 +10549,55 @@ defmodule CreateNewStickerSet do
   |------|------| ------------|
   | user_id | int53 | Sticker set owner; ignored for regular users. |
   | title | string | Sticker set title; 1-64 characters. |
-  | name | string | Sticker set name. Can contain only English letters, digits and underscores. Must end with <em>"<em>by</em><bot username>"</em> (<em><bot_username></em> is case insensitive) for bots; 1-64 characters. |
-  | stickers | inputSticker | List of stickers to be added to the set; must be non-empty. All stickers must have the same format. For TGS stickers, <a class="el" href="classtd_1_1td__api_1_1upload_sticker_file.html">uploadStickerFile</a> must be used before the sticker is shown. |
+  | name | string | Sticker set name. Can contain only English letters, digits and underscores. Must end with <em>"<em>by</em><bot username>"</em> (<em><bot_username></em> is case insensitive) for bots; 0-64 characters. If empty, then the name returned by <a class="el" href="classtd_1_1td__api_1_1get_suggested_sticker_set_name.html">getSuggestedStickerSetName</a> will be used automatically. |
+  | sticker_type | StickerType | Type of the stickers in the set. |
+  | needs_repainting | bool | Pass true if stickers in the sticker set must be repainted; for custom emoji sticker sets only. |
+  | stickers | inputSticker | List of stickers to be added to the set; 1-200 stickers for custom emoji sticker sets, and 1-120 stickers otherwise. For TGS stickers, <a class="el" href="classtd_1_1td__api_1_1upload_sticker_file.html">uploadStickerFile</a> must be used before the sticker is shown. |
   | source | string | Source of the sticker set; may be empty if unknown. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1create_new_sticker_set.html).
   """
 
-  defstruct "@type": "createNewStickerSet", "@extra": nil, user_id: nil, title: nil, name: nil, stickers: nil, source: nil
+  defstruct "@type": "createNewStickerSet", "@extra": nil, user_id: nil, title: nil, name: nil, sticker_type: nil, needs_repainting: nil, stickers: nil, source: nil
+end
+defmodule GetBotInfoShortDescription do
+  @moduledoc  """
+  Returns the text shown on a bot's profile page and sent together with the link when users share the bot in the given language. Can be called only if userTypeBot.can_be_edited == true.
+  Returns object_ptr<Text>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+  | language_code | string | A two-letter ISO 639-1 language code or an empty string. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_bot_info_short_description.html).
+  """
+
+  defstruct "@type": "getBotInfoShortDescription", "@extra": nil, bot_user_id: nil, language_code: nil
+end
+defmodule GetStoryInteractions do
+  @moduledoc  """
+  Returns interactions with a story. The method can be called only for stories posted on behalf of the current user.
+  Returns object_ptr<StoryInteractions>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_id | int32 | Story identifier. |
+  | query | string | Query to search for in names, usernames and titles; may be empty to get all relevant interactions. |
+  | only_contacts | bool | Pass true to get only interactions by contacts; pass false to get all relevant interactions. |
+  | prefer_forwards | bool | Pass true to get forwards and reposts first, then reactions, then other views; pass false to get interactions sorted just by interaction date. |
+  | prefer_with_reaction | bool | Pass true to get interactions with reaction first; pass false to get interactions sorted just by interaction date. Ignored if prefer_forwards == true. |
+  | offset | string | Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results. |
+  | limit | int32 | The maximum number of story interactions to return. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_story_interactions.html).
+  """
+
+  defstruct "@type": "getStoryInteractions", "@extra": nil, story_id: nil, query: nil, only_contacts: nil, prefer_forwards: nil, prefer_with_reaction: nil, offset: nil, limit: nil
 end
 defmodule ReadAllChatReactions do
   @moduledoc  """
-  Marks all reactions in a chat as read.
+  Marks all reactions in a chat or a forum topic as read.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -7132,6 +10609,20 @@ defmodule ReadAllChatReactions do
 
   defstruct "@type": "readAllChatReactions", "@extra": nil, chat_id: nil
 end
+defmodule AllowBotToSendMessages do
+  @moduledoc  """
+  Allows the specified bot to send messages to the user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | Identifier of the target bot. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1allow_bot_to_send_messages.html).
+  """
+
+  defstruct "@type": "allowBotToSendMessages", "@extra": nil, bot_user_id: nil
+end
 defmodule RegisterUser do
   @moduledoc  """
   Finishes user registration. Works only when the current authorization state is authorizationStateWaitRegistration.
@@ -7141,11 +10632,12 @@ defmodule RegisterUser do
   |------|------| ------------|
   | first_name | string | The first name of the user; 1-64 characters. |
   | last_name | string | The last name of the user; 0-64 characters. |
+  | disable_notification | bool | Pass true to disable notification about the current user joining Telegram for other users that added them to contact list. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1register_user.html).
   """
 
-  defstruct "@type": "registerUser", "@extra": nil, first_name: nil, last_name: nil
+  defstruct "@type": "registerUser", "@extra": nil, first_name: nil, last_name: nil, disable_notification: nil
 end
 defmodule ReadFilePart do
   @moduledoc  """
@@ -7163,9 +10655,20 @@ defmodule ReadFilePart do
 
   defstruct "@type": "readFilePart", "@extra": nil, file_id: nil, offset: nil, count: nil
 end
+defmodule GetForumTopicDefaultIcons do
+  @moduledoc  """
+  Returns the list of custom emoji, which can be used as forum topic icon by all users.
+  Returns object_ptr<Stickers>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_forum_topic_default_icons.html).
+  """
+
+  defstruct "@type": "getForumTopicDefaultIcons", "@extra": nil
+end
 defmodule ToggleChatIsPinned do
   @moduledoc  """
-  Changes the pinned state of a chat. There can be up to GetOption("pinned_chat_count_max")/GetOption("pinned_archived_chat_count_max") pinned non-secret chats and the same number of secret chats in the main/archive chat list. The limit can be increased with Telegram Premium.
+  Changes the pinned state of a chat. There can be up to getOption("pinned_chat_count_max")/getOption("pinned_archived_chat_count_max") pinned non-secret chats and the same number of secret chats in the main/archive chat list. The limit can be increased with Telegram Premium.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
@@ -7178,17 +10681,6 @@ defmodule ToggleChatIsPinned do
   """
 
   defstruct "@type": "toggleChatIsPinned", "@extra": nil, chat_list: nil, chat_id: nil, is_pinned: nil
-end
-defmodule GetRecommendedChatFilters do
-  @moduledoc  """
-  Returns recommended chat filters for the current user.
-  Returns object_ptr<RecommendedChatFilters>.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_recommended_chat_filters.html).
-  """
-
-  defstruct "@type": "getRecommendedChatFilters", "@extra": nil
 end
 defmodule CheckCreatedPublicChatsLimit do
   @moduledoc  """
@@ -7204,9 +10696,24 @@ defmodule CheckCreatedPublicChatsLimit do
 
   defstruct "@type": "checkCreatedPublicChatsLimit", "@extra": nil, type: nil
 end
+defmodule SetStickerMaskPosition do
+  @moduledoc  """
+  Changes the mask position of a mask sticker. The sticker must belong to a mask sticker set that is owned by the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker | InputFile | Sticker. |
+  | mask_position | maskPosition | Position where the mask is placed; pass null to remove mask position. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_sticker_mask_position.html).
+  """
+
+  defstruct "@type": "setStickerMaskPosition", "@extra": nil, sticker: nil, mask_position: nil
+end
 defmodule GetChatInviteLinkCounts do
   @moduledoc  """
-  Returns list of chat administrators with number of their invite links. Requires owner privileges in the chat.
+  Returns the list of chat administrators with number of their invite links. Requires owner privileges in the chat.
   Returns object_ptr<ChatInviteLinkCounts>.
 
   | Name | Type | Description |
@@ -7246,6 +10753,21 @@ defmodule GetUserFullInfo do
 
   defstruct "@type": "getUserFullInfo", "@extra": nil, user_id: nil
 end
+defmodule DeleteChatBackground do
+  @moduledoc  """
+  Deletes background in a specific chat.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | restore_previous | bool | Pass true to restore previously set background. Can be used only in private and secret chats with non-deleted users if userFullInfo.set_chat_background == true. Supposed to be used from <a class="el" href="classtd_1_1td__api_1_1message_chat_set_background.html">messageChatSetBackground</a> messages with the currently set background that was set for both sides by the other user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_chat_background.html).
+  """
+
+  defstruct "@type": "deleteChatBackground", "@extra": nil, chat_id: nil, restore_previous: nil
+end
 defmodule EndGroupCallRecording do
   @moduledoc  """
   Ends recording of an active group call. Requires groupCall.can_be_managed group call flag.
@@ -7259,6 +10781,35 @@ defmodule EndGroupCallRecording do
   """
 
   defstruct "@type": "endGroupCallRecording", "@extra": nil, group_call_id: nil
+end
+defmodule ToggleGeneralForumTopicIsHidden do
+  @moduledoc  """
+  Toggles whether a General topic is hidden in a forum supergroup chat; requires can_manage_topics right in the supergroup.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | is_hidden | bool | Pass true to hide and close the General topic; pass false to unhide it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_general_forum_topic_is_hidden.html).
+  """
+
+  defstruct "@type": "toggleGeneralForumTopicIsHidden", "@extra": nil, chat_id: nil, is_hidden: nil
+end
+defmodule GetChatSponsoredMessages do
+  @moduledoc  """
+  Returns sponsored messages to be shown in a chat; for channel chats only.
+  Returns object_ptr<SponsoredMessages>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_chat_sponsored_messages.html).
+  """
+
+  defstruct "@type": "getChatSponsoredMessages", "@extra": nil, chat_id: nil
 end
 defmodule SetGroupCallTitle do
   @moduledoc  """
@@ -7274,6 +10825,20 @@ defmodule SetGroupCallTitle do
   """
 
   defstruct "@type": "setGroupCallTitle", "@extra": nil, group_call_id: nil, title: nil
+end
+defmodule SetReadDatePrivacySettings do
+  @moduledoc  """
+  Changes privacy settings for message read date.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | settings | readDatePrivacySettings | New settings. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_read_date_privacy_settings.html).
+  """
+
+  defstruct "@type": "setReadDatePrivacySettings", "@extra": nil, settings: nil
 end
 defmodule CheckPasswordRecoveryCode do
   @moduledoc  """
@@ -7311,16 +10876,15 @@ defmodule SendMessageAlbum do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Target chat. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the messages will be sent. |
-  | reply_to_message_id | int53 | Identifier of a replied message; 0 if none. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the messages will be sent. |
+  | reply_to | InputMessageReplyTo | Information about the message or story to be replied; pass null if none. |
   | options | messageSendOptions | Options to be used to send the messages; pass null to use default options. |
-  | input_message_contents | InputMessageContent | Contents of messages to be sent. At most 10 messages can be added to an album. |
-  | only_preview | bool | Pass true to get fake messages instead of actually sending them. |
+  | input_message_contents | InputMessageContent | Contents of messages to be sent. At most 10 messages can be added to an album. All messages must have the same value of show_caption_above_media. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1send_message_album.html).
   """
 
-  defstruct "@type": "sendMessageAlbum", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to_message_id: nil, options: nil, input_message_contents: nil, only_preview: nil
+  defstruct "@type": "sendMessageAlbum", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_to: nil, options: nil, input_message_contents: nil
 end
 defmodule TestCallString do
   @moduledoc  """
@@ -7376,6 +10940,36 @@ defmodule GetSavedAnimations do
 
   defstruct "@type": "getSavedAnimations", "@extra": nil
 end
+defmodule ToggleSavedMessagesTopicIsPinned do
+  @moduledoc  """
+  Changes the pinned state of a Saved Messages topic. There can be up to getOption("pinned_saved_messages_topic_count_max") pinned topics. The limit can be increased with Telegram Premium.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic to pin or unpin. |
+  | is_pinned | bool | Pass true to pin the topic; pass false to unpin it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_saved_messages_topic_is_pinned.html).
+  """
+
+  defstruct "@type": "toggleSavedMessagesTopicIsPinned", "@extra": nil, saved_messages_topic_id: nil, is_pinned: nil
+end
+defmodule SetApplicationVerificationToken do
+  @moduledoc  """
+  Application verification has been completed. Can be called before authorization.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | verification_id | int53 | Unique identifier for the verification process as received from <a class="el" href="classtd_1_1td__api_1_1update_application_verification_required.html">updateApplicationVerificationRequired</a>. |
+  | token | string | Play Integrity API token for the Android application, or secret from push notification for the iOS application; pass an empty string to abort verification and receive error VERIFICATION_FAILED for the request. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_application_verification_token.html).
+  """
+
+  defstruct "@type": "setApplicationVerificationToken", "@extra": nil, verification_id: nil, token: nil
+end
 defmodule GetBankCardInfo do
   @moduledoc  """
   Returns information about a bank card.
@@ -7390,6 +10984,67 @@ defmodule GetBankCardInfo do
 
   defstruct "@type": "getBankCardInfo", "@extra": nil, bank_card_number: nil
 end
+defmodule SetSupergroupUnrestrictBoostCount do
+  @moduledoc  """
+  Changes the number of times the supergroup must be boosted by a user to ignore slow mode and chat permission restrictions; requires can_restrict_members administrator right.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Identifier of the supergroup. |
+  | unrestrict_boost_count | int32 | New value of the unrestrict_boost_count supergroup setting; 0-8. Use 0 to remove the setting. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_supergroup_unrestrict_boost_count.html).
+  """
+
+  defstruct "@type": "setSupergroupUnrestrictBoostCount", "@extra": nil, supergroup_id: nil, unrestrict_boost_count: nil
+end
+defmodule ReportSupergroupAntiSpamFalsePositive do
+  @moduledoc  """
+  Reports a false deletion of a message by aggressive anti-spam checks; requires administrator rights in the supergroup. Can be called only for messages from chatEventMessageDeleted with can_report_anti_spam_false_positive == true.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | supergroup_id | int53 | Supergroup identifier. |
+  | message_id | int53 | Identifier of the erroneously deleted message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_supergroup_anti_spam_false_positive.html).
+  """
+
+  defstruct "@type": "reportSupergroupAntiSpamFalsePositive", "@extra": nil, supergroup_id: nil, message_id: nil
+end
+defmodule DeleteQuickReplyShortcutMessages do
+  @moduledoc  """
+  Deletes specified quick reply messages.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique identifier of the quick reply shortcut to which the messages belong. |
+  | message_ids | int53 | Unique identifiers of the messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1delete_quick_reply_shortcut_messages.html).
+  """
+
+  defstruct "@type": "deleteQuickReplyShortcutMessages", "@extra": nil, shortcut_id: nil, message_ids: nil
+end
+defmodule RemoveMessageReaction do
+  @moduledoc  """
+  Removes a reaction from a message. A chosen reaction can always be removed.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which the message belongs. |
+  | message_id | int53 | Identifier of the message. |
+  | reaction_type | ReactionType | Type of the reaction to remove. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1remove_message_reaction.html).
+  """
+
+  defstruct "@type": "removeMessageReaction", "@extra": nil, chat_id: nil, message_id: nil, reaction_type: nil
+end
 defmodule EditInlineMessageLiveLocation do
   @moduledoc  """
   Edits the content of a live location in an inline message sent via a bot; for bots only.
@@ -7400,13 +11055,14 @@ defmodule EditInlineMessageLiveLocation do
   | inline_message_id | string | Inline message identifier. |
   | reply_markup | ReplyMarkup | The new message reply markup; pass null if none. |
   | location | location | New location content of the message; pass null to stop sharing the live location. |
+  | live_period | int32 | New time relative to the message send date, for which the location can be updated, in seconds. If 0x7FFFFFFF specified, then the location can be updated forever. Otherwise, must not exceed the current live_period by more than a day, and the live location expiration date must remain in the next 90 days. Pass 0 to keep the current live_period. |
   | heading | int32 | The new direction in which the location moves, in degrees; 1-360. Pass 0 if unknown. |
   | proximity_alert_radius | int32 | The new maximum distance for proximity alerts, in meters (0-100000). Pass 0 if the notification is disabled. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1edit_inline_message_live_location.html).
   """
 
-  defstruct "@type": "editInlineMessageLiveLocation", "@extra": nil, inline_message_id: nil, reply_markup: nil, location: nil, heading: nil, proximity_alert_radius: nil
+  defstruct "@type": "editInlineMessageLiveLocation", "@extra": nil, inline_message_id: nil, reply_markup: nil, location: nil, live_period: nil, heading: nil, proximity_alert_radius: nil
 end
 defmodule SetInlineGameScore do
   @moduledoc  """
@@ -7426,6 +11082,25 @@ defmodule SetInlineGameScore do
 
   defstruct "@type": "setInlineGameScore", "@extra": nil, inline_message_id: nil, edit_message: nil, user_id: nil, score: nil, force: nil
 end
+defmodule GetForumTopics do
+  @moduledoc  """
+  Returns found forum topics in a forum chat. This is a temporary method for getting information about topic list from the server.
+  Returns object_ptr<ForumTopics>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the forum chat. |
+  | query | string | Query to search for in the forum topic's name. |
+  | offset_date | int32 | The date starting from which the results need to be fetched. Use 0 or any date in the future to get results from the last topic. |
+  | offset_message_id | int53 | The message identifier of the last message in the last found topic, or 0 for the first request. |
+  | offset_message_thread_id | int53 | The message thread identifier of the last found topic, or 0 for the first request. |
+  | limit | int32 | The maximum number of forum topics to be returned; up to 100. For optimal performance, the number of returned forum topics is chosen by TDLib and can be smaller than the specified limit. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_forum_topics.html).
+  """
+
+  defstruct "@type": "getForumTopics", "@extra": nil, chat_id: nil, query: nil, offset_date: nil, offset_message_id: nil, offset_message_thread_id: nil, limit: nil
+end
 defmodule GetPremiumState do
   @moduledoc  """
   Returns state of Telegram Premium subscription and promotion videos for Premium features.
@@ -7436,6 +11111,32 @@ defmodule GetPremiumState do
   """
 
   defstruct "@type": "getPremiumState", "@extra": nil
+end
+defmodule ToggleBusinessConnectedBotChatIsPaused do
+  @moduledoc  """
+  Pauses or resumes the connected business bot in a specific chat.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | is_paused | bool | Pass true to pause the connected bot in the chat; pass false to resume the bot. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1toggle_business_connected_bot_chat_is_paused.html).
+  """
+
+  defstruct "@type": "toggleBusinessConnectedBotChatIsPaused", "@extra": nil, chat_id: nil, is_paused: nil
+end
+defmodule GetDefaultChatEmojiStatuses do
+  @moduledoc  """
+  Returns default emoji statuses for chats.
+  Returns object_ptr<EmojiStatuses>.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1get_default_chat_emoji_statuses.html).
+  """
+
+  defstruct "@type": "getDefaultChatEmojiStatuses", "@extra": nil
 end
 defmodule TestReturnError do
   @moduledoc  """
@@ -7451,15 +11152,29 @@ defmodule TestReturnError do
 
   defstruct "@type": "testReturnError", "@extra": nil, error: nil
 end
+defmodule SetDefaultReactionType do
+  @moduledoc  """
+  Changes type of default reaction for the current user.
+  Returns object_ptr<Ok>.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reaction_type | ReactionType | New type of the default reaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_default_reaction_type.html).
+  """
+
+  defstruct "@type": "setDefaultReactionType", "@extra": nil, reaction_type: nil
+end
 defmodule SetChatAvailableReactions do
   @moduledoc  """
-  Changes reactions, available in a chat. Available for basic groups, supergroups, and channels. Requires can_change_info administrator right.
+  Changes reactions, available in a chat. Available for basic groups, supergroups, and channels. Requires can_change_info member right.
   Returns object_ptr<Ok>.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat. |
-  | available_reactions | string | New list of reactions, available in the chat. All reactions must be active. |
+  | available_reactions | ChatAvailableReactions | Reactions available in the chat. All explicitly specified emoji reactions must be active. In channel chats up to the chat's boost level custom emoji reactions can be explicitly specified. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1set_chat_available_reactions.html).
   """
@@ -7498,7 +11213,7 @@ defmodule GetMessage do
 end
 defmodule GetRepliedMessage do
   @moduledoc  """
-  Returns information about a message that is replied by a given message. Also returns the pinned message, the game message, and the invoice message for messages of the types messagePinMessage, messageGameScore, and messagePaymentSuccessful respectively.
+  Returns information about a non-bundled message that is replied by a given message. Also, returns the pinned message, the game message, the invoice message, the message with a previously set same background, the giveaway message, and the topic creation message for messages of the types messagePinMessage, messageGameScore, messagePaymentSuccessful, messageChatSetBackground, messagePremiumGiveawayCompleted and topic messages without non-bundled replied message respectively.
   Returns object_ptr<Message>.
 
   | Name | Type | Description |

--- a/lib/tdlib/object.ex
+++ b/lib/tdlib/object.ex
@@ -1,8 +1,17 @@
 defmodule TDLib.Object do
   @moduledoc """
   This module was generated using Telegram's TDLib documentation. It contains
-  1154 submodules (= structs).
+  1679 submodules (= structs).
   """
+defmodule SavedMessagesTopicType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_saved_messages_topic_type.html).
+  """
+
+  defstruct "@type": "SavedMessagesTopicType", "@extra": nil
+end
 defmodule UpdateMessageContent do
   @moduledoc  """
   The message content has changed.
@@ -63,6 +72,29 @@ defmodule UpdateChatActionBar do
 
   defstruct "@type": "updateChatActionBar", "@extra": nil, chat_id: nil, action_bar: nil
 end
+defmodule InternalLinkTypeDefaultMessageAutoDeleteTimerSettings do
+  @moduledoc  """
+  The link is a link to the default message auto-delete timer settings section of the app settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_default_message_auto_delete_timer_settings.html).
+  """
+
+  defstruct "@type": "internalLinkTypeDefaultMessageAutoDeleteTimerSettings", "@extra": nil
+end
+defmodule InputChatPhotoSticker do
+  @moduledoc  """
+  A sticker on a custom background.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker | chatPhotoSticker | Information about the sticker. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_chat_photo_sticker.html).
+  """
+
+  defstruct "@type": "inputChatPhotoSticker", "@extra": nil, sticker: nil
+end
 defmodule DatedFile do
   @moduledoc  """
   File with the date it was uploaded.
@@ -76,6 +108,19 @@ defmodule DatedFile do
   """
 
   defstruct "@type": "datedFile", "@extra": nil, file: nil, date: nil
+end
+defmodule SuggestedActionExtendPremium do
+  @moduledoc  """
+  Suggests the user to extend their expiring Telegram Premium subscription.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | manage_premium_subscription_url | string | A URL for managing Telegram Premium subscription. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_extend_premium.html).
+  """
+
+  defstruct "@type": "suggestedActionExtendPremium", "@extra": nil, manage_premium_subscription_url: nil
 end
 defmodule SessionTypeChrome do
   @moduledoc  """
@@ -96,44 +141,55 @@ defmodule Message do
   | id | int53 | Message identifier; unique for the chat to which the message belongs. |
   | sender_id | MessageSender | Identifier of the sender of the message. |
   | chat_id | int53 | Chat identifier. |
-  | sending_state | MessageSendingState | The sending state of the message; may be null. |
-  | scheduling_state | MessageSchedulingState | The scheduling state of the message; may be null. |
+  | sending_state | MessageSendingState | The sending state of the message; may be null if the message isn't being sent and didn't fail to be sent. |
+  | scheduling_state | MessageSchedulingState | The scheduling state of the message; may be null if the message isn't scheduled. |
   | is_outgoing | bool | True, if the message is outgoing. |
   | is_pinned | bool | True, if the message is pinned. |
+  | is_from_offline | bool | True, if the message was sent because of a scheduled action by the message sender, for example, as away, or greeting service message. |
   | can_be_edited | bool | True, if the message can be edited. For live location and poll messages this fields shows whether <a class="el" href="classtd_1_1td__api_1_1edit_message_live_location.html">editMessageLiveLocation</a> or <a class="el" href="classtd_1_1td__api_1_1stop_poll.html">stopPoll</a> can be used with this message by the application. |
   | can_be_forwarded | bool | True, if the message can be forwarded. |
+  | can_be_replied_in_another_chat | bool | True, if the message can be replied in another chat or topic. |
   | can_be_saved | bool | True, if content of the message can be saved locally or copied. |
   | can_be_deleted_only_for_self | bool | True, if the message can be deleted only for the current user while other users will continue to see it. |
   | can_be_deleted_for_all_users | bool | True, if the message can be deleted for all users. |
   | can_get_added_reactions | bool | True, if the list of added reactions is available through <a class="el" href="classtd_1_1td__api_1_1get_message_added_reactions.html">getMessageAddedReactions</a>. |
   | can_get_statistics | bool | True, if the message statistics are available through <a class="el" href="classtd_1_1td__api_1_1get_message_statistics.html">getMessageStatistics</a>. |
-  | can_get_message_thread | bool | True, if information about the message thread is available through <a class="el" href="classtd_1_1td__api_1_1get_message_thread.html">getMessageThread</a>. |
+  | can_get_message_thread | bool | True, if information about the message thread is available through <a class="el" href="classtd_1_1td__api_1_1get_message_thread.html">getMessageThread</a> and <a class="el" href="classtd_1_1td__api_1_1get_message_thread_history.html">getMessageThreadHistory</a>. |
+  | can_get_read_date | bool | True, if read date of the message can be received through <a class="el" href="classtd_1_1td__api_1_1get_message_read_date.html">getMessageReadDate</a>. |
   | can_get_viewers | bool | True, if chat members already viewed the message can be received through <a class="el" href="classtd_1_1td__api_1_1get_message_viewers.html">getMessageViewers</a>. |
   | can_get_media_timestamp_links | bool | True, if media timestamp links can be generated for media timestamp entities in the message text, caption or web page description through <a class="el" href="classtd_1_1td__api_1_1get_message_link.html">getMessageLink</a>. |
+  | can_report_reactions | bool | True, if reactions on the message can be reported through <a class="el" href="classtd_1_1td__api_1_1report_message_reactions.html">reportMessageReactions</a>. |
   | has_timestamped_media | bool | True, if media timestamp entities refers to a media in this message as opposed to a media in the replied message. |
   | is_channel_post | bool | True, if the message is a channel post. All messages to channels are channel posts, all other messages are not channel posts. |
+  | is_topic_message | bool | True, if the message is a forum topic message. |
   | contains_unread_mention | bool | True, if the message contains an unread mention for the current user. |
   | date | int32 | Point in time (Unix timestamp) when the message was sent. |
   | edit_date | int32 | Point in time (Unix timestamp) when the message was last edited. |
-  | forward_info | messageForwardInfo | Information about the initial message sender; may be null. |
-  | interaction_info | messageInteractionInfo | Information about interactions with the message; may be null. |
+  | forward_info | messageForwardInfo | Information about the initial message sender; may be null if none or unknown. |
+  | import_info | messageImportInfo | Information about the initial message for messages created with <a class="el" href="classtd_1_1td__api_1_1import_messages.html">importMessages</a>; may be null if the message isn't imported. |
+  | interaction_info | messageInteractionInfo | Information about interactions with the message; may be null if none. |
   | unread_reactions | unreadReaction | Information about unread reactions added to the message. |
-  | reply_in_chat_id | int53 | If non-zero, the identifier of the chat to which the replied message belongs; Currently, only messages in the Replies chat can have different reply_in_chat_id and chat_id. |
-  | reply_to_message_id | int53 | If non-zero, the identifier of the message this message is replying to; can be the identifier of a deleted message. |
+  | fact_check | factCheck | Information about fact-check added to the message; may be null if none. |
+  | reply_to | MessageReplyTo | Information about the message or the story this message is replying to; may be null if none. |
   | message_thread_id | int53 | If non-zero, the identifier of the message thread the message belongs to; unique within the chat to which the message belongs. |
-  | ttl | int32 | For self-destructing messages, the message's TTL (Time To Live), in seconds; 0 if none. TDLib will send <a class="el" href="classtd_1_1td__api_1_1update_delete_messages.html">updateDeleteMessages</a> or <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> once the TTL expires. |
-  | ttl_expires_in | double | Time left before the message expires, in seconds. If the TTL timer isn't started yet, equals to the value of the ttl field. |
-  | via_bot_user_id | int53 | If non-zero, the user identifier of the bot through which this message was sent. |
+  | saved_messages_topic_id | int53 | Identifier of the Saved Messages topic for the message; 0 for messages not from Saved Messages. |
+  | self_destruct_type | MessageSelfDestructType | The message's self-destruct type; may be null if none. |
+  | self_destruct_in | double | Time left before the message self-destruct timer expires, in seconds; 0 if self-destruction isn't scheduled yet. |
+  | auto_delete_in | double | Time left before the message will be automatically deleted by message_auto_delete_time setting of the chat, in seconds; 0 if never. |
+  | via_bot_user_id | int53 | If non-zero, the user identifier of the inline bot through which this message was sent. |
+  | sender_business_bot_user_id | int53 | If non-zero, the user identifier of the business bot that sent this message. |
+  | sender_boost_count | int32 | Number of times the sender of the message boosted the supergroup at the time the message was sent; 0 if none or unknown. For messages sent by the current user, supergroupFullInfo.my_boost_count must be used instead. |
   | author_signature | string | For channel posts and anonymous group messages, optional author signature. |
-  | media_album_id | int64 | Unique identifier of an album this message belongs to. Only audios, documents, photos and videos can be grouped together in albums. |
+  | media_album_id | int64 | Unique identifier of an album this message belongs to; 0 if none. Only audios, documents, photos and videos can be grouped together in albums. |
+  | effect_id | int64 | Unique identifier of the effect added to the message; 0 if none. |
   | restriction_reason | string | If non-empty, contains a human-readable description of the reason why access to this message must be restricted. |
   | content | MessageContent | Content of the message. |
-  | reply_markup | ReplyMarkup | Reply markup for the message; may be null. |
+  | reply_markup | ReplyMarkup | Reply markup for the message; may be null if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message.html).
   """
 
-  defstruct "@type": "message", "@extra": nil, id: nil, sender_id: nil, chat_id: nil, sending_state: nil, scheduling_state: nil, is_outgoing: nil, is_pinned: nil, can_be_edited: nil, can_be_forwarded: nil, can_be_saved: nil, can_be_deleted_only_for_self: nil, can_be_deleted_for_all_users: nil, can_get_added_reactions: nil, can_get_statistics: nil, can_get_message_thread: nil, can_get_viewers: nil, can_get_media_timestamp_links: nil, has_timestamped_media: nil, is_channel_post: nil, contains_unread_mention: nil, date: nil, edit_date: nil, forward_info: nil, interaction_info: nil, unread_reactions: nil, reply_in_chat_id: nil, reply_to_message_id: nil, message_thread_id: nil, ttl: nil, ttl_expires_in: nil, via_bot_user_id: nil, author_signature: nil, media_album_id: nil, restriction_reason: nil, content: nil, reply_markup: nil
+  defstruct "@type": "message", "@extra": nil, id: nil, sender_id: nil, chat_id: nil, sending_state: nil, scheduling_state: nil, is_outgoing: nil, is_pinned: nil, is_from_offline: nil, can_be_edited: nil, can_be_forwarded: nil, can_be_replied_in_another_chat: nil, can_be_saved: nil, can_be_deleted_only_for_self: nil, can_be_deleted_for_all_users: nil, can_get_added_reactions: nil, can_get_statistics: nil, can_get_message_thread: nil, can_get_read_date: nil, can_get_viewers: nil, can_get_media_timestamp_links: nil, can_report_reactions: nil, has_timestamped_media: nil, is_channel_post: nil, is_topic_message: nil, contains_unread_mention: nil, date: nil, edit_date: nil, forward_info: nil, import_info: nil, interaction_info: nil, unread_reactions: nil, fact_check: nil, reply_to: nil, message_thread_id: nil, saved_messages_topic_id: nil, self_destruct_type: nil, self_destruct_in: nil, auto_delete_in: nil, via_bot_user_id: nil, sender_business_bot_user_id: nil, sender_boost_count: nil, author_signature: nil, media_album_id: nil, effect_id: nil, restriction_reason: nil, content: nil, reply_markup: nil
 end
 defmodule PassportElementTypeInternalPassport do
   @moduledoc  """
@@ -145,6 +201,16 @@ defmodule PassportElementTypeInternalPassport do
 
   defstruct "@type": "passportElementTypeInternalPassport", "@extra": nil
 end
+defmodule CanSendMessageToUserResultUserIsDeleted do
+  @moduledoc  """
+  The user can't be messaged, because they are deleted or unknown.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_message_to_user_result_user_is_deleted.html).
+  """
+
+  defstruct "@type": "canSendMessageToUserResultUserIsDeleted", "@extra": nil
+end
 defmodule SponsoredMessage do
   @moduledoc  """
   Describes a sponsored message.
@@ -153,15 +219,19 @@ defmodule SponsoredMessage do
   |------|------| ------------|
   | message_id | int53 | Message identifier; unique for the chat to which the sponsored message belongs among both ordinary and sponsored messages. |
   | is_recommended | bool | True, if the message needs to be labeled as "recommended" instead of "sponsored". |
-  | sponsor_chat_id | int53 | Sponsor chat identifier; 0 if the sponsor chat is accessible through an invite link. |
-  | sponsor_chat_info | chatInviteLinkInfo | Information about the sponsor chat; may be null unless sponsor_chat_id == 0. |
-  | link | InternalLinkType | An internal link to be opened when the sponsored message is clicked; may be null if the sponsor chat needs to be opened instead. |
+  | can_be_reported | bool | True, if the message can be reported to Telegram moderators through <a class="el" href="classtd_1_1td__api_1_1report_chat_sponsored_message.html">reportChatSponsoredMessage</a>. |
   | content | MessageContent | Content of the message. Currently, can be only of the type <a class="el" href="classtd_1_1td__api_1_1message_text.html">messageText</a>. |
+  | sponsor | messageSponsor | Information about the sponsor of the message. |
+  | title | string | Title of the sponsored message. |
+  | button_text | string | Text for the message action button. |
+  | accent_color_id | int32 | Identifier of the accent color for title, button text and message background. |
+  | background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the message background; 0 if none. |
+  | additional_info | string | If non-empty, additional information about the sponsored message to be shown along with the message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sponsored_message.html).
   """
 
-  defstruct "@type": "sponsoredMessage", "@extra": nil, message_id: nil, is_recommended: nil, sponsor_chat_id: nil, sponsor_chat_info: nil, link: nil, content: nil
+  defstruct "@type": "sponsoredMessage", "@extra": nil, message_id: nil, is_recommended: nil, can_be_reported: nil, content: nil, sponsor: nil, title: nil, button_text: nil, accent_color_id: nil, background_custom_emoji_id: nil, additional_info: nil
 end
 defmodule CallProblemDistortedSpeech do
   @moduledoc  """
@@ -173,15 +243,29 @@ defmodule CallProblemDistortedSpeech do
 
   defstruct "@type": "callProblemDistortedSpeech", "@extra": nil
 end
-defmodule StickerTypeVideo do
+defmodule EmojiCategoryTypeChatPhoto do
   @moduledoc  """
-  The sticker is a video in WEBM format.
+  The category must be used for chat photo emoji selection.
 
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_video.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_type_chat_photo.html).
   """
 
-  defstruct "@type": "stickerTypeVideo", "@extra": nil
+  defstruct "@type": "emojiCategoryTypeChatPhoto", "@extra": nil
+end
+defmodule UpdateChatRevenueAmount do
+  @moduledoc  """
+  The revenue earned from sponsored messages in a chat has changed. If chat revenue screen is opened, then getChatRevenueTransactions may be called to fetch new transactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+  | revenue_amount | chatRevenueAmount | New amount of earned revenue. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_revenue_amount.html).
+  """
+
+  defstruct "@type": "updateChatRevenueAmount", "@extra": nil, chat_id: nil, revenue_amount: nil
 end
 defmodule InputPassportElementIdentityCard do
   @moduledoc  """
@@ -211,12 +295,12 @@ defmodule RichTextUnderline do
 end
 defmodule Game do
   @moduledoc  """
-  Describes a game.
+  Describes a game. Use getInternalLink with internalLinkTypeGame to share the game.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | id | int64 | Game ID. |
-  | short_name | string | Game short name. To share a game use the URL <a href="https://t.me/{bot_username}?game={game_short_name}">https://t.me/{bot_username}?game={game_short_name}</a>. |
+  | id | int64 | Unique game identifier. |
+  | short_name | string | Game short name. |
   | title | string | Game title. |
   | text | formattedText | Game text, usually containing scoreboards for a game. |
   | description | string | Game description. |
@@ -227,16 +311,6 @@ defmodule Game do
   """
 
   defstruct "@type": "game", "@extra": nil, id: nil, short_name: nil, title: nil, text: nil, description: nil, photo: nil, animation: nil
-end
-defmodule ChatReportReasonViolence do
-  @moduledoc  """
-  The chat promotes violence.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_violence.html).
-  """
-
-  defstruct "@type": "chatReportReasonViolence", "@extra": nil
 end
 defmodule StorageStatisticsFast do
   @moduledoc  """
@@ -254,6 +328,38 @@ defmodule StorageStatisticsFast do
   """
 
   defstruct "@type": "storageStatisticsFast", "@extra": nil, files_size: nil, file_count: nil, database_size: nil, language_pack_database_size: nil, log_size: nil
+end
+defmodule CheckChatUsernameResultUsernamePurchasable do
+  @moduledoc  """
+  The username can be purchased at https://fragment.com. Information about the username can be received using getCollectibleItemInfo.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_chat_username_result_username_purchasable.html).
+  """
+
+  defstruct "@type": "checkChatUsernameResultUsernamePurchasable", "@extra": nil
+end
+defmodule EmojiReaction do
+  @moduledoc  """
+  Contains information about an emoji reaction.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji | string | Text representation of the reaction. |
+  | title | string | Reaction title. |
+  | is_active | bool | True, if the reaction can be added to new messages and enabled in chats. |
+  | static_icon | sticker | Static icon for the reaction. |
+  | appear_animation | sticker | Appear animation for the reaction. |
+  | select_animation | sticker | Select animation for the reaction. |
+  | activate_animation | sticker | Activate animation for the reaction. |
+  | effect_animation | sticker | Effect animation for the reaction. |
+  | around_animation | sticker | Around animation for the reaction; may be null. |
+  | center_animation | sticker | Center animation for the reaction; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_reaction.html).
+  """
+
+  defstruct "@type": "emojiReaction", "@extra": nil, emoji: nil, title: nil, is_active: nil, static_icon: nil, appear_animation: nil, select_animation: nil, activate_animation: nil, effect_animation: nil, around_animation: nil, center_animation: nil
 end
 defmodule ChatMemberStatusMember do
   @moduledoc  """
@@ -273,7 +379,7 @@ defmodule UpdateLanguagePackStrings do
   |------|------| ------------|
   | localization_target | string | Localization target to which the language pack belongs. |
   | language_pack_id | string | Identifier of the updated language pack. |
-  | strings | languagePackString | List of changed language pack strings. |
+  | strings | languagePackString | List of changed language pack strings; empty if all strings have changed. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_language_pack_strings.html).
   """
@@ -282,7 +388,7 @@ defmodule UpdateLanguagePackStrings do
 end
 defmodule InternalLinkTypeBackground do
   @moduledoc  """
-  The link is a link to a background. Call searchBackground with the given background name to process the link.
+  The link is a link to a background. Call searchBackground with the given background name to process the link If background is found and the user wants to apply it, then call setDefaultBackground.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -292,6 +398,24 @@ defmodule InternalLinkTypeBackground do
   """
 
   defstruct "@type": "internalLinkTypeBackground", "@extra": nil, background_name: nil
+end
+defmodule PaymentReceiptTypeRegular do
+  @moduledoc  """
+  The payment was done using a third-party payment provider.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | payment_provider_user_id | int53 | User identifier of the payment provider bot. |
+  | invoice | invoice | Information about the invoice. |
+  | order_info | orderInfo | Order information; may be null. |
+  | shipping_option | shippingOption | Chosen shipping option; may be null. |
+  | credentials_title | string | Title of the saved credentials chosen by the buyer. |
+  | tip_amount | int53 | The amount of tip chosen by the buyer in the smallest units of the currency. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_receipt_type_regular.html).
+  """
+
+  defstruct "@type": "paymentReceiptTypeRegular", "@extra": nil, payment_provider_user_id: nil, invoice: nil, order_info: nil, shipping_option: nil, credentials_title: nil, tip_amount: nil
 end
 defmodule PassportElementErrorSourceFile do
   @moduledoc  """
@@ -308,7 +432,7 @@ defmodule PassportElementErrorSourceFile do
 end
 defmodule PremiumFeatureAppIcons do
   @moduledoc  """
-  Allowed to set a premium appllication icons.
+  Allowed to set a premium application icons.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_app_icons.html).
@@ -318,7 +442,7 @@ defmodule PremiumFeatureAppIcons do
 end
 defmodule InternalLinkTypeChatInvite do
   @moduledoc  """
-  The link is a chat invite link. Call checkChatInviteLink with the given invite link to process the link.
+  The link is a chat invite link. Call checkChatInviteLink with the given invite link to process the link. If the link is valid and the user wants to join the chat, then call joinChatByInviteLink.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -365,6 +489,15 @@ defmodule PageBlockPullQuote do
 
   defstruct "@type": "pageBlockPullQuote", "@extra": nil, text: nil, credit: nil
 end
+defmodule InputStoryContent do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_input_story_content.html).
+  """
+
+  defstruct "@type": "InputStoryContent", "@extra": nil
+end
 defmodule UpdateCall do
   @moduledoc  """
   New call was created or information about a call was updated.
@@ -377,6 +510,62 @@ defmodule UpdateCall do
   """
 
   defstruct "@type": "updateCall", "@extra": nil, call: nil
+end
+defmodule PremiumFeatureSavedMessagesTags do
+  @moduledoc  """
+  The ability to use tags in Saved Messages.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_saved_messages_tags.html).
+  """
+
+  defstruct "@type": "premiumFeatureSavedMessagesTags", "@extra": nil
+end
+defmodule QuickReplyMessage do
+  @moduledoc  """
+  Describes a message that can be used for quick reply.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int53 | Unique message identifier among all quick replies. |
+  | sending_state | MessageSendingState | The sending state of the message; may be null if the message isn't being sent and didn't fail to be sent. |
+  | can_be_edited | bool | True, if the message can be edited. |
+  | reply_to_message_id | int53 | The identifier of the quick reply message to which the message replies; 0 if none. |
+  | via_bot_user_id | int53 | If non-zero, the user identifier of the bot through which this message was sent. |
+  | media_album_id | int64 | Unique identifier of an album this message belongs to; 0 if none. Only audios, documents, photos and videos can be grouped together in albums. |
+  | content | MessageContent | Content of the message. |
+  | reply_markup | ReplyMarkup | Inline keyboard reply markup for the message; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1quick_reply_message.html).
+  """
+
+  defstruct "@type": "quickReplyMessage", "@extra": nil, id: nil, sending_state: nil, can_be_edited: nil, reply_to_message_id: nil, via_bot_user_id: nil, media_album_id: nil, content: nil, reply_markup: nil
+end
+defmodule InviteLinkChatType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_invite_link_chat_type.html).
+  """
+
+  defstruct "@type": "InviteLinkChatType", "@extra": nil
+end
+defmodule MessageExtendedMediaPreview do
+  @moduledoc  """
+  The media is hidden until the invoice is paid.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | width | int32 | Media width; 0 if unknown. |
+  | height | int32 | Media height; 0 if unknown. |
+  | duration | int32 | Media duration, in seconds; 0 if unknown. |
+  | minithumbnail | minithumbnail | Media minithumbnail; may be null. |
+  | caption | formattedText | Media caption. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_extended_media_preview.html).
+  """
+
+  defstruct "@type": "messageExtendedMediaPreview", "@extra": nil, width: nil, height: nil, duration: nil, minithumbnail: nil, caption: nil
 end
 defmodule PushMessageContentHidden do
   @moduledoc  """
@@ -476,18 +665,36 @@ defmodule DeviceTokenSimplePush do
 
   defstruct "@type": "deviceTokenSimplePush", "@extra": nil, endpoint: nil
 end
-defmodule AvailableReactions do
+defmodule InputBackgroundPrevious do
   @moduledoc  """
-  Represents a list of available reactions.
+  A background previously set in the chat; for chat backgrounds only.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reactions | availableReaction | List of reactions. |
+  | message_id | int53 | Identifier of the message with the background. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_background_previous.html).
+  """
+
+  defstruct "@type": "inputBackgroundPrevious", "@extra": nil, message_id: nil
+end
+defmodule AvailableReactions do
+  @moduledoc  """
+  Represents a list of reactions that can be added to a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | top_reactions | availableReaction | List of reactions to be shown at the top. |
+  | recent_reactions | availableReaction | List of recently used reactions. |
+  | popular_reactions | availableReaction | List of popular reactions. |
+  | allow_custom_emoji | bool | True, if any custom emoji reaction can be added by Telegram Premium subscribers. |
+  | are_tags | bool | True, if the reactions will be tags and the message can be found by them. |
+  | unavailability_reason | ReactionUnavailabilityReason | The reason why the current user can't add reactions to the message, despite some other users can; may be null if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1available_reactions.html).
   """
 
-  defstruct "@type": "availableReactions", "@extra": nil, reactions: nil
+  defstruct "@type": "availableReactions", "@extra": nil, top_reactions: nil, recent_reactions: nil, popular_reactions: nil, allow_custom_emoji: nil, are_tags: nil, unavailability_reason: nil
 end
 defmodule ChatEventMemberInvited do
   @moduledoc  """
@@ -502,6 +709,20 @@ defmodule ChatEventMemberInvited do
   """
 
   defstruct "@type": "chatEventMemberInvited", "@extra": nil, user_id: nil, status: nil
+end
+defmodule InlineQueryResultsButton do
+  @moduledoc  """
+  Represents a button to be shown above inline query results.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | string | The text of the button. |
+  | type | InlineQueryResultsButtonType | Type of the button. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1inline_query_results_button.html).
+  """
+
+  defstruct "@type": "inlineQueryResultsButton", "@extra": nil, text: nil, type: nil
 end
 defmodule AutoDownloadSettingsPresets do
   @moduledoc  """
@@ -541,6 +762,16 @@ defmodule TopChatCategoryChannels do
 
   defstruct "@type": "topChatCategoryChannels", "@extra": nil
 end
+defmodule UserPrivacySettingRuleAllowPremiumUsers do
+  @moduledoc  """
+  A rule to allow all Premium Users to do something; currently, allowed only for userPrivacySettingAllowChatInvites.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_rule_allow_premium_users.html).
+  """
+
+  defstruct "@type": "userPrivacySettingRuleAllowPremiumUsers", "@extra": nil
+end
 defmodule ClosedVectorPath do
   @moduledoc  """
   Represents a closed vector path. The path begins at the end point of the last command.
@@ -577,6 +808,19 @@ defmodule UserStatusOnline do
 
   defstruct "@type": "userStatusOnline", "@extra": nil, expires: nil
 end
+defmodule PremiumSourceBusinessFeature do
+  @moduledoc  """
+  A user tried to use a Business feature.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | feature | BusinessFeature | The used feature; pass null if none specific feature was used. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_source_business_feature.html).
+  """
+
+  defstruct "@type": "premiumSourceBusinessFeature", "@extra": nil, feature: nil
+end
 defmodule MessageFileType do
   @moduledoc  """
 
@@ -596,6 +840,16 @@ defmodule TextEntityTypeBankCardNumber do
 
   defstruct "@type": "textEntityTypeBankCardNumber", "@extra": nil
 end
+defmodule AutosaveSettingsScopeChannelChats do
+  @moduledoc  """
+  Autosave settings applied to all channel chats without chat-specific settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings_scope_channel_chats.html).
+  """
+
+  defstruct "@type": "autosaveSettingsScopeChannelChats", "@extra": nil
+end
 defmodule ChatTypeSupergroup do
   @moduledoc  """
   A supergroup or channel (with unlimited members).
@@ -609,6 +863,25 @@ defmodule ChatTypeSupergroup do
   """
 
   defstruct "@type": "chatTypeSupergroup", "@extra": nil, supergroup_id: nil, is_channel: nil
+end
+defmodule StoryAreaType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_area_type.html).
+  """
+
+  defstruct "@type": "StoryAreaType", "@extra": nil
+end
+defmodule StickerTypeCustomEmoji do
+  @moduledoc  """
+  The sticker is a custom emoji to be used inside message text and caption.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_custom_emoji.html).
+  """
+
+  defstruct "@type": "stickerTypeCustomEmoji", "@extra": nil
 end
 defmodule MessageAnimatedEmoji do
   @moduledoc  """
@@ -638,6 +911,15 @@ defmodule WebAppInfo do
 
   defstruct "@type": "webAppInfo", "@extra": nil, launch_id: nil, url: nil
 end
+defmodule PhoneNumberCodeType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_phone_number_code_type.html).
+  """
+
+  defstruct "@type": "PhoneNumberCodeType", "@extra": nil
+end
 defmodule TopChatCategoryGroups do
   @moduledoc  """
   A category containing frequently used basic groups and supergroups.
@@ -650,13 +932,27 @@ defmodule TopChatCategoryGroups do
 end
 defmodule MessageExpiredVideo do
   @moduledoc  """
-  An expired video message (self-destructed after TTL has elapsed).
+  A self-destructed video message.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_expired_video.html).
   """
 
   defstruct "@type": "messageExpiredVideo", "@extra": nil
+end
+defmodule AuthenticationCodeTypeFragment do
+  @moduledoc  """
+  A digit-only authentication code is delivered to https://fragment.com. The user must be logged in there via a wallet owning the phone number's NFT.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | URL to open to receive the code. |
+  | length | int32 | Length of the code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authentication_code_type_fragment.html).
+  """
+
+  defstruct "@type": "authenticationCodeTypeFragment", "@extra": nil, url: nil, length: nil
 end
 defmodule TargetChatCurrent do
   @moduledoc  """
@@ -667,6 +963,16 @@ defmodule TargetChatCurrent do
   """
 
   defstruct "@type": "targetChatCurrent", "@extra": nil
+end
+defmodule BlockListStories do
+  @moduledoc  """
+  The block list that disallows viewing of stories of the current user.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1block_list_stories.html).
+  """
+
+  defstruct "@type": "blockListStories", "@extra": nil
 end
 defmodule InputInlineQueryResultDocument do
   @moduledoc  """
@@ -690,6 +996,16 @@ defmodule InputInlineQueryResultDocument do
 
   defstruct "@type": "inputInlineQueryResultDocument", "@extra": nil, id: nil, title: nil, description: nil, document_url: nil, mime_type: nil, thumbnail_url: nil, thumbnail_width: nil, thumbnail_height: nil, reply_markup: nil, input_message_content: nil
 end
+defmodule PremiumLimitTypePinnedSavedMessagesTopicCount do
+  @moduledoc  """
+  The maximum number of pinned Saved Messages topics.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_pinned_saved_messages_topic_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypePinnedSavedMessagesTopicCount", "@extra": nil
+end
 defmodule SecretChatStateClosed do
   @moduledoc  """
   The secret chat is closed.
@@ -712,6 +1028,15 @@ defmodule ResetPasswordResultPending do
   """
 
   defstruct "@type": "resetPasswordResultPending", "@extra": nil, pending_reset_date: nil
+end
+defmodule MessageSelfDestructType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_self_destruct_type.html).
+  """
+
+  defstruct "@type": "MessageSelfDestructType", "@extra": nil
 end
 defmodule TargetChatChosen do
   @moduledoc  """
@@ -818,13 +1143,23 @@ defmodule UpdateNotificationGroup do
   | notification_settings_chat_id | int53 | Chat identifier, which notification settings must be applied to the added notifications. |
   | notification_sound_id | int64 | Identifier of the notification sound to be played; 0 if sound is disabled. |
   | total_count | int32 | Total number of unread notifications in the group, can be bigger than number of active notifications. |
-  | added_notifications | notification | List of added group notifications, sorted by notification ID. |
-  | removed_notification_ids | int32 | Identifiers of removed group notifications, sorted by notification ID. |
+  | added_notifications | notification | List of added group notifications, sorted by notification identifier. |
+  | removed_notification_ids | int32 | Identifiers of removed group notifications, sorted by notification identifier. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_notification_group.html).
   """
 
   defstruct "@type": "updateNotificationGroup", "@extra": nil, notification_group_id: nil, type: nil, chat_id: nil, notification_settings_chat_id: nil, notification_sound_id: nil, total_count: nil, added_notifications: nil, removed_notification_ids: nil
+end
+defmodule MessageReadDateTooOld do
+  @moduledoc  """
+  The message is too old to get read date.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_read_date_too_old.html).
+  """
+
+  defstruct "@type": "messageReadDateTooOld", "@extra": nil
 end
 defmodule DatabaseStatistics do
   @moduledoc  """
@@ -839,6 +1174,21 @@ defmodule DatabaseStatistics do
 
   defstruct "@type": "databaseStatistics", "@extra": nil, statistics: nil
 end
+defmodule StarRevenueStatistics do
+  @moduledoc  """
+  A detailed statistics about Telegram stars earned by a bot or a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | revenue_by_day_graph | StatisticalGraph | A graph containing amount of revenue in a given day. |
+  | status | starRevenueStatus | Telegram star revenue status. |
+  | usd_rate | double | Current conversion rate of a Telegram star to USD. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_revenue_statistics.html).
+  """
+
+  defstruct "@type": "starRevenueStatistics", "@extra": nil, revenue_by_day_graph: nil, status: nil, usd_rate: nil
+end
 defmodule PageBlockVerticalAlignment do
   @moduledoc  """
 
@@ -848,6 +1198,15 @@ defmodule PageBlockVerticalAlignment do
 
   defstruct "@type": "PageBlockVerticalAlignment", "@extra": nil
 end
+defmodule PremiumStoryFeature do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_premium_story_feature.html).
+  """
+
+  defstruct "@type": "PremiumStoryFeature", "@extra": nil
+end
 defmodule ReplyMarkupShowKeyboard do
   @moduledoc  """
   Contains a custom keyboard layout to quickly reply to bots.
@@ -855,6 +1214,7 @@ defmodule ReplyMarkupShowKeyboard do
   | Name | Type | Description |
   |------|------| ------------|
   | rows | keyboardButton | A list of rows of bot keyboard buttons. |
+  | is_persistent | bool | True, if the keyboard is supposed to always be shown when the ordinary keyboard is hidden. |
   | resize_keyboard | bool | True, if the application needs to resize the keyboard vertically. |
   | one_time | bool | True, if the application needs to hide the keyboard after use. |
   | is_personal | bool | True, if the keyboard must automatically be shown to the current user. For outgoing messages, specify true to show the keyboard only for the mentioned users and for the target user of a reply. |
@@ -863,7 +1223,7 @@ defmodule ReplyMarkupShowKeyboard do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reply_markup_show_keyboard.html).
   """
 
-  defstruct "@type": "replyMarkupShowKeyboard", "@extra": nil, rows: nil, resize_keyboard: nil, one_time: nil, is_personal: nil, input_field_placeholder: nil
+  defstruct "@type": "replyMarkupShowKeyboard", "@extra": nil, rows: nil, is_persistent: nil, resize_keyboard: nil, one_time: nil, is_personal: nil, input_field_placeholder: nil
 end
 defmodule ChatInviteLinkInfo do
   @moduledoc  """
@@ -873,23 +1233,40 @@ defmodule ChatInviteLinkInfo do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier of the invite link; 0 if the user has no access to the chat before joining. |
   | accessible_for | int32 | If non-zero, the amount of time for which read access to the chat will remain available, in seconds. |
-  | type | ChatType | Type of the chat. |
+  | type | InviteLinkChatType | Type of the chat. |
   | title | string | Title of the chat. |
   | photo | chatPhotoInfo | Chat photo; may be null. |
+  | accent_color_id | int32 | Identifier of the accent color for chat title and background of chat photo. |
   | description | string | Chat description. |
   | member_count | int32 | Number of members in the chat. |
   | member_user_ids | int53 | User identifiers of some chat members that may be known to the current user. |
   | creates_join_request | bool | True, if the link only creates join request. |
   | is_public | bool | True, if the chat is a public supergroup or channel, i.e. it has a username or it is a location-based supergroup. |
+  | is_verified | bool | True, if the chat is verified. |
+  | is_scam | bool | True, if many users reported this chat as a scam. |
+  | is_fake | bool | True, if many users reported this chat as a fake account. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_invite_link_info.html).
   """
 
-  defstruct "@type": "chatInviteLinkInfo", "@extra": nil, chat_id: nil, accessible_for: nil, type: nil, title: nil, photo: nil, description: nil, member_count: nil, member_user_ids: nil, creates_join_request: nil, is_public: nil
+  defstruct "@type": "chatInviteLinkInfo", "@extra": nil, chat_id: nil, accessible_for: nil, type: nil, title: nil, photo: nil, accent_color_id: nil, description: nil, member_count: nil, member_user_ids: nil, creates_join_request: nil, is_public: nil, is_verified: nil, is_scam: nil, is_fake: nil
+end
+defmodule PremiumGiveawayParticipantStatusDisallowedCountry do
+  @moduledoc  """
+  The user can't participate in the giveaway, because they phone number is from a disallowed country.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_country_code | string | A two-letter ISO 3166-1 alpha-2 country code of the user's country. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_participant_status_disallowed_country.html).
+  """
+
+  defstruct "@type": "premiumGiveawayParticipantStatusDisallowedCountry", "@extra": nil, user_country_code: nil
 end
 defmodule UserStatusEmpty do
   @moduledoc  """
-  The user status was never changed.
+  The user's status has never been changed.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_status_empty.html).
@@ -907,6 +1284,20 @@ defmodule TextEntityTypeItalic do
 
   defstruct "@type": "textEntityTypeItalic", "@extra": nil
 end
+defmodule UserLink do
+  @moduledoc  """
+  Contains an HTTPS URL, which can be used to get information about a user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | The URL. |
+  | expires_in | int32 | Left time for which the link is valid, in seconds; 0 if the link is a public username link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_link.html).
+  """
+
+  defstruct "@type": "userLink", "@extra": nil, url: nil, expires_in: nil
+end
 defmodule StorageStatistics do
   @moduledoc  """
   Contains the exact storage usage statistics split by chats and file type.
@@ -921,6 +1312,19 @@ defmodule StorageStatistics do
   """
 
   defstruct "@type": "storageStatistics", "@extra": nil, size: nil, count: nil, by_chat: nil
+end
+defmodule ChatFolderIcon do
+  @moduledoc  """
+  Represents an icon for a chat folder.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | The chosen icon name for short folder representation; one of "All", "Unread", "Unmuted", "Bots", "Channels", "Groups", "Private", "Custom", "Setup", "Cat", "Crown", "Favorite", "Flower", "Game", "Home", "Love", "Mask", "Party", "Sport", "Study", "Trade", "Travel", "Work", "Airplane", "Book", "Light", "Like", "Money", "Note", "Palette". |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder_icon.html).
+  """
+
+  defstruct "@type": "chatFolderIcon", "@extra": nil, name: nil
 end
 defmodule RichTexts do
   @moduledoc  """
@@ -950,7 +1354,7 @@ defmodule InputPassportElementPhoneNumber do
 end
 defmodule ChatEventUsernameChanged do
   @moduledoc  """
-  The chat username was changed.
+  The chat editable username was changed.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -962,9 +1366,19 @@ defmodule ChatEventUsernameChanged do
 
   defstruct "@type": "chatEventUsernameChanged", "@extra": nil, old_username: nil, new_username: nil
 end
+defmodule MessageReadDateMyPrivacyRestricted do
+  @moduledoc  """
+  The read date is unknown due to privacy settings of the current user, but will be known if the user subscribes to Telegram Premium.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_read_date_my_privacy_restricted.html).
+  """
+
+  defstruct "@type": "messageReadDateMyPrivacyRestricted", "@extra": nil
+end
 defmodule ConnectionStateConnecting do
   @moduledoc  """
-  Currently establishing a connection to the Telegram servers.
+  Establishing a connection to the Telegram servers.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1connection_state_connecting.html).
@@ -1013,19 +1427,15 @@ defmodule InputInlineQueryResultVoiceNote do
 
   defstruct "@type": "inputInlineQueryResultVoiceNote", "@extra": nil, id: nil, title: nil, voice_note_url: nil, voice_note_duration: nil, reply_markup: nil, input_message_content: nil
 end
-defmodule UpdateChatIsBlocked do
+defmodule PremiumLimitTypeChatFolderChosenChatCount do
   @moduledoc  """
-  A chat was blocked or unblocked.
+  The maximum number of pinned and always included, or always excluded chats in a chat folder.
 
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_id | int53 | Chat identifier. |
-  | is_blocked | bool | New value of is_blocked. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_is_blocked.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_chat_folder_chosen_chat_count.html).
   """
 
-  defstruct "@type": "updateChatIsBlocked", "@extra": nil, chat_id: nil, is_blocked: nil
+  defstruct "@type": "premiumLimitTypeChatFolderChosenChatCount", "@extra": nil
 end
 defmodule CountryInfo do
   @moduledoc  """
@@ -1057,31 +1467,6 @@ defmodule TextEntities do
 
   defstruct "@type": "textEntities", "@extra": nil, entities: nil
 end
-defmodule ChatFilter do
-  @moduledoc  """
-  Represents a filter of user chats.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | title | string | The title of the filter; 1-12 characters without line feeds. |
-  | icon_name | string | The chosen icon name for short filter representation. If non-empty, must be one of "All", "Unread", "Unmuted", "Bots", "Channels", "Groups", "Private", "Custom", "Setup", "Cat", "Crown", "Favorite", "Flower", "Game", "Home", "Love", "Mask", "Party", "Sport", "Study", "Trade", "Travel", "Work", "Airplane", "Book", "Light", "Like", "Money", "Note", "Palette". If empty, use <a class="el" href="classtd_1_1td__api_1_1get_chat_filter_default_icon_name.html">getChatFilterDefaultIconName</a> to get default icon name for the filter. |
-  | pinned_chat_ids | int53 | The chat identifiers of pinned chats in the filtered chat list. There can be up to GetOption("chat_filter_chosen_chat_count_max") pinned and always included non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
-  | included_chat_ids | int53 | The chat identifiers of always included chats in the filtered chat list. There can be up to GetOption("chat_filter_chosen_chat_count_max") pinned and always included non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
-  | excluded_chat_ids | int53 | The chat identifiers of always excluded chats in the filtered chat list. There can be up to GetOption("chat_filter_chosen_chat_count_max") always excluded non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
-  | exclude_muted | bool | True, if muted chats need to be excluded. |
-  | exclude_read | bool | True, if read chats need to be excluded. |
-  | exclude_archived | bool | True, if archived chats need to be excluded. |
-  | include_contacts | bool | True, if contacts need to be included. |
-  | include_non_contacts | bool | True, if non-contact users need to be included. |
-  | include_bots | bool | True, if bots need to be included. |
-  | include_groups | bool | True, if basic groups and supergroups need to be included. |
-  | include_channels | bool | True, if channels need to be included. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_filter.html).
-  """
-
-  defstruct "@type": "chatFilter", "@extra": nil, title: nil, icon_name: nil, pinned_chat_ids: nil, included_chat_ids: nil, excluded_chat_ids: nil, exclude_muted: nil, exclude_read: nil, exclude_archived: nil, include_contacts: nil, include_non_contacts: nil, include_bots: nil, include_groups: nil, include_channels: nil
-end
 defmodule SupergroupMembersFilterBots do
   @moduledoc  """
   Returns bot members of the supergroup or channel.
@@ -1091,6 +1476,16 @@ defmodule SupergroupMembersFilterBots do
   """
 
   defstruct "@type": "supergroupMembersFilterBots", "@extra": nil
+end
+defmodule PremiumStoryFeatureStealthMode do
+  @moduledoc  """
+  The ability to hide the fact that the user viewed other's stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_stealth_mode.html).
+  """
+
+  defstruct "@type": "premiumStoryFeatureStealthMode", "@extra": nil
 end
 defmodule PassportElementTemporaryRegistration do
   @moduledoc  """
@@ -1105,6 +1500,20 @@ defmodule PassportElementTemporaryRegistration do
 
   defstruct "@type": "passportElementTemporaryRegistration", "@extra": nil, temporary_registration: nil
 end
+defmodule UpdateBusinessMessageEdited do
+  @moduledoc  """
+  A message in a business account was edited; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | connection_id | string | Unique identifier of the business connection. |
+  | message | businessMessage | The edited message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_business_message_edited.html).
+  """
+
+  defstruct "@type": "updateBusinessMessageEdited", "@extra": nil, connection_id: nil, message: nil
+end
 defmodule ChatMembersFilterMembers do
   @moduledoc  """
   Returns all chat members, including restricted chat members.
@@ -1114,6 +1523,20 @@ defmodule ChatMembersFilterMembers do
   """
 
   defstruct "@type": "chatMembersFilterMembers", "@extra": nil
+end
+defmodule MessageForumTopicCreated do
+  @moduledoc  """
+  A forum topic has been created.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | Name of the topic. |
+  | icon | forumTopicIcon | Icon of the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forum_topic_created.html).
+  """
+
+  defstruct "@type": "messageForumTopicCreated", "@extra": nil, name: nil, icon: nil
 end
 defmodule SearchMessagesFilterDocument do
   @moduledoc  """
@@ -1153,20 +1576,6 @@ defmodule ChatActionBarJoinRequest do
 
   defstruct "@type": "chatActionBarJoinRequest", "@extra": nil, title: nil, is_channel: nil, request_date: nil
 end
-defmodule RecommendedChatFilter do
-  @moduledoc  """
-  Describes a recommended chat filter.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | filter | chatFilter | The chat filter. |
-  | description | string | Chat filter description. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recommended_chat_filter.html).
-  """
-
-  defstruct "@type": "recommendedChatFilter", "@extra": nil, filter: nil, description: nil
-end
 defmodule ChatInviteLinkMember do
   @moduledoc  """
   Describes a chat member joined a chat via an invite link.
@@ -1175,21 +1584,36 @@ defmodule ChatInviteLinkMember do
   |------|------| ------------|
   | user_id | int53 | User identifier. |
   | joined_chat_date | int32 | Point in time (Unix timestamp) when the user joined the chat. |
+  | via_chat_folder_invite_link | bool | True, if the user has joined the chat using an invite link for a chat folder. |
   | approver_user_id | int53 | User identifier of the chat administrator, approved user join request. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_invite_link_member.html).
   """
 
-  defstruct "@type": "chatInviteLinkMember", "@extra": nil, user_id: nil, joined_chat_date: nil, approver_user_id: nil
+  defstruct "@type": "chatInviteLinkMember", "@extra": nil, user_id: nil, joined_chat_date: nil, via_chat_folder_invite_link: nil, approver_user_id: nil
+end
+defmodule ChatEventForumTopicPinned do
+  @moduledoc  """
+  A pinned forum topic was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_topic_info | forumTopicInfo | Information about the old pinned topic; may be null. |
+  | new_topic_info | forumTopicInfo | Information about the new pinned topic; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_pinned.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicPinned", "@extra": nil, old_topic_info: nil, new_topic_info: nil
 end
 defmodule UpdateChatLastMessage do
   @moduledoc  """
-  The last message of a chat was changed. If last_message is null, then the last message in the chat became unknown. Some new unknown messages might be added to the chat in this case.
+  The last message of a chat was changed.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | last_message | message | The new last message in the chat; may be null. |
+  | last_message | message | The new last message in the chat; may be null if the last message became unknown. While the last message is unknown, new messages can be added to the chat without corresponding <a class="el" href="classtd_1_1td__api_1_1update_new_message.html">updateNewMessage</a> update. |
   | positions | chatPosition | The new chat positions in the chat lists. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_last_message.html).
@@ -1209,7 +1633,7 @@ defmodule GroupCallVideoQualityFull do
 end
 defmodule WebPage do
   @moduledoc  """
-  Describes a web page preview.
+  Describes a link preview.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -1226,6 +1650,10 @@ defmodule WebPage do
   | embed_height | int32 | Height of the embedded preview. |
   | duration | int32 | Duration of the content, in seconds. |
   | author | string | Author of the content. |
+  | has_large_media | bool | True, if size of media in the preview can be changed. |
+  | show_large_media | bool | True, if large media preview must be shown; otherwise, the media preview must be shown small and only the first frame must be shown for videos. |
+  | skip_confirmation | bool | True, if there is no need to show an ordinary open URL confirmation, when opening the URL from the preview, because the URL is shown in the message text in clear. |
+  | show_above_text | bool | True, if the link preview must be shown above message text; otherwise, the link preview must be shown below the message text. |
   | animation | animation | Preview of the content as an animation, if available; may be null. |
   | audio | audio | Preview of the content as an audio file, if available; may be null. |
   | document | document | Preview of the content as a document, if available; may be null. |
@@ -1233,16 +1661,19 @@ defmodule WebPage do
   | video | video | Preview of the content as a video, if available; may be null. |
   | video_note | videoNote | Preview of the content as a video note, if available; may be null. |
   | voice_note | voiceNote | Preview of the content as a voice note, if available; may be null. |
-  | instant_view_version | int32 | Version of instant view, available for the web page (currently, can be 1 or 2), 0 if none. |
+  | story_sender_chat_id | int53 | The identifier of the sender of the previewed story; 0 if none. |
+  | story_id | int32 | The identifier of the previewed story; 0 if none. |
+  | stickers | sticker | Up to 4 stickers from the sticker set available via the link. |
+  | instant_view_version | int32 | Version of web page instant view (currently, can be 1 or 2); 0 if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1web_page.html).
   """
 
-  defstruct "@type": "webPage", "@extra": nil, url: nil, display_url: nil, type: nil, site_name: nil, title: nil, description: nil, photo: nil, embed_url: nil, embed_type: nil, embed_width: nil, embed_height: nil, duration: nil, author: nil, animation: nil, audio: nil, document: nil, sticker: nil, video: nil, video_note: nil, voice_note: nil, instant_view_version: nil
+  defstruct "@type": "webPage", "@extra": nil, url: nil, display_url: nil, type: nil, site_name: nil, title: nil, description: nil, photo: nil, embed_url: nil, embed_type: nil, embed_width: nil, embed_height: nil, duration: nil, author: nil, has_large_media: nil, show_large_media: nil, skip_confirmation: nil, show_above_text: nil, animation: nil, audio: nil, document: nil, sticker: nil, video: nil, video_note: nil, voice_note: nil, story_sender_chat_id: nil, story_id: nil, stickers: nil, instant_view_version: nil
 end
 defmodule UpdateMessageSendAcknowledged do
   @moduledoc  """
-  A request to send a message has reached the Telegram server. This doesn't mean that the message will be sent successfully or even that the send message request will be processed. This update will be sent only if the option "use_quick_ack" is set to true. This update may be sent multiple times for the same message.
+  A request to send a message has reached the Telegram server. This doesn't mean that the message will be sent successfully. This update is sent only if the option "use_quick_ack" is set to true. This update may be sent multiple times for the same message.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -1254,9 +1685,23 @@ defmodule UpdateMessageSendAcknowledged do
 
   defstruct "@type": "updateMessageSendAcknowledged", "@extra": nil, chat_id: nil, message_id: nil
 end
+defmodule AutosaveSettingsException do
+  @moduledoc  """
+  Contains autosave settings for a chat, which overrides default settings for the corresponding scope.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | settings | scopeAutosaveSettings | Autosave settings for the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings_exception.html).
+  """
+
+  defstruct "@type": "autosaveSettingsException", "@extra": nil, chat_id: nil, settings: nil
+end
 defmodule AuthorizationStateWaitRegistration do
   @moduledoc  """
-  The user is unregistered and need to accept terms of service and enter their first name and last name to finish registration.
+  The user is unregistered and need to accept terms of service and enter their first name and last name to finish registration. Call registerUser to accept the terms of service and provide the data.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -1266,6 +1711,20 @@ defmodule AuthorizationStateWaitRegistration do
   """
 
   defstruct "@type": "authorizationStateWaitRegistration", "@extra": nil, terms_of_service: nil
+end
+defmodule UpdateChatRemovedFromList do
+  @moduledoc  """
+  A chat was removed from a chat list.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | chat_list | ChatList | The chat list from which the chat was removed. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_removed_from_list.html).
+  """
+
+  defstruct "@type": "updateChatRemovedFromList", "@extra": nil, chat_id: nil, chat_list: nil
 end
 defmodule EncryptedPassportElement do
   @moduledoc  """
@@ -1310,29 +1769,14 @@ defmodule PersonalDetails do
 
   defstruct "@type": "personalDetails", "@extra": nil, first_name: nil, middle_name: nil, last_name: nil, native_first_name: nil, native_middle_name: nil, native_last_name: nil, birthdate: nil, gender: nil, country_code: nil, residence_country_code: nil
 end
-defmodule ChatReportReasonCopyright do
+defmodule StoryContent do
   @moduledoc  """
-  The chat contains copyrighted content.
 
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_copyright.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_content.html).
   """
 
-  defstruct "@type": "chatReportReasonCopyright", "@extra": nil
-end
-defmodule UpdateChatMessageTtl do
-  @moduledoc  """
-  The message Time To Live setting for a chat was changed.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_id | int53 | Chat identifier. |
-  | message_ttl | int32 | New value of message_ttl. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_message_ttl.html).
-  """
-
-  defstruct "@type": "updateChatMessageTtl", "@extra": nil, chat_id: nil, message_ttl: nil
+  defstruct "@type": "StoryContent", "@extra": nil
 end
 defmodule ChatMember do
   @moduledoc  """
@@ -1342,7 +1786,7 @@ defmodule ChatMember do
   |------|------| ------------|
   | member_id | MessageSender | Identifier of the chat member. Currently, other chats can be only Left or Banned. Only supergroups and channels can have other chats as Left or Banned members and these chats must be supergroups or channels. |
   | inviter_user_id | int53 | Identifier of a user that invited/promoted/banned this member in the chat; 0 if unknown. |
-  | joined_chat_date | int32 | Point in time (Unix timestamp) when the user joined the chat. |
+  | joined_chat_date | int32 | Point in time (Unix timestamp) when the user joined/was promoted/was banned in the chat. |
   | status | ChatMemberStatus | Status of the member in the chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_member.html).
@@ -1373,6 +1817,21 @@ defmodule InputPassportElementErrorSourceFrontSide do
 
   defstruct "@type": "inputPassportElementErrorSourceFrontSide", "@extra": nil, file_hash: nil
 end
+defmodule BusinessStartPage do
+  @moduledoc  """
+  Describes settings for a business account start page.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | title | string | Title text of the start page. |
+  | message | string | Message text of the start page. |
+  | sticker | sticker | Greeting sticker of the start page; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_start_page.html).
+  """
+
+  defstruct "@type": "businessStartPage", "@extra": nil, title: nil, message: nil, sticker: nil
+end
 defmodule BotCommands do
   @moduledoc  """
   Contains a list of bot commands.
@@ -1386,6 +1845,19 @@ defmodule BotCommands do
   """
 
   defstruct "@type": "botCommands", "@extra": nil, bot_user_id: nil, commands: nil
+end
+defmodule MessageBotWriteAccessAllowed do
+  @moduledoc  """
+  The user allowed the bot to send messages.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reason | BotWriteAccessAllowReason | The reason why the bot was allowed to write messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_bot_write_access_allowed.html).
+  """
+
+  defstruct "@type": "messageBotWriteAccessAllowed", "@extra": nil, reason: nil
 end
 defmodule OptionValueInteger do
   @moduledoc  """
@@ -1438,6 +1910,19 @@ defmodule SearchMessagesFilterUnreadReaction do
 
   defstruct "@type": "searchMessagesFilterUnreadReaction", "@extra": nil
 end
+defmodule StarTransactionPartnerChannel do
+  @moduledoc  """
+  The transaction is a transaction with a channel chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_channel.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerChannel", "@extra": nil, chat_id: nil
+end
 defmodule PremiumLimitTypePinnedChatCount do
   @moduledoc  """
   The maximum number of pinned chats in the main chat list.
@@ -1461,13 +1946,23 @@ defmodule SentWebAppMessage do
 
   defstruct "@type": "sentWebAppMessage", "@extra": nil, inline_message_id: nil
 end
+defmodule CanSendStoryResultBoostNeeded do
+  @moduledoc  """
+  The chat must be boosted first by Telegram Premium subscribers to post more stories. Call getChatBoostStatus to get current boost status of the chat.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_boost_needed.html).
+  """
+
+  defstruct "@type": "canSendStoryResultBoostNeeded", "@extra": nil
+end
 defmodule MessagePaymentSuccessful do
   @moduledoc  """
   A payment has been completed.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | invoice_chat_id | int53 | Identifier of the chat, containing the corresponding invoice message; 0 if unknown. |
+  | invoice_chat_id | int53 | Identifier of the chat, containing the corresponding invoice message. |
   | invoice_message_id | int53 | Identifier of the message with the corresponding invoice; can be 0 or an identifier of a deleted message. |
   | currency | string | Currency for the price of the product. |
   | total_amount | int53 | Total price for the product, in the smallest units of the currency. |
@@ -1496,7 +1991,7 @@ defmodule UpdateChatHasProtectedContent do
 end
 defmodule ValidatedOrderInfo do
   @moduledoc  """
-  Contains a temporary identifier of validated order information, which is stored for one hour. Also contains the available shipping options.
+  Contains a temporary identifier of validated order information, which is stored for one hour, and the available shipping options.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -1522,6 +2017,21 @@ defmodule PageBlockCollage do
 
   defstruct "@type": "pageBlockCollage", "@extra": nil, page_blocks: nil, caption: nil
 end
+defmodule MessageForumTopicEdited do
+  @moduledoc  """
+  A forum topic has been edited.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | If non-empty, the new name of the topic. |
+  | edit_icon_custom_emoji_id | bool | True, if icon's custom_emoji_id is changed. |
+  | icon_custom_emoji_id | int64 | New unique identifier of the custom emoji shown on the topic icon; 0 if none. Must be ignored if edit_icon_custom_emoji_id is false. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forum_topic_edited.html).
+  """
+
+  defstruct "@type": "messageForumTopicEdited", "@extra": nil, name: nil, edit_icon_custom_emoji_id: nil, icon_custom_emoji_id: nil
+end
 defmodule InputInlineQueryResultVideo do
   @moduledoc  """
   Represents a link to a page containing an embedded video player or a video file.
@@ -1544,6 +2054,41 @@ defmodule InputInlineQueryResultVideo do
   """
 
   defstruct "@type": "inputInlineQueryResultVideo", "@extra": nil, id: nil, title: nil, description: nil, thumbnail_url: nil, video_url: nil, mime_type: nil, video_width: nil, video_height: nil, video_duration: nil, reply_markup: nil, input_message_content: nil
+end
+defmodule CanSendMessageToUserResult do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_can_send_message_to_user_result.html).
+  """
+
+  defstruct "@type": "CanSendMessageToUserResult", "@extra": nil
+end
+defmodule StoryInteractionTypeRepost do
+  @moduledoc  """
+  A repost of the story as a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story | story | The reposted story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interaction_type_repost.html).
+  """
+
+  defstruct "@type": "storyInteractionTypeRepost", "@extra": nil, story: nil
+end
+defmodule CanSendStoryResultWeeklyLimitExceeded do
+  @moduledoc  """
+  The weekly limit for the number of posted stories exceeded. The user needs to buy Telegram Premium or wait specified time.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | retry_after | int32 | Time left before the user can send the next story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_weekly_limit_exceeded.html).
+  """
+
+  defstruct "@type": "canSendStoryResultWeeklyLimitExceeded", "@extra": nil, retry_after: nil
 end
 defmodule BotCommandScopeAllPrivateChats do
   @moduledoc  """
@@ -1575,13 +2120,39 @@ defmodule UpdatePollAnswer do
   | Name | Type | Description |
   |------|------| ------------|
   | poll_id | int64 | Unique poll identifier. |
-  | user_id | int53 | The user, who changed the answer to the poll. |
+  | voter_id | MessageSender | Identifier of the message sender that changed the answer to the poll. |
   | option_ids | int32 | 0-based identifiers of answer options, chosen by the user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_poll_answer.html).
   """
 
-  defstruct "@type": "updatePollAnswer", "@extra": nil, poll_id: nil, user_id: nil, option_ids: nil
+  defstruct "@type": "updatePollAnswer", "@extra": nil, poll_id: nil, voter_id: nil, option_ids: nil
+end
+defmodule EmailAddressResetStateAvailable do
+  @moduledoc  """
+  Email address can be reset after the given period. Call resetAuthenticationEmailAddress to reset it and allow the user to authorize with a code sent to the user's phone number.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | wait_period | int32 | Time required to wait before the email address can be reset; 0 if the user is subscribed to Telegram Premium. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1email_address_reset_state_available.html).
+  """
+
+  defstruct "@type": "emailAddressResetStateAvailable", "@extra": nil, wait_period: nil
+end
+defmodule FoundPosition do
+  @moduledoc  """
+  Contains 0-based match position.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | position | int32 | The position of the match. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_position.html).
+  """
+
+  defstruct "@type": "foundPosition", "@extra": nil, position: nil
 end
 defmodule TMeUrlTypeChatInvite do
   @moduledoc  """
@@ -1672,6 +2243,21 @@ defmodule PageBlockAnchor do
 
   defstruct "@type": "pageBlockAnchor", "@extra": nil, name: nil
 end
+defmodule InputStoryAreaTypeSuggestedReaction do
+  @moduledoc  """
+  An area pointing to a suggested reaction.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reaction_type | ReactionType | Type of the reaction. |
+  | is_dark | bool | True, if reaction has a dark background. |
+  | is_flipped | bool | True, if reaction corner is flipped. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_suggested_reaction.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypeSuggestedReaction", "@extra": nil, reaction_type: nil, is_dark: nil, is_flipped: nil
+end
 defmodule Address do
   @moduledoc  """
   Describes an address.
@@ -1713,6 +2299,98 @@ defmodule CallbackQueryPayloadData do
 
   defstruct "@type": "callbackQueryPayloadData", "@extra": nil, data: nil
 end
+defmodule InputStoryAreaTypeLink do
+  @moduledoc  """
+  An area pointing to a HTTP or tg:// link.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | HTTP or tg:// URL to be opened when the area is clicked. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_link.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypeLink", "@extra": nil, url: nil
+end
+defmodule MessageChatBoost do
+  @moduledoc  """
+  The chat was boosted by the sender of the message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boost_count | int32 | Number of times the chat was boosted. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_boost.html).
+  """
+
+  defstruct "@type": "messageChatBoost", "@extra": nil, boost_count: nil
+end
+defmodule InternalLinkTypeBusinessChat do
+  @moduledoc  """
+  The link is a link to a business chat. Use getBusinessChatLinkInfo with the provided link name to get information about the link, then open received private chat and replace chat draft with the provided text.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link_name | string | Name of the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_business_chat.html).
+  """
+
+  defstruct "@type": "internalLinkTypeBusinessChat", "@extra": nil, link_name: nil
+end
+defmodule ReportChatSponsoredMessageOption do
+  @moduledoc  """
+  Describes an option to report a sponsored message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | bytes | Unique identifier of the option. |
+  | text | string | Text of the option. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_option.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageOption", "@extra": nil, id: nil, text: nil
+end
+defmodule MessageChatSetMessageAutoDeleteTime do
+  @moduledoc  """
+  The auto-delete or self-destruct timer for messages in the chat has been changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_auto_delete_time | int32 | New value auto-delete or self-destruct time, in seconds; 0 if disabled. |
+  | from_user_id | int53 | If not 0, a user identifier, which default setting was automatically applied. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_set_message_auto_delete_time.html).
+  """
+
+  defstruct "@type": "messageChatSetMessageAutoDeleteTime", "@extra": nil, message_auto_delete_time: nil, from_user_id: nil
+end
+defmodule BusinessGreetingMessageSettings do
+  @moduledoc  """
+  Describes settings for greeting messages that are automatically sent by a Telegram Business account as response to incoming messages in an inactive private chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique quick reply shortcut identifier for the greeting messages. |
+  | recipients | businessRecipients | Chosen recipients of the greeting messages. |
+  | inactivity_days | int32 | The number of days after which a chat will be considered as inactive; currently, must be on of 7, 14, 21, or 28. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_greeting_message_settings.html).
+  """
+
+  defstruct "@type": "businessGreetingMessageSettings", "@extra": nil, shortcut_id: nil, recipients: nil, inactivity_days: nil
+end
+defmodule AutosaveSettingsScopePrivateChats do
+  @moduledoc  """
+  Autosave settings applied to all private chats without chat-specific settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings_scope_private_chats.html).
+  """
+
+  defstruct "@type": "autosaveSettingsScopePrivateChats", "@extra": nil
+end
 defmodule ChatEventVideoChatMuteNewParticipantsToggled do
   @moduledoc  """
   The mute_new_participants setting of a video chat was toggled.
@@ -1725,6 +2403,21 @@ defmodule ChatEventVideoChatMuteNewParticipantsToggled do
   """
 
   defstruct "@type": "chatEventVideoChatMuteNewParticipantsToggled", "@extra": nil, mute_new_participants: nil
+end
+defmodule ChatRevenueTransactionTypeWithdrawal do
+  @moduledoc  """
+  Describes a withdrawal of earnings.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | withdrawal_date | int32 | Point in time (Unix timestamp) when the earnings withdrawal started. |
+  | provider | string | Name of the payment provider. |
+  | state | RevenueWithdrawalState | State of the withdrawal. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_transaction_type_withdrawal.html).
+  """
+
+  defstruct "@type": "chatRevenueTransactionTypeWithdrawal", "@extra": nil, withdrawal_date: nil, provider: nil, state: nil
 end
 defmodule FileTypeSecretThumbnail do
   @moduledoc  """
@@ -1755,6 +2448,20 @@ defmodule InputInlineQueryResultVenue do
 
   defstruct "@type": "inputInlineQueryResultVenue", "@extra": nil, id: nil, venue: nil, thumbnail_url: nil, thumbnail_width: nil, thumbnail_height: nil, reply_markup: nil, input_message_content: nil
 end
+defmodule StoryArea do
+  @moduledoc  """
+  Describes a clickable rectangle area on a story media.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | position | storyAreaPosition | Position of the area. |
+  | type | StoryAreaType | Type of the area. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area.html).
+  """
+
+  defstruct "@type": "storyArea", "@extra": nil, position: nil, type: nil
+end
 defmodule PushMessageContentDocument do
   @moduledoc  """
   A document message (a general file).
@@ -1782,13 +2489,22 @@ defmodule MessageChatAddMembers do
 
   defstruct "@type": "messageChatAddMembers", "@extra": nil, member_user_ids: nil
 end
+defmodule InlineQueryResultsButtonType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_inline_query_results_button_type.html).
+  """
+
+  defstruct "@type": "InlineQueryResultsButtonType", "@extra": nil
+end
 defmodule MessageLink do
   @moduledoc  """
-  Contains an HTTPS link to a message in a supergroup or channel.
+  Contains an HTTPS link to a message in a supergroup or channel, or a forum topic.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | link | string | Message link. |
+  | link | string | The link. |
   | is_public | bool | True, if the link will work for non-members of the chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_link.html).
@@ -1825,22 +2541,40 @@ defmodule ChatAdministratorRights do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | can_manage_chat | bool | True, if the administrator can get chat event log, get chat statistics, get message statistics in channels, get channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other privilege; applicable to supergroups and channels only. |
+  | can_manage_chat | bool | True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report supergroup spam messages and ignore slow mode. Implied by any other privilege; applicable to supergroups and channels only. |
   | can_change_info | bool | True, if the administrator can change the chat title, photo, and other settings. |
-  | can_post_messages | bool | True, if the administrator can create channel posts; applicable to channels only. |
+  | can_post_messages | bool | True, if the administrator can create channel posts or view channel statistics; applicable to channels only. |
   | can_edit_messages | bool | True, if the administrator can edit messages of other users and pin messages; applicable to channels only. |
   | can_delete_messages | bool | True, if the administrator can delete messages of other users. |
   | can_invite_users | bool | True, if the administrator can invite new users to the chat. |
-  | can_restrict_members | bool | True, if the administrator can restrict, ban, or unban chat members; always true for channels. |
+  | can_restrict_members | bool | True, if the administrator can restrict, ban, or unban chat members or view supergroup statistics; always true for channels. |
   | can_pin_messages | bool | True, if the administrator can pin messages; applicable to basic groups and supergroups only. |
+  | can_manage_topics | bool | True, if the administrator can create, rename, close, reopen, hide, and unhide forum topics; applicable to forum supergroups only. |
   | can_promote_members | bool | True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that were directly or indirectly promoted by them. |
   | can_manage_video_chats | bool | True, if the administrator can manage video chats. |
+  | can_post_stories | bool | True, if the administrator can create new chat stories, or edit and delete posted stories; applicable to supergroups and channels only. |
+  | can_edit_stories | bool | True, if the administrator can edit stories posted by other users, post stories to the chat page, pin chat stories, and access story archive; applicable to supergroups and channels only. |
+  | can_delete_stories | bool | True, if the administrator can delete stories posted by other users; applicable to supergroups and channels only. |
   | is_anonymous | bool | True, if the administrator isn't shown in the chat member list and sends messages anonymously; applicable to supergroups only. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_administrator_rights.html).
   """
 
-  defstruct "@type": "chatAdministratorRights", "@extra": nil, can_manage_chat: nil, can_change_info: nil, can_post_messages: nil, can_edit_messages: nil, can_delete_messages: nil, can_invite_users: nil, can_restrict_members: nil, can_pin_messages: nil, can_promote_members: nil, can_manage_video_chats: nil, is_anonymous: nil
+  defstruct "@type": "chatAdministratorRights", "@extra": nil, can_manage_chat: nil, can_change_info: nil, can_post_messages: nil, can_edit_messages: nil, can_delete_messages: nil, can_invite_users: nil, can_restrict_members: nil, can_pin_messages: nil, can_manage_topics: nil, can_promote_members: nil, can_manage_video_chats: nil, can_post_stories: nil, can_edit_stories: nil, can_delete_stories: nil, is_anonymous: nil
+end
+defmodule ChatRevenueTransactionTypeRefund do
+  @moduledoc  """
+  Describes a refund for failed withdrawal of earnings.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | refund_date | int32 | Point in time (Unix timestamp) when the transaction was refunded. |
+  | provider | string | Name of the payment provider. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_transaction_type_refund.html).
+  """
+
+  defstruct "@type": "chatRevenueTransactionTypeRefund", "@extra": nil, refund_date: nil, provider: nil
 end
 defmodule NotificationSounds do
   @moduledoc  """
@@ -1855,15 +2589,38 @@ defmodule NotificationSounds do
 
   defstruct "@type": "notificationSounds", "@extra": nil, notification_sounds: nil
 end
-defmodule PremiumLimitTypeChatFilterChosenChatCount do
+defmodule BusinessInfo do
   @moduledoc  """
-  The maximum number of pinned and always included, or always excluded chats in a chat filter.
+  Contains information about a Telegram Business account.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | location | businessLocation | Location of the business; may be null if none. |
+  | opening_hours | businessOpeningHours | Opening hours of the business; may be null if none. The hours are guaranteed to be valid and has already been split by week days. |
+  | local_opening_hours | businessOpeningHours | Opening hours of the business in the local time; may be null if none. The hours are guaranteed to be valid and has already been split by week days. Local time zone identifier will be empty. An <a class="el" href="classtd_1_1td__api_1_1update_user_full_info.html">updateUserFullInfo</a> update is not triggered when value of this field changes. |
+  | next_open_in | int32 | Time left before the business will open the next time, in seconds; 0 if unknown. An <a class="el" href="classtd_1_1td__api_1_1update_user_full_info.html">updateUserFullInfo</a> update is not triggered when value of this field changes. |
+  | next_close_in | int32 | Time left before the business will close the next time, in seconds; 0 if unknown. An <a class="el" href="classtd_1_1td__api_1_1update_user_full_info.html">updateUserFullInfo</a> update is not triggered when value of this field changes. |
+  | greeting_message_settings | businessGreetingMessageSettings | The greeting message; may be null if none or the Business account is not of the current user. |
+  | away_message_settings | businessAwayMessageSettings | The away message; may be null if none or the Business account is not of the current user. |
+  | start_page | businessStartPage | Information about start page of the account; may be null if none. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_chat_filter_chosen_chat_count.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_info.html).
   """
 
-  defstruct "@type": "premiumLimitTypeChatFilterChosenChatCount", "@extra": nil
+  defstruct "@type": "businessInfo", "@extra": nil, location: nil, opening_hours: nil, local_opening_hours: nil, next_open_in: nil, next_close_in: nil, greeting_message_settings: nil, away_message_settings: nil, start_page: nil
+end
+defmodule InputStoryAreas do
+  @moduledoc  """
+  Contains a list of story areas to be added.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | areas | inputStoryArea | List of input story areas. Currently, a story can have up to 10 <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_location.html">inputStoryAreaTypeLocation</a>, <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_found_venue.html">inputStoryAreaTypeFoundVenue</a>, and <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_previous_venue.html">inputStoryAreaTypePreviousVenue</a> areas, up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("story_suggested_reaction_area_count_max") <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_suggested_reaction.html">inputStoryAreaTypeSuggestedReaction</a> areas, up to 1 <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_message.html">inputStoryAreaTypeMessage</a> area, and up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("story_link_area_count_max") <a class="el" href="classtd_1_1td__api_1_1input_story_area_type_link.html">inputStoryAreaTypeLink</a> areas if the current user is a Telegram Premium user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_areas.html).
+  """
+
+  defstruct "@type": "inputStoryAreas", "@extra": nil, areas: nil
 end
 defmodule InputPassportElementEmailAddress do
   @moduledoc  """
@@ -1891,6 +2648,19 @@ defmodule Hashtags do
 
   defstruct "@type": "hashtags", "@extra": nil, hashtags: nil
 end
+defmodule StoryPrivacySettingsEveryone do
+  @moduledoc  """
+  The story can be viewed by everyone.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | except_user_ids | int53 | Identifiers of the users that can't see the story; always unknown and empty for non-owned stories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_privacy_settings_everyone.html).
+  """
+
+  defstruct "@type": "storyPrivacySettingsEveryone", "@extra": nil, except_user_ids: nil
+end
 defmodule InputMessageGame do
   @moduledoc  """
   A message with a game; not supported for channels or secret chats.
@@ -1904,6 +2674,23 @@ defmodule InputMessageGame do
   """
 
   defstruct "@type": "inputMessageGame", "@extra": nil, bot_user_id: nil, game_short_name: nil
+end
+defmodule WebApp do
+  @moduledoc  """
+  Describes a Web App. Use getInternalLink with internalLinkTypeWebApp to share the Web App.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | short_name | string | Web App short name. |
+  | title | string | Web App title. |
+  | description | string | Web App description. |
+  | photo | photo | Web App photo. |
+  | animation | animation | Web App animation; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1web_app.html).
+  """
+
+  defstruct "@type": "webApp", "@extra": nil, short_name: nil, title: nil, description: nil, photo: nil, animation: nil
 end
 defmodule BackgroundTypeWallpaper do
   @moduledoc  """
@@ -1929,20 +2716,18 @@ defmodule NotificationGroupTypeCalls do
 
   defstruct "@type": "notificationGroupTypeCalls", "@extra": nil
 end
-defmodule ChatStatisticsMessageInteractionInfo do
+defmodule ChatPhotoStickerTypeCustomEmoji do
   @moduledoc  """
-  Contains statistics about interactions with a message.
+  Information about the custom emoji, which was used to create the chat photo.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | message_id | int53 | Message identifier. |
-  | view_count | int32 | Number of times the message was viewed. |
-  | forward_count | int32 | Number of times the message was forwarded. |
+  | custom_emoji_id | int64 | Identifier of the custom emoji. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_statistics_message_interaction_info.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_photo_sticker_type_custom_emoji.html).
   """
 
-  defstruct "@type": "chatStatisticsMessageInteractionInfo", "@extra": nil, message_id: nil, view_count: nil, forward_count: nil
+  defstruct "@type": "chatPhotoStickerTypeCustomEmoji", "@extra": nil, custom_emoji_id: nil
 end
 defmodule BotInfo do
   @moduledoc  """
@@ -1950,7 +2735,7 @@ defmodule BotInfo do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | share_text | string | The text that is shown on the bot's profile page and is sent together with the link when users share the bot. |
+  | short_description | string | The text that is shown on the bot's profile page and is sent together with the link when users share the bot. |
   | description | string | The text shown in the chat with the bot if the chat is empty. |
   | photo | photo | Photo shown in the chat with the bot if the chat is empty; may be null. |
   | animation | animation | Animation shown in the chat with the bot if the chat is empty; may be null. |
@@ -1958,11 +2743,15 @@ defmodule BotInfo do
   | commands | botCommand | List of the bot commands. |
   | default_group_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to basic group and supergroup chats; may be null. |
   | default_channel_administrator_rights | chatAdministratorRights | Default administrator rights for adding the bot to channels; may be null. |
+  | edit_commands_link | InternalLinkType | The internal link, which can be used to edit bot commands; may be null. |
+  | edit_description_link | InternalLinkType | The internal link, which can be used to edit bot description; may be null. |
+  | edit_description_media_link | InternalLinkType | The internal link, which can be used to edit the photo or animation shown in the chat with the bot if the chat is empty; may be null. |
+  | edit_settings_link | InternalLinkType | The internal link, which can be used to edit bot settings; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1bot_info.html).
   """
 
-  defstruct "@type": "botInfo", "@extra": nil, share_text: nil, description: nil, photo: nil, animation: nil, menu_button: nil, commands: nil, default_group_administrator_rights: nil, default_channel_administrator_rights: nil
+  defstruct "@type": "botInfo", "@extra": nil, short_description: nil, description: nil, photo: nil, animation: nil, menu_button: nil, commands: nil, default_group_administrator_rights: nil, default_channel_administrator_rights: nil, edit_commands_link: nil, edit_description_link: nil, edit_description_media_link: nil, edit_settings_link: nil
 end
 defmodule InputMessageVoiceNote do
   @moduledoc  """
@@ -1970,15 +2759,16 @@ defmodule InputMessageVoiceNote do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | voice_note | InputFile | Voice note to be sent. |
+  | voice_note | InputFile | Voice note to be sent. The voice note must be encoded with the Opus codec and stored inside an OGG container with a single audio channel, or be in MP3 or M4A format as regular audio. |
   | duration | int32 | Duration of the voice note, in seconds. |
-  | waveform | bytes | Waveform representation of the voice note, in 5-bit format. |
-  | caption | formattedText | Voice note caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
+  | waveform | bytes | Waveform representation of the voice note in 5-bit format. |
+  | caption | formattedText | Voice note caption; may be null if empty; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | self_destruct_type | MessageSelfDestructType | Voice note self-destruct type; may be null if none; pass null if none; private chats only. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_voice_note.html).
   """
 
-  defstruct "@type": "inputMessageVoiceNote", "@extra": nil, voice_note: nil, duration: nil, waveform: nil, caption: nil
+  defstruct "@type": "inputMessageVoiceNote", "@extra": nil, voice_note: nil, duration: nil, waveform: nil, caption: nil, self_destruct_type: nil
 end
 defmodule InputMessageDice do
   @moduledoc  """
@@ -2020,6 +2810,16 @@ defmodule PushMessageContentVideo do
 
   defstruct "@type": "pushMessageContentVideo", "@extra": nil, video: nil, caption: nil, is_secret: nil, is_pinned: nil
 end
+defmodule PremiumFeatureCustomEmoji do
+  @moduledoc  """
+  Allowed to use custom emoji stickers in message texts and captions.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_custom_emoji.html).
+  """
+
+  defstruct "@type": "premiumFeatureCustomEmoji", "@extra": nil
+end
 defmodule ThemeSettings do
   @moduledoc  """
   Describes theme settings.
@@ -2037,6 +2837,43 @@ defmodule ThemeSettings do
 
   defstruct "@type": "themeSettings", "@extra": nil, accent_color: nil, background: nil, outgoing_message_fill: nil, animate_outgoing_message_fill: nil, outgoing_message_accent_color: nil
 end
+defmodule InternalLinkTypeInstantView do
+  @moduledoc  """
+  The link must be opened in an Instant View. Call getWebPageInstantView with the given URL to process the link. If Instant View is found, then show it, otherwise, open the fallback URL in an external browser.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | URL to be passed to <a class="el" href="classtd_1_1td__api_1_1get_web_page_instant_view.html">getWebPageInstantView</a>. |
+  | fallback_url | string | An URL to open if <a class="el" href="classtd_1_1td__api_1_1get_web_page_instant_view.html">getWebPageInstantView</a> fails. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_instant_view.html).
+  """
+
+  defstruct "@type": "internalLinkTypeInstantView", "@extra": nil, url: nil, fallback_url: nil
+end
+defmodule PremiumFeatureRealTimeChatTranslation do
+  @moduledoc  """
+  Allowed to translate chat messages real-time.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_real_time_chat_translation.html).
+  """
+
+  defstruct "@type": "premiumFeatureRealTimeChatTranslation", "@extra": nil
+end
+defmodule CollectibleItemTypeUsername do
+  @moduledoc  """
+  A username.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | username | string | The username. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1collectible_item_type_username.html).
+  """
+
+  defstruct "@type": "collectibleItemTypeUsername", "@extra": nil, username: nil
+end
 defmodule InputCredentials do
   @moduledoc  """
 
@@ -2045,6 +2882,16 @@ defmodule InputCredentials do
   """
 
   defstruct "@type": "InputCredentials", "@extra": nil
+end
+defmodule EmojiCategorySourcePremium do
+  @moduledoc  """
+  The category contains premium stickers that must be found by getPremiumStickers.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_source_premium.html).
+  """
+
+  defstruct "@type": "emojiCategorySourcePremium", "@extra": nil
 end
 defmodule Updates do
   @moduledoc  """
@@ -2080,7 +2927,7 @@ defmodule PageBlock do
 end
 defmodule ConnectionStateUpdating do
   @moduledoc  """
-  Downloading data received while the application was offline.
+  Downloading data supposed to be received while the application was offline.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1connection_state_updating.html).
@@ -2110,6 +2957,31 @@ defmodule BackgroundFill do
   """
 
   defstruct "@type": "BackgroundFill", "@extra": nil
+end
+defmodule PushMessageContentPremiumGiveaway do
+  @moduledoc  """
+  A message with a Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | winner_count | int32 | Number of users which will receive Telegram Premium subscription gift codes; 0 for pinned message. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation; 0 for pinned message. |
+  | is_pinned | bool | True, if the message is a pinned message with the specified content. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_premium_giveaway.html).
+  """
+
+  defstruct "@type": "pushMessageContentPremiumGiveaway", "@extra": nil, winner_count: nil, month_count: nil, is_pinned: nil
+end
+defmodule ReportReasonUnrelatedLocation do
+  @moduledoc  """
+  The location-based chat is unrelated to its stated location.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_unrelated_location.html).
+  """
+
+  defstruct "@type": "reportReasonUnrelatedLocation", "@extra": nil
 end
 defmodule SessionTypeMac do
   @moduledoc  """
@@ -2168,6 +3040,15 @@ defmodule Users do
 
   defstruct "@type": "users", "@extra": nil, total_count: nil, user_ids: nil
 end
+defmodule StoryOrigin do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_origin.html).
+  """
+
+  defstruct "@type": "StoryOrigin", "@extra": nil
+end
 defmodule PushMessageContentChatAddMembers do
   @moduledoc  """
   New chat members were invited to a group.
@@ -2202,14 +3083,14 @@ defmodule UnreadReaction do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reaction | string | Text representation of the reaction. |
+  | type | ReactionType | Type of the reaction. |
   | sender_id | MessageSender | Identifier of the sender, added the reaction. |
   | is_big | bool | True, if the reaction was added with a big animation. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1unread_reaction.html).
   """
 
-  defstruct "@type": "unreadReaction", "@extra": nil, reaction: nil, sender_id: nil, is_big: nil
+  defstruct "@type": "unreadReaction", "@extra": nil, type: nil, sender_id: nil, is_big: nil
 end
 defmodule NotificationTypeNewSecretChat do
   @moduledoc  """
@@ -2220,6 +3101,35 @@ defmodule NotificationTypeNewSecretChat do
   """
 
   defstruct "@type": "notificationTypeNewSecretChat", "@extra": nil
+end
+defmodule AuthenticationCodeTypeFirebaseAndroid do
+  @moduledoc  """
+  A digit-only authentication code is delivered via Firebase Authentication to the official Android application.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | use_play_integrity | bool | True, if Play Integrity API must be used for device verification. Otherwise, SafetyNet Attestation API must be used. |
+  | nonce | bytes | Nonce to pass to the Play Integrity API or the SafetyNet Attestation API. |
+  | length | int32 | Length of the code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authentication_code_type_firebase_android.html).
+  """
+
+  defstruct "@type": "authenticationCodeTypeFirebaseAndroid", "@extra": nil, use_play_integrity: nil, nonce: nil, length: nil
+end
+defmodule MessageReplyToStory do
+  @moduledoc  """
+  Describes a story replied by a given message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story. |
+  | story_id | int32 | The identifier of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_reply_to_story.html).
+  """
+
+  defstruct "@type": "messageReplyToStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
 end
 defmodule TextParseMode do
   @moduledoc  """
@@ -2257,13 +3167,28 @@ defmodule ChatTypePrivate do
 
   defstruct "@type": "chatTypePrivate", "@extra": nil, user_id: nil
 end
+defmodule MessageChatSetBackground do
+  @moduledoc  """
+  A new background was set in the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_background_message_id | int53 | Identifier of the message with a previously set same background; 0 if none. Can be an identifier of a deleted message. |
+  | background | chatBackground | The new background. |
+  | only_for_self | bool | True, if the background was set only for self. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_set_background.html).
+  """
+
+  defstruct "@type": "messageChatSetBackground", "@extra": nil, old_background_message_id: nil, background: nil, only_for_self: nil
+end
 defmodule NotificationTypeNewPushMessage do
   @moduledoc  """
   New message was received through a push notification.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | message_id | int53 | The message identifier. The message will not be available in the chat history, but the ID can be used in <a class="el" href="classtd_1_1td__api_1_1view_messages.html">viewMessages</a>, or as reply_to_message_id. |
+  | message_id | int53 | The message identifier. The message will not be available in the chat history, but the identifier can be used in <a class="el" href="classtd_1_1td__api_1_1view_messages.html">viewMessages</a>, or as a message to be replied in the same chat. |
   | sender_id | MessageSender | Identifier of the sender of the message. Corresponding user or chat may be inaccessible. |
   | sender_name | string | Name of the sender. |
   | is_outgoing | bool | True, if the message is outgoing. |
@@ -2273,6 +3198,32 @@ defmodule NotificationTypeNewPushMessage do
   """
 
   defstruct "@type": "notificationTypeNewPushMessage", "@extra": nil, message_id: nil, sender_id: nil, sender_name: nil, is_outgoing: nil, content: nil
+end
+defmodule UpdateDefaultReactionType do
+  @moduledoc  """
+  The type of default reaction has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reaction_type | ReactionType | The new type of the default reaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_default_reaction_type.html).
+  """
+
+  defstruct "@type": "updateDefaultReactionType", "@extra": nil, reaction_type: nil
+end
+defmodule NewChatPrivacySettings do
+  @moduledoc  """
+  Contains privacy settings for new chats with non-contacts.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | allow_new_chats_from_unknown_users | bool | True, if non-contacts users are able to write first to the current user. Telegram Premium subscribers are able to write first regardless of this setting. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1new_chat_privacy_settings.html).
+  """
+
+  defstruct "@type": "newChatPrivacySettings", "@extra": nil, allow_new_chats_from_unknown_users: nil
 end
 defmodule ChatSourceMtprotoProxy do
   @moduledoc  """
@@ -2284,18 +3235,36 @@ defmodule ChatSourceMtprotoProxy do
 
   defstruct "@type": "chatSourceMtprotoProxy", "@extra": nil
 end
-defmodule AuthorizationStateWaitEncryptionKey do
+defmodule StarRevenueStatus do
   @moduledoc  """
-  TDLib needs an encryption key to decrypt the local database.
+  Contains information about Telegram stars earned by a bot or a chat.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_encrypted | bool | True, if the database is currently encrypted. |
+  | total_count | int53 | Total number of the stars earned. |
+  | current_count | int53 | The number of Telegram stars that aren't withdrawn yet. |
+  | available_count | int53 | The number of Telegram stars that are available for withdrawal. |
+  | withdrawal_enabled | bool | True, if Telegram stars can be withdrawn now or later. |
+  | next_withdrawal_in | int32 | Time left before the next withdrawal can be started, in seconds; 0 if withdrawal can be started now. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_encryption_key.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_revenue_status.html).
   """
 
-  defstruct "@type": "authorizationStateWaitEncryptionKey", "@extra": nil, is_encrypted: nil
+  defstruct "@type": "starRevenueStatus", "@extra": nil, total_count: nil, current_count: nil, available_count: nil, withdrawal_enabled: nil, next_withdrawal_in: nil
+end
+defmodule UpdateChatBusinessBotManageBar do
+  @moduledoc  """
+  The bar for managing business bot was changed in a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | business_bot_manage_bar | businessBotManageBar | The new value of the business bot manage bar; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_business_bot_manage_bar.html).
+  """
+
+  defstruct "@type": "updateChatBusinessBotManageBar", "@extra": nil, chat_id: nil, business_bot_manage_bar: nil
 end
 defmodule MessageWebAppDataReceived do
   @moduledoc  """
@@ -2304,7 +3273,7 @@ defmodule MessageWebAppDataReceived do
   | Name | Type | Description |
   |------|------| ------------|
   | button_text | string | Text of the <a class="el" href="classtd_1_1td__api_1_1keyboard_button_type_web_app.html">keyboardButtonTypeWebApp</a> button, which opened the Web App. |
-  | data | string | Received data. |
+  | data | string | The data. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_web_app_data_received.html).
   """
@@ -2329,6 +3298,35 @@ defmodule InputInlineQueryResult do
   """
 
   defstruct "@type": "InputInlineQueryResult", "@extra": nil
+end
+defmodule RevenueWithdrawalStateFailed do
+  @moduledoc  """
+  Withdrawal failed.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1revenue_withdrawal_state_failed.html).
+  """
+
+  defstruct "@type": "revenueWithdrawalStateFailed", "@extra": nil
+end
+defmodule PremiumGiftCodeInfo do
+  @moduledoc  """
+  Contains information about a Telegram Premium gift code.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | creator_id | MessageSender | Identifier of a chat or a user that created the gift code; may be null if unknown. If null and the code is from <a class="el" href="classtd_1_1td__api_1_1message_premium_gift_code.html">messagePremiumGiftCode</a> message, then creator_id from the message can be used. |
+  | creation_date | int32 | Point in time (Unix timestamp) when the code was created. |
+  | is_from_giveaway | bool | True, if the gift code was created for a giveaway. |
+  | giveaway_message_id | int53 | Identifier of the corresponding giveaway message in the creator_id chat; can be 0 or an identifier of a deleted message. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+  | user_id | int53 | Identifier of a user for which the code was created; 0 if none. |
+  | use_date | int32 | Point in time (Unix timestamp) when the code was activated; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_gift_code_info.html).
+  """
+
+  defstruct "@type": "premiumGiftCodeInfo", "@extra": nil, creator_id: nil, creation_date: nil, is_from_giveaway: nil, giveaway_message_id: nil, month_count: nil, user_id: nil, use_date: nil
 end
 defmodule PassportElementRentalAgreement do
   @moduledoc  """
@@ -2362,19 +3360,72 @@ defmodule LogStream do
 
   defstruct "@type": "LogStream", "@extra": nil
 end
-defmodule ChatEventMessageTtlChanged do
+defmodule StoryInteractions do
   @moduledoc  """
-  The message TTL was changed.
+  Represents a list of interactions with a story.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | old_message_ttl | int32 | Previous value of message_ttl. |
-  | new_message_ttl | int32 | New value of message_ttl. |
+  | total_count | int32 | Approximate total number of interactions found. |
+  | total_forward_count | int32 | Approximate total number of found forwards and reposts; always 0 for chat stories. |
+  | total_reaction_count | int32 | Approximate total number of found reactions; always 0 for chat stories. |
+  | interactions | storyInteraction | List of story interactions. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_message_ttl_changed.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interactions.html).
   """
 
-  defstruct "@type": "chatEventMessageTtlChanged", "@extra": nil, old_message_ttl: nil, new_message_ttl: nil
+  defstruct "@type": "storyInteractions", "@extra": nil, total_count: nil, total_forward_count: nil, total_reaction_count: nil, interactions: nil, next_offset: nil
+end
+defmodule StickerFullType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_sticker_full_type.html).
+  """
+
+  defstruct "@type": "StickerFullType", "@extra": nil
+end
+defmodule InternalLinkTypeSideMenuBot do
+  @moduledoc  """
+  The link is a link to a bot, which can be installed to the side menu. Call searchPublicChat with the given bot username, check that the user is a bot and can be added to attachment menu. Then, use getAttachmentMenuBot to receive information about the bot. If the bot isn't added to side menu, then show a disclaimer about Mini Apps being a third-party apps, ask the user to accept their Terms of service and confirm adding the bot to side and attachment menu. If the user accept the terms and confirms adding, then use toggleBotIsAddedToAttachmentMenu to add the bot. If the bot is added to side menu, then use getWebAppUrl with the given URL and open the returned URL as a Web App.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_username | string | Username of the bot. |
+  | url | string | URL to be passed to <a class="el" href="classtd_1_1td__api_1_1get_web_app_url.html">getWebAppUrl</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_side_menu_bot.html).
+  """
+
+  defstruct "@type": "internalLinkTypeSideMenuBot", "@extra": nil, bot_username: nil, url: nil
+end
+defmodule CloseBirthdayUser do
+  @moduledoc  """
+  Describes a user that had or will have a birthday soon.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | birthdate | birthdate | Birthdate of the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1close_birthday_user.html).
+  """
+
+  defstruct "@type": "closeBirthdayUser", "@extra": nil, user_id: nil, birthdate: nil
+end
+defmodule InputInvoiceTelegram do
+  @moduledoc  """
+  An invoice for a payment toward Telegram; must not be used in the in-store apps.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | purpose | TelegramPaymentPurpose | Transaction purpose. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_invoice_telegram.html).
+  """
+
+  defstruct "@type": "inputInvoiceTelegram", "@extra": nil, purpose: nil
 end
 defmodule ChatStatisticsInviterInfo do
   @moduledoc  """
@@ -2389,6 +3440,16 @@ defmodule ChatStatisticsInviterInfo do
   """
 
   defstruct "@type": "chatStatisticsInviterInfo", "@extra": nil, user_id: nil, added_member_count: nil
+end
+defmodule PremiumFeatureBackgroundForBoth do
+  @moduledoc  """
+  The ability to set private chat background for both users.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_background_for_both.html).
+  """
+
+  defstruct "@type": "premiumFeatureBackgroundForBoth", "@extra": nil
 end
 defmodule Notification do
   @moduledoc  """
@@ -2405,6 +3466,29 @@ defmodule Notification do
   """
 
   defstruct "@type": "notification", "@extra": nil, id: nil, date: nil, is_silent: nil, type: nil
+end
+defmodule SavedMessagesTopicTypeSavedFromChat do
+  @moduledoc  """
+  Topic containing messages forwarded from a specific chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_topic_type_saved_from_chat.html).
+  """
+
+  defstruct "@type": "savedMessagesTopicTypeSavedFromChat", "@extra": nil, chat_id: nil
+end
+defmodule StoryPrivacySettingsCloseFriends do
+  @moduledoc  """
+  The story can be viewed by all close friends.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_privacy_settings_close_friends.html).
+  """
+
+  defstruct "@type": "storyPrivacySettingsCloseFriends", "@extra": nil
 end
 defmodule ProxyTypeSocks5 do
   @moduledoc  """
@@ -2436,9 +3520,19 @@ defmodule UpdateFileGenerationStart do
 
   defstruct "@type": "updateFileGenerationStart", "@extra": nil, generation_id: nil, original_path: nil, destination_path: nil, conversion: nil
 end
+defmodule BusinessFeatureEmojiStatus do
+  @moduledoc  """
+  The ability to show an emoji status along with the business name.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_emoji_status.html).
+  """
+
+  defstruct "@type": "businessFeatureEmojiStatus", "@extra": nil
+end
 defmodule AuthorizationStateWaitTdlibParameters do
   @moduledoc  """
-  TDLib needs TdlibParameters for initialization.
+  Initialization parameters are needed. Call setTdlibParameters to provide them.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_tdlib_parameters.html).
@@ -2470,12 +3564,15 @@ defmodule StickerSetInfo do
   | id | int64 | Identifier of the sticker set. |
   | title | string | Title of the sticker set. |
   | name | string | Name of the sticker set. |
-  | thumbnail | thumbnail | Sticker set thumbnail in WEBP, TGS, or WEBM format with width and height 100; may be null. |
+  | thumbnail | thumbnail | Sticker set thumbnail in WEBP, TGS, or WEBM format with width and height 100; may be null. The file can be downloaded only before the thumbnail is changed. |
   | thumbnail_outline | closedVectorPath | Sticker set thumbnail's outline represented as a list of closed vector paths; may be empty. The coordinate system origin is in the upper-left corner. |
+  | is_owned | bool | True, if the sticker set is owned by the current user. |
   | is_installed | bool | True, if the sticker set has been installed by the current user. |
   | is_archived | bool | True, if the sticker set has been archived. A sticker set can't be installed and archived simultaneously. |
   | is_official | bool | True, if the sticker set is official. |
   | sticker_type | StickerType | Type of the stickers in the set. |
+  | needs_repainting | bool | True, if stickers in the sticker set are custom emoji that must be repainted; for custom emoji sticker sets only. |
+  | is_allowed_as_chat_emoji_status | bool | True, if stickers in the sticker set are custom emoji that can be used as chat emoji status; for custom emoji sticker sets only. |
   | is_viewed | bool | True for already viewed trending sticker sets. |
   | size | int32 | Total number of stickers in the set. |
   | covers | sticker | Up to the first 5 stickers from the set, depending on the context. If the application needs more stickers the full sticker set needs to be requested. |
@@ -2483,7 +3580,7 @@ defmodule StickerSetInfo do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_set_info.html).
   """
 
-  defstruct "@type": "stickerSetInfo", "@extra": nil, id: nil, title: nil, name: nil, thumbnail: nil, thumbnail_outline: nil, is_installed: nil, is_archived: nil, is_official: nil, sticker_type: nil, is_viewed: nil, size: nil, covers: nil
+  defstruct "@type": "stickerSetInfo", "@extra": nil, id: nil, title: nil, name: nil, thumbnail: nil, thumbnail_outline: nil, is_owned: nil, is_installed: nil, is_archived: nil, is_official: nil, sticker_type: nil, needs_repainting: nil, is_allowed_as_chat_emoji_status: nil, is_viewed: nil, size: nil, covers: nil
 end
 defmodule RichTextReference do
   @moduledoc  """
@@ -2511,35 +3608,40 @@ defmodule ProfilePhoto do
   | big | file | A big (640x640) user profile photo. The file can be downloaded only before the photo is changed. |
   | minithumbnail | minithumbnail | User profile photo minithumbnail; may be null. |
   | has_animation | bool | True, if the photo has animated variant. |
+  | is_personal | bool | True, if the photo is visible only for the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1profile_photo.html).
   """
 
-  defstruct "@type": "profilePhoto", "@extra": nil, id: nil, small: nil, big: nil, minithumbnail: nil, has_animation: nil
+  defstruct "@type": "profilePhoto", "@extra": nil, id: nil, small: nil, big: nil, minithumbnail: nil, has_animation: nil, is_personal: nil
 end
-defmodule ChatReportReasonUnrelatedLocation do
+defmodule MessageUsersShared do
   @moduledoc  """
-  The location-based chat is unrelated to its stated location.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_unrelated_location.html).
-  """
-
-  defstruct "@type": "chatReportReasonUnrelatedLocation", "@extra": nil
-end
-defmodule UpdateSelectedBackground do
-  @moduledoc  """
-  The selected background has changed.
+  The current user shared users, which were requested by the bot.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | for_dark_theme | bool | True, if background for dark theme has changed. |
-  | background | background | The new selected background; may be null. |
+  | users | sharedUser | The shared users. |
+  | button_id | int32 | Identifier of the keyboard button with the request. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_selected_background.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_users_shared.html).
   """
 
-  defstruct "@type": "updateSelectedBackground", "@extra": nil, for_dark_theme: nil, background: nil
+  defstruct "@type": "messageUsersShared", "@extra": nil, users: nil, button_id: nil
+end
+defmodule StarTransactionPartnerUser do
+  @moduledoc  """
+  The transaction is a transaction with another user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of the user. |
+  | product_info | productInfo | Information about the bought product; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_user.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerUser", "@extra": nil, user_id: nil, product_info: nil
 end
 defmodule MessageReaction do
   @moduledoc  """
@@ -2547,15 +3649,16 @@ defmodule MessageReaction do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reaction | string | Text representation of the reaction. |
+  | type | ReactionType | Type of the reaction. |
   | total_count | int32 | Number of times the reaction was added. |
   | is_chosen | bool | True, if the reaction is chosen by the current user. |
+  | used_sender_id | MessageSender | Identifier of the message sender used by the current user to add the reaction; may be null if unknown or the reaction isn't chosen. |
   | recent_sender_ids | MessageSender | Identifiers of at most 3 recent message senders, added the reaction; available in private, basic group and supergroup chats. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_reaction.html).
   """
 
-  defstruct "@type": "messageReaction", "@extra": nil, reaction: nil, total_count: nil, is_chosen: nil, recent_sender_ids: nil
+  defstruct "@type": "messageReaction", "@extra": nil, type: nil, total_count: nil, is_chosen: nil, used_sender_id: nil, recent_sender_ids: nil
 end
 defmodule ChatJoinRequests do
   @moduledoc  """
@@ -2581,9 +3684,83 @@ defmodule TextEntityTypeUnderline do
 
   defstruct "@type": "textEntityTypeUnderline", "@extra": nil
 end
+defmodule Story do
+  @moduledoc  """
+  Represents a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Unique story identifier among stories of the given sender. |
+  | sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | sender_id | MessageSender | Identifier of the sender of the story; may be null if the story is posted on behalf of the sender_chat_id. |
+  | date | int32 | Point in time (Unix timestamp) when the story was published. |
+  | is_being_sent | bool | True, if the story is being sent by the current user. |
+  | is_being_edited | bool | True, if the story is being edited by the current user. |
+  | is_edited | bool | True, if the story was edited. |
+  | is_posted_to_chat_page | bool | True, if the story is saved in the sender's profile and will be available there after expiration. |
+  | is_visible_only_for_self | bool | True, if the story is visible only for the current user. |
+  | can_be_deleted | bool | True, if the story can be deleted. |
+  | can_be_edited | bool | True, if the story can be edited. |
+  | can_be_forwarded | bool | True, if the story can be forwarded as a message. Otherwise, screenshots and saving of the story content must be also forbidden. |
+  | can_be_replied | bool | True, if the story can be replied in the chat with the story sender. |
+  | can_toggle_is_posted_to_chat_page | bool | True, if the story's is_posted_to_chat_page value can be changed. |
+  | can_get_statistics | bool | True, if the story statistics are available through <a class="el" href="classtd_1_1td__api_1_1get_story_statistics.html">getStoryStatistics</a>. |
+  | can_get_interactions | bool | True, if interactions with the story can be received through <a class="el" href="classtd_1_1td__api_1_1get_story_interactions.html">getStoryInteractions</a>. |
+  | has_expired_viewers | bool | True, if users viewed the story can't be received, because the story has expired more than <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("story_viewers_expiration_delay") seconds ago. |
+  | repost_info | storyRepostInfo | Information about the original story; may be null if the story wasn't reposted. |
+  | interaction_info | storyInteractionInfo | Information about interactions with the story; may be null if the story isn't owned or there were no interactions. |
+  | chosen_reaction_type | ReactionType | Type of the chosen reaction; may be null if none. |
+  | privacy_settings | StoryPrivacySettings | Privacy rules affecting story visibility; may be approximate for non-owned stories. |
+  | content | StoryContent | Content of the story. |
+  | areas | storyArea | Clickable areas to be shown on the story content. |
+  | caption | formattedText | Caption of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story.html).
+  """
+
+  defstruct "@type": "story", "@extra": nil, id: nil, sender_chat_id: nil, sender_id: nil, date: nil, is_being_sent: nil, is_being_edited: nil, is_edited: nil, is_posted_to_chat_page: nil, is_visible_only_for_self: nil, can_be_deleted: nil, can_be_edited: nil, can_be_forwarded: nil, can_be_replied: nil, can_toggle_is_posted_to_chat_page: nil, can_get_statistics: nil, can_get_interactions: nil, has_expired_viewers: nil, repost_info: nil, interaction_info: nil, chosen_reaction_type: nil, privacy_settings: nil, content: nil, areas: nil, caption: nil
+end
+defmodule ChatBoostStatus do
+  @moduledoc  """
+  Describes current boost status of a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boost_url | string | An HTTP URL, which can be used to boost the chat. |
+  | applied_slot_ids | int32 | Identifiers of boost slots of the current user applied to the chat. |
+  | level | int32 | Current boost level of the chat. |
+  | gift_code_boost_count | int32 | The number of boosts received by the chat from created Telegram Premium gift codes and giveaways; always 0 if the current user isn't an administrator in the chat. |
+  | boost_count | int32 | The number of boosts received by the chat. |
+  | current_level_boost_count | int32 | The number of boosts added to reach the current level. |
+  | next_level_boost_count | int32 | The number of boosts needed to reach the next level; 0 if the next level isn't available. |
+  | premium_member_count | int32 | Approximate number of Telegram Premium subscribers joined the chat; always 0 if the current user isn't an administrator in the chat. |
+  | premium_member_percentage | double | A percentage of Telegram Premium subscribers joined the chat; always 0 if the current user isn't an administrator in the chat. |
+  | prepaid_giveaways | prepaidPremiumGiveaway | The list of prepaid giveaways available for the chat; only for chat administrators. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_status.html).
+  """
+
+  defstruct "@type": "chatBoostStatus", "@extra": nil, boost_url: nil, applied_slot_ids: nil, level: nil, gift_code_boost_count: nil, boost_count: nil, current_level_boost_count: nil, next_level_boost_count: nil, premium_member_count: nil, premium_member_percentage: nil, prepaid_giveaways: nil
+end
+defmodule ChatEventAccentColorChanged do
+  @moduledoc  """
+  The chat accent color or background custom emoji were changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_accent_color_id | int32 | Previous identifier of chat accent color. |
+  | old_background_custom_emoji_id | int64 | Previous identifier of the custom emoji; 0 if none. |
+  | new_accent_color_id | int32 | New identifier of chat accent color. |
+  | new_background_custom_emoji_id | int64 | New identifier of the custom emoji; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_accent_color_changed.html).
+  """
+
+  defstruct "@type": "chatEventAccentColorChanged", "@extra": nil, old_accent_color_id: nil, old_background_custom_emoji_id: nil, new_accent_color_id: nil, new_background_custom_emoji_id: nil
+end
 defmodule InternalLinkTypeBotAddToChannel do
   @moduledoc  """
-  The link is a link to a Telegram bot, which is supposed to be added to a channel chat as an administrator. Call searchPublicChat with the given bot username and check that the user is a bot, ask the current user to select a channel chat to add the bot to as an administrator. Then call getChatMember to receive the current bot rights in the chat and if the bot already is an administrator, check that the current user can edit its administrator rights and combine received rights with the requested administrator rights. Then show confirmation box to the user, and call setChatMemberStatus with the chosen chat and confirmed rights.
+  The link is a link to a Telegram bot, which is supposed to be added to a channel chat as an administrator. Call searchPublicChat with the given bot username and check that the user is a bot, ask the current user to select a channel chat to add the bot to as an administrator. Then, call getChatMember to receive the current bot rights in the chat and if the bot already is an administrator, check that the current user can edit its administrator rights and combine received rights with the requested administrator rights. Then, show confirmation box to the user, and call setChatMemberStatus with the chosen chat and confirmed rights.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -2594,6 +3771,21 @@ defmodule InternalLinkTypeBotAddToChannel do
   """
 
   defstruct "@type": "internalLinkTypeBotAddToChannel", "@extra": nil, bot_username: nil, administrator_rights: nil
+end
+defmodule InputBusinessStartPage do
+  @moduledoc  """
+  Describes settings for a business account start page to set.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | title | string | Title text of the start page; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("business_start_page_title_length_max") characters. |
+  | message | string | Message text of the start page; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("business_start_page_message_length_max") characters. |
+  | sticker | InputFile | Greeting sticker of the start page; pass null if none. The sticker must belong to a sticker set and must not be a custom emoji. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_business_start_page.html).
+  """
+
+  defstruct "@type": "inputBusinessStartPage", "@extra": nil, title: nil, message: nil, sticker: nil
 end
 defmodule UserPrivacySetting do
   @moduledoc  """
@@ -2617,6 +3809,29 @@ defmodule PushMessageContentText do
   """
 
   defstruct "@type": "pushMessageContentText", "@extra": nil, text: nil, is_pinned: nil
+end
+defmodule AuthenticationCodeTypeSmsWord do
+  @moduledoc  """
+  An authentication code is a word delivered via an SMS message to the specified phone number; non-official applications may not receive this type of code.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | first_letter | string | The first letters of the word if known. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authentication_code_type_sms_word.html).
+  """
+
+  defstruct "@type": "authenticationCodeTypeSmsWord", "@extra": nil, first_letter: nil
+end
+defmodule MessageSourceChatList do
+  @moduledoc  """
+  The message is from a chat list or a forum topic list.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_chat_list.html).
+  """
+
+  defstruct "@type": "messageSourceChatList", "@extra": nil
 end
 defmodule MessageChatChangeTitle do
   @moduledoc  """
@@ -2662,7 +3877,7 @@ defmodule AddedReactions do
   |------|------| ------------|
   | total_count | int32 | The total number of found reactions. |
   | reactions | addedReaction | The list of added reactions. |
-  | next_offset | string | The offset for the next request. If empty, there are no more results. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1added_reactions.html).
   """
@@ -2712,6 +3927,26 @@ defmodule MaskPointEyes do
 
   defstruct "@type": "maskPointEyes", "@extra": nil
 end
+defmodule PremiumStoryFeaturePermanentViewsHistory do
+  @moduledoc  """
+  The ability to check who opened the current user's stories after they expire.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_permanent_views_history.html).
+  """
+
+  defstruct "@type": "premiumStoryFeaturePermanentViewsHistory", "@extra": nil
+end
+defmodule PremiumLimitTypeActiveStoryCount do
+  @moduledoc  """
+  The maximum number of active stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_active_story_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeActiveStoryCount", "@extra": nil
+end
 defmodule ChatActionUploadingVideo do
   @moduledoc  """
   The user is uploading a video.
@@ -2725,18 +3960,33 @@ defmodule ChatActionUploadingVideo do
 
   defstruct "@type": "chatActionUploadingVideo", "@extra": nil, progress: nil
 end
-defmodule MessageChatSetTtl do
+defmodule InternalLinkTypeWebApp do
   @moduledoc  """
-  The TTL (Time To Live) setting for messages in the chat has been changed.
+  The link is a link to a Web App. Call searchPublicChat with the given bot username, check that the user is a bot, then call searchWebApp with the received bot and the given web_app_short_name. Process received foundWebApp by showing a confirmation dialog if needed. If the bot can be added to attachment or side menu, but isn't added yet, then show a disclaimer about Mini Apps being a third-party apps instead of the dialog and ask the user to accept their Terms of service. If the user accept the terms and confirms adding, then use toggleBotIsAddedToAttachmentMenu to add the bot. Then, call getWebAppLinkUrl and open the returned URL as a Web App.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | ttl | int32 | New message TTL. |
+  | bot_username | string | Username of the bot that owns the Web App. |
+  | web_app_short_name | string | Short name of the Web App. |
+  | start_parameter | string | Start parameter to be passed to <a class="el" href="classtd_1_1td__api_1_1get_web_app_link_url.html">getWebAppLinkUrl</a>. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_set_ttl.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_web_app.html).
   """
 
-  defstruct "@type": "messageChatSetTtl", "@extra": nil, ttl: nil
+  defstruct "@type": "internalLinkTypeWebApp", "@extra": nil, bot_username: nil, web_app_short_name: nil, start_parameter: nil
+end
+defmodule MessageForumTopicIsHiddenToggled do
+  @moduledoc  """
+  A General forum topic has been hidden or unhidden.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_hidden | bool | True, if the topic was hidden; otherwise, the topic was unhidden. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forum_topic_is_hidden_toggled.html).
+  """
+
+  defstruct "@type": "messageForumTopicIsHiddenToggled", "@extra": nil, is_hidden: nil
 end
 defmodule ChatEventAvailableReactionsChanged do
   @moduledoc  """
@@ -2744,8 +3994,8 @@ defmodule ChatEventAvailableReactionsChanged do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | old_available_reactions | string | Previous chat available reactions. |
-  | new_available_reactions | string | New chat available reactions. |
+  | old_available_reactions | ChatAvailableReactions | Previous chat available reactions. |
+  | new_available_reactions | ChatAvailableReactions | New chat available reactions. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_available_reactions_changed.html).
   """
@@ -2831,16 +4081,6 @@ defmodule PollType do
 
   defstruct "@type": "PollType", "@extra": nil
 end
-defmodule InternalLinkTypeFilterSettings do
-  @moduledoc  """
-  The link is a link to the filter settings section of the app.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_filter_settings.html).
-  """
-
-  defstruct "@type": "internalLinkTypeFilterSettings", "@extra": nil
-end
 defmodule PushMessageContentVoiceNote do
   @moduledoc  """
   A voice note message.
@@ -2871,6 +4111,20 @@ defmodule InlineQueryResultLocation do
 
   defstruct "@type": "inlineQueryResultLocation", "@extra": nil, id: nil, location: nil, title: nil, thumbnail: nil
 end
+defmodule InputMessageReplyToMessage do
+  @moduledoc  """
+  Describes a message to be replied in the same chat and forum topic.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_id | int53 | The identifier of the message to be replied in the same chat and forum topic. |
+  | quote | inputTextQuote | Quote from the message to be replied; pass null if none. Must always be null for replies in secret chats. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_reply_to_message.html).
+  """
+
+  defstruct "@type": "inputMessageReplyToMessage", "@extra": nil, message_id: nil, quote: nil
+end
 defmodule PageBlockFooter do
   @moduledoc  """
   The footer of a page.
@@ -2883,6 +4137,15 @@ defmodule PageBlockFooter do
   """
 
   defstruct "@type": "pageBlockFooter", "@extra": nil, footer: nil
+end
+defmodule PremiumGiveawayInfo do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_premium_giveaway_info.html).
+  """
+
+  defstruct "@type": "PremiumGiveawayInfo", "@extra": nil
 end
 defmodule Sessions do
   @moduledoc  """
@@ -2910,6 +4173,59 @@ defmodule JsonValueString do
   """
 
   defstruct "@type": "jsonValueString", "@extra": nil, value: nil
+end
+defmodule StickerFullTypeMask do
+  @moduledoc  """
+  The sticker is a mask in WEBP format to be placed on photos or videos.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | mask_position | maskPosition | Position where the mask is placed; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_full_type_mask.html).
+  """
+
+  defstruct "@type": "stickerFullTypeMask", "@extra": nil, mask_position: nil
+end
+defmodule UpdateApplicationVerificationRequired do
+  @moduledoc  """
+  A request can't be completed unless application verification is performed; for official mobile applications only. The method setApplicationVerificationToken must be called once the verification is completed or failed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | verification_id | int53 | Unique identifier for the verification process. |
+  | nonce | string | Unique nonce for the classic Play Integrity verification (<a href="https://developer.android.com/google/play/integrity/classic">https://developer.android.com/google/play/integrity/classic</a>) for Android, or a unique string to compare with verify_nonce field from a push notification for iOS. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_application_verification_required.html).
+  """
+
+  defstruct "@type": "updateApplicationVerificationRequired", "@extra": nil, verification_id: nil, nonce: nil
+end
+defmodule ReportReasonPornography do
+  @moduledoc  """
+  The chat contains pornographic messages.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_pornography.html).
+  """
+
+  defstruct "@type": "reportReasonPornography", "@extra": nil
+end
+defmodule BusinessAwayMessageSettings do
+  @moduledoc  """
+  Describes settings for messages that are automatically sent by a Telegram Business account when it is away.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | Unique quick reply shortcut identifier for the away messages. |
+  | recipients | businessRecipients | Chosen recipients of the away messages. |
+  | schedule | BusinessAwayMessageSchedule | Settings used to check whether the current user is away. |
+  | offline_only | bool | True, if the messages must not be sent if the account was online in the last 10 minutes. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_away_message_settings.html).
+  """
+
+  defstruct "@type": "businessAwayMessageSettings", "@extra": nil, shortcut_id: nil, recipients: nil, schedule: nil, offline_only: nil
 end
 defmodule EmailAddressAuthenticationCodeInfo do
   @moduledoc  """
@@ -2978,6 +4294,16 @@ defmodule MessageDocument do
 
   defstruct "@type": "messageDocument", "@extra": nil, document: nil, caption: nil
 end
+defmodule StarTransactionPartnerAppStore do
+  @moduledoc  """
+  The transaction is a transaction with App Store.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_app_store.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerAppStore", "@extra": nil
+end
 defmodule AuthorizationStateClosing do
   @moduledoc  """
   TDLib is closing, all subsequent queries will be answered with the error 500. Note that closing TDLib can take a while. All resources will be freed only after authorizationStateClosed has been received.
@@ -2987,6 +4313,34 @@ defmodule AuthorizationStateClosing do
   """
 
   defstruct "@type": "authorizationStateClosing", "@extra": nil
+end
+defmodule ChatBoostSourceGiftCode do
+  @moduledoc  """
+  The chat created a Telegram Premium gift code for a user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of a user, for which the gift code was created. |
+  | gift_code | string | The created Telegram Premium gift code, which is known only if this is a gift code for the current user, or it has already been claimed. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_source_gift_code.html).
+  """
+
+  defstruct "@type": "chatBoostSourceGiftCode", "@extra": nil, user_id: nil, gift_code: nil
+end
+defmodule InputStoryAreaTypeFoundVenue do
+  @moduledoc  """
+  An area pointing to a venue found by the bot getOption("venue_search_bot_username").
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | query_id | int64 | Identifier of the inline query, used to found the venue. |
+  | result_id | string | Identifier of the inline query result. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_found_venue.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypeFoundVenue", "@extra": nil, query_id: nil, result_id: nil
 end
 defmodule MessagePoll do
   @moduledoc  """
@@ -3007,7 +4361,7 @@ defmodule CallStateDiscarded do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reason | CallDiscardReason | The reason, why the call has ended. |
+  | reason | CallDiscardReason | The reason why the call has ended. |
   | need_rating | bool | True, if the call rating must be sent to the server. |
   | need_debug_information | bool | True, if the call debug information must be sent to the server. |
   | need_log | bool | True, if the call log must be sent to the server. |
@@ -3016,6 +4370,16 @@ defmodule CallStateDiscarded do
   """
 
   defstruct "@type": "callStateDiscarded", "@extra": nil, reason: nil, need_rating: nil, need_debug_information: nil, need_log: nil
+end
+defmodule SuggestedActionRestorePremium do
+  @moduledoc  """
+  Suggests the user to restore a recently expired Premium subscription.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_restore_premium.html).
+  """
+
+  defstruct "@type": "suggestedActionRestorePremium", "@extra": nil
 end
 defmodule LanguagePackStringValuePluralized do
   @moduledoc  """
@@ -3048,6 +4412,25 @@ defmodule MessagePassportDataSent do
 
   defstruct "@type": "messagePassportDataSent", "@extra": nil, types: nil
 end
+defmodule StickerFormatWebp do
+  @moduledoc  """
+  The sticker is an image in WEBP format.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_format_webp.html).
+  """
+
+  defstruct "@type": "stickerFormatWebp", "@extra": nil
+end
+defmodule BlockList do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_block_list.html).
+  """
+
+  defstruct "@type": "BlockList", "@extra": nil
+end
 defmodule DiceStickersRegular do
   @moduledoc  """
   A regular animated sticker.
@@ -3061,24 +4444,29 @@ defmodule DiceStickersRegular do
 
   defstruct "@type": "diceStickersRegular", "@extra": nil, sticker: nil
 end
+defmodule InternalLinkTypeStory do
+  @moduledoc  """
+  The link is a link to a story. Call searchPublicChat with the given sender username, then call getStory with the received chat identifier and the given story identifier, then show the story if received.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_username | string | Username of the sender of the story. |
+  | story_id | int32 | Story identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_story.html).
+  """
+
+  defstruct "@type": "internalLinkTypeStory", "@extra": nil, story_sender_username: nil, story_id: nil
+end
 defmodule TextEntityTypeMention do
   @moduledoc  """
-  A mention of a user by their username.
+  A mention of a user, a supergroup, or a channel by their username.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_mention.html).
   """
 
   defstruct "@type": "textEntityTypeMention", "@extra": nil
-end
-defmodule ChatReportReason do
-  @moduledoc  """
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_report_reason.html).
-  """
-
-  defstruct "@type": "ChatReportReason", "@extra": nil
 end
 defmodule ChatStatisticsSupergroup do
   @moduledoc  """
@@ -3140,6 +4528,20 @@ defmodule TestBytes do
 
   defstruct "@type": "testBytes", "@extra": nil, value: nil
 end
+defmodule StoryAreaTypeLocation do
+  @moduledoc  """
+  An area pointing to a location.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | location | location | The location. |
+  | address | locationAddress | Address of the location; may be null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_type_location.html).
+  """
+
+  defstruct "@type": "storyAreaTypeLocation", "@extra": nil, location: nil, address: nil
+end
 defmodule ChatActionUploadingPhoto do
   @moduledoc  """
   The user is uploading a photo.
@@ -3153,9 +4555,60 @@ defmodule ChatActionUploadingPhoto do
 
   defstruct "@type": "chatActionUploadingPhoto", "@extra": nil, progress: nil
 end
+defmodule StarTransactionDirectionIncoming do
+  @moduledoc  """
+  The transaction is incoming and increases the number of owned Telegram stars.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_direction_incoming.html).
+  """
+
+  defstruct "@type": "starTransactionDirectionIncoming", "@extra": nil
+end
+defmodule MessageEffectTypePremiumSticker do
+  @moduledoc  """
+  An effect from a premium sticker.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker | sticker | The premium sticker. The effect can be found at sticker.full_type.premium_animation. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_effect_type_premium_sticker.html).
+  """
+
+  defstruct "@type": "messageEffectTypePremiumSticker", "@extra": nil, sticker: nil
+end
+defmodule ProductInfo do
+  @moduledoc  """
+  Contains information about a product that can be paid with invoice.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | title | string | Product title. |
+  | description | formattedText | Product description. |
+  | photo | photo | Product photo; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1product_info.html).
+  """
+
+  defstruct "@type": "productInfo", "@extra": nil, title: nil, description: nil, photo: nil
+end
+defmodule InternalLinkTypeChatBoost do
+  @moduledoc  """
+  The link is a link to boost a Telegram chat. Call getChatBoostLinkInfo with the given URL to process the link. If the chat is found, then call getChatBoostStatus and getAvailableChatBoostSlots to get the current boost status and check whether the chat can be boosted. If the user wants to boost the chat and the chat can be boosted, then call boostChat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | URL to be passed to <a class="el" href="classtd_1_1td__api_1_1get_chat_boost_link_info.html">getChatBoostLinkInfo</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_chat_boost.html).
+  """
+
+  defstruct "@type": "internalLinkTypeChatBoost", "@extra": nil, url: nil
+end
 defmodule RtmpUrl do
   @moduledoc  """
-  Represents an RTMP url.
+  Represents an RTMP URL.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3166,6 +4619,16 @@ defmodule RtmpUrl do
   """
 
   defstruct "@type": "rtmpUrl", "@extra": nil, url: nil, stream_key: nil
+end
+defmodule PremiumGiveawayParticipantStatusEligible do
+  @moduledoc  """
+  The user is eligible for the giveaway.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_participant_status_eligible.html).
+  """
+
+  defstruct "@type": "premiumGiveawayParticipantStatusEligible", "@extra": nil
 end
 defmodule PushMessageContentMessageForwards do
   @moduledoc  """
@@ -3230,9 +4693,23 @@ defmodule SupergroupMembersFilterSearch do
 
   defstruct "@type": "supergroupMembersFilterSearch", "@extra": nil, query: nil
 end
+defmodule PaymentReceiptTypeStars do
+  @moduledoc  """
+  The payment was done using Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | star_count | int53 | Number of Telegram stars that were paid. |
+  | transaction_id | string | Unique identifier of the transaction that can be used to dispute it. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_receipt_type_stars.html).
+  """
+
+  defstruct "@type": "paymentReceiptTypeStars", "@extra": nil, star_count: nil, transaction_id: nil
+end
 defmodule InternalLinkTypeAttachmentMenuBot do
   @moduledoc  """
-  The link is a link to an attachment menu bot to be opened in the specified or a chosen chat. Process given target_chat to open the chat. Then call searchPublicChat with the given bot username, check that the user is a bot and can be added to attachment menu. Then use getAttachmentMenuBot to receive information about the bot. If the bot isn't added to attachment menu, then user needs to confirm adding the bot to attachment menu. If user confirms adding, then use toggleBotIsAddedToAttachmentMenu to add it. If the attachment menu bot can't be used in the opened chat, show an error to the user. If the bot is added to attachment menu and can be used in the chat, then use openWebApp with the given URL.
+  The link is a link to an attachment menu bot to be opened in the specified or a chosen chat. Process given target_chat to open the chat. Then, call searchPublicChat with the given bot username, check that the user is a bot and can be added to attachment menu. Then, use getAttachmentMenuBot to receive information about the bot. If the bot isn't added to attachment menu, then show a disclaimer about Mini Apps being a third-party apps, ask the user to accept their Terms of service and confirm adding the bot to side and attachment menu. If the user accept the terms and confirms adding, then use toggleBotIsAddedToAttachmentMenu to add the bot. If the attachment menu bot can't be used in the opened chat, show an error to the user. If the bot is added to attachment menu and can be used in the chat, then use openWebApp with the given URL.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3244,6 +4721,62 @@ defmodule InternalLinkTypeAttachmentMenuBot do
   """
 
   defstruct "@type": "internalLinkTypeAttachmentMenuBot", "@extra": nil, target_chat: nil, bot_username: nil, url: nil
+end
+defmodule MessageExtendedMediaVideo do
+  @moduledoc  """
+  The media is a video.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | video | video | The video. |
+  | caption | formattedText | Photo caption. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_extended_media_video.html).
+  """
+
+  defstruct "@type": "messageExtendedMediaVideo", "@extra": nil, video: nil, caption: nil
+end
+defmodule ChatEventBackgroundChanged do
+  @moduledoc  """
+  The chat background was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_background | chatBackground | Previous background; may be null if none. |
+  | new_background | chatBackground | New background; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_background_changed.html).
+  """
+
+  defstruct "@type": "chatEventBackgroundChanged", "@extra": nil, old_background: nil, new_background: nil
+end
+defmodule UpdateStorySendFailed do
+  @moduledoc  """
+  A story failed to send. If the story sending is canceled, then updateStoryDeleted will be received instead of this update.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story | story | The failed to send story. |
+  | error | error | The cause of the story sending failure. |
+  | error_type | CanSendStoryResult | Type of the error; may be null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story_send_failed.html).
+  """
+
+  defstruct "@type": "updateStorySendFailed", "@extra": nil, story: nil, error: nil, error_type: nil
+end
+defmodule UpdateContactCloseBirthdays do
+  @moduledoc  """
+  The list of contacts that had birthdays recently or will have birthday soon has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | close_birthday_users | closeBirthdayUser | List of contact users with close birthday. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_contact_close_birthdays.html).
+  """
+
+  defstruct "@type": "updateContactCloseBirthdays", "@extra": nil, close_birthday_users: nil
 end
 defmodule PaymentProviderOther do
   @moduledoc  """
@@ -3267,19 +4800,28 @@ defmodule User do
   | id | int53 | User identifier. |
   | first_name | string | First name of the user. |
   | last_name | string | Last name of the user. |
-  | username | string | Username of the user. |
+  | usernames | usernames | Usernames of the user; may be null. |
   | phone_number | string | Phone number of the user. |
   | status | UserStatus | Current online status of the user. |
   | profile_photo | profilePhoto | Profile photo of the user; may be null. |
+  | accent_color_id | int32 | Identifier of the accent color for name, and backgrounds of profile photo, reply header, and link preview. For Telegram Premium users only. |
+  | background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the reply header and link preview background; 0 if none. For Telegram Premium users only. |
+  | profile_accent_color_id | int32 | Identifier of the accent color for the user's profile; -1 if none. For Telegram Premium users only. |
+  | profile_background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the background of the user's profile; 0 if none. For Telegram Premium users only. |
+  | emoji_status | emojiStatus | Emoji status to be shown instead of the default Telegram Premium badge; may be null. For Telegram Premium users only. |
   | is_contact | bool | The user is a contact of the current user. |
   | is_mutual_contact | bool | The user is a contact of the current user and the current user is a contact of the user. |
+  | is_close_friend | bool | The user is a close friend of the current user; implies that the user is a contact. |
   | is_verified | bool | True, if the user is verified. |
   | is_premium | bool | True, if the user is a Telegram Premium user. |
   | is_support | bool | True, if the user is Telegram support account. |
   | restriction_reason | string | If non-empty, it contains a human-readable description of the reason why access to this user must be restricted. |
   | is_scam | bool | True, if many users reported this user as a scam. |
   | is_fake | bool | True, if many users reported this user as a fake account. |
-  | have_access | bool | If false, the user is inaccessible, and the only information known about the user is inside this class. Identifier of the user can't be passed to any method except GetUser. |
+  | has_active_stories | bool | True, if the user has non-expired stories available to the current user. |
+  | has_unread_active_stories | bool | True, if the user has unread non-expired stories available to the current user. |
+  | restricts_new_chats | bool | True, if the user may restrict new chats with non-contacts. Use <a class="el" href="classtd_1_1td__api_1_1can_send_message_to_user.html">canSendMessageToUser</a> to check whether the current user can message the user or try to create a chat with them. |
+  | have_access | bool | If false, the user is inaccessible, and the only information known about the user is inside this class. Identifier of the user can't be passed to any method. |
   | type | UserType | Type of the user. |
   | language_code | string | IETF language tag of the user's language; only available to bots. |
   | added_to_attachment_menu | bool | True, if the user added the current bot to attachment menu; only available to bots. |
@@ -3287,7 +4829,7 @@ defmodule User do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user.html).
   """
 
-  defstruct "@type": "user", "@extra": nil, id: nil, first_name: nil, last_name: nil, username: nil, phone_number: nil, status: nil, profile_photo: nil, is_contact: nil, is_mutual_contact: nil, is_verified: nil, is_premium: nil, is_support: nil, restriction_reason: nil, is_scam: nil, is_fake: nil, have_access: nil, type: nil, language_code: nil, added_to_attachment_menu: nil
+  defstruct "@type": "user", "@extra": nil, id: nil, first_name: nil, last_name: nil, usernames: nil, phone_number: nil, status: nil, profile_photo: nil, accent_color_id: nil, background_custom_emoji_id: nil, profile_accent_color_id: nil, profile_background_custom_emoji_id: nil, emoji_status: nil, is_contact: nil, is_mutual_contact: nil, is_close_friend: nil, is_verified: nil, is_premium: nil, is_support: nil, restriction_reason: nil, is_scam: nil, is_fake: nil, has_active_stories: nil, has_unread_active_stories: nil, restricts_new_chats: nil, have_access: nil, type: nil, language_code: nil, added_to_attachment_menu: nil
 end
 defmodule UpdateChatReplyMarkup do
   @moduledoc  """
@@ -3302,6 +4844,46 @@ defmodule UpdateChatReplyMarkup do
   """
 
   defstruct "@type": "updateChatReplyMarkup", "@extra": nil, chat_id: nil, reply_markup_message_id: nil
+end
+defmodule EmailAddressAuthenticationGoogleId do
+  @moduledoc  """
+  An authentication token received through Google ID.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | The token. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1email_address_authentication_google_id.html).
+  """
+
+  defstruct "@type": "emailAddressAuthenticationGoogleId", "@extra": nil, token: nil
+end
+defmodule EmailAddressResetStatePending do
+  @moduledoc  """
+  Email address reset has already been requested. Call resetAuthenticationEmailAddress to check whether immediate reset is possible.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reset_in | int32 | Left time before the email address will be reset, in seconds. <a class="el" href="classtd_1_1td__api_1_1update_authorization_state.html">updateAuthorizationState</a> is not sent when this field changes. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1email_address_reset_state_pending.html).
+  """
+
+  defstruct "@type": "emailAddressResetStatePending", "@extra": nil, reset_in: nil
+end
+defmodule BusinessChatLinkInfo do
+  @moduledoc  """
+  Contains information about a business chat link.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the private chat that created the link. |
+  | text | formattedText | Message draft text that must be added to the input field. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_chat_link_info.html).
+  """
+
+  defstruct "@type": "businessChatLinkInfo", "@extra": nil, chat_id: nil, text: nil
 end
 defmodule ChatEventInviteLinkEdited do
   @moduledoc  """
@@ -3325,15 +4907,17 @@ defmodule UpdateChatMember do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | actor_user_id | int53 | Identifier of the user, changing the rights. |
-  | date | int32 | Point in time (Unix timestamp) when the user rights was changed. |
+  | date | int32 | Point in time (Unix timestamp) when the user rights were changed. |
   | invite_link | chatInviteLink | If user has joined the chat using an invite link, the invite link; may be null. |
+  | via_join_request | bool | True, if the user has joined the chat after sending a join request and being approved by an administrator. |
+  | via_chat_folder_invite_link | bool | True, if the user has joined the chat using an invite link for a chat folder. |
   | old_chat_member | chatMember | Previous chat member. |
   | new_chat_member | chatMember | New chat member. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_member.html).
   """
 
-  defstruct "@type": "updateChatMember", "@extra": nil, chat_id: nil, actor_user_id: nil, date: nil, invite_link: nil, old_chat_member: nil, new_chat_member: nil
+  defstruct "@type": "updateChatMember", "@extra": nil, chat_id: nil, actor_user_id: nil, date: nil, invite_link: nil, via_join_request: nil, via_chat_folder_invite_link: nil, old_chat_member: nil, new_chat_member: nil
 end
 defmodule CallProblemEcho do
   @moduledoc  """
@@ -3347,7 +4931,7 @@ defmodule CallProblemEcho do
 end
 defmodule InternalLinkTypePremiumFeatures do
   @moduledoc  """
-  The link is a link to the Premium features screen of the applcation from which the user can subscribe to Telegram Premium. Call getPremiumFeatures with the given referrer to process the link.
+  The link is a link to the Premium features screen of the application from which the user can subscribe to Telegram Premium. Call getPremiumFeatures with the given referrer to process the link.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3376,6 +4960,24 @@ defmodule ThumbnailFormat do
 
   defstruct "@type": "ThumbnailFormat", "@extra": nil
 end
+defmodule ChatBoostSource do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_boost_source.html).
+  """
+
+  defstruct "@type": "ChatBoostSource", "@extra": nil
+end
+defmodule SpeechRecognitionResult do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_speech_recognition_result.html).
+  """
+
+  defstruct "@type": "SpeechRecognitionResult", "@extra": nil
+end
 defmodule InlineQueryResultAudio do
   @moduledoc  """
   Represents an audio file.
@@ -3390,6 +4992,23 @@ defmodule InlineQueryResultAudio do
 
   defstruct "@type": "inlineQueryResultAudio", "@extra": nil, id: nil, audio: nil
 end
+defmodule UpdateChatAccentColors do
+  @moduledoc  """
+  Chat accent colors have changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | accent_color_id | int32 | The new chat accent color identifier. |
+  | background_custom_emoji_id | int64 | The new identifier of a custom emoji to be shown on the reply header and link preview background; 0 if none. |
+  | profile_accent_color_id | int32 | The new chat profile accent color identifier; -1 if none. |
+  | profile_background_custom_emoji_id | int64 | The new identifier of a custom emoji to be shown on the profile background; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_accent_colors.html).
+  """
+
+  defstruct "@type": "updateChatAccentColors", "@extra": nil, chat_id: nil, accent_color_id: nil, background_custom_emoji_id: nil, profile_accent_color_id: nil, profile_background_custom_emoji_id: nil
+end
 defmodule InputBackground do
   @moduledoc  """
 
@@ -3398,6 +5017,46 @@ defmodule InputBackground do
   """
 
   defstruct "@type": "InputBackground", "@extra": nil
+end
+defmodule ChatEventForumTopicCreated do
+  @moduledoc  """
+  A new forum topic was created.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic_info | forumTopicInfo | Information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_created.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicCreated", "@extra": nil, topic_info: nil
+end
+defmodule ChatRevenueTransactionTypeEarnings do
+  @moduledoc  """
+  Describes earnings from sponsored messages in a chat in some time frame.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | start_date | int32 | Point in time (Unix timestamp) when the earnings started. |
+  | end_date | int32 | Point in time (Unix timestamp) when the earnings ended. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_transaction_type_earnings.html).
+  """
+
+  defstruct "@type": "chatRevenueTransactionTypeEarnings", "@extra": nil, start_date: nil, end_date: nil
+end
+defmodule InternalLinkTypePremiumGiftCode do
+  @moduledoc  """
+  The link is a link with a Telegram Premium gift code. Call checkPremiumGiftCode with the given code to process the link. If the code is valid and the user wants to apply it, then call applyPremiumGiftCode.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | string | The Telegram Premium gift code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_premium_gift_code.html).
+  """
+
+  defstruct "@type": "internalLinkTypePremiumGiftCode", "@extra": nil, code: nil
 end
 defmodule InputInlineQueryResultLocation do
   @moduledoc  """
@@ -3446,6 +5105,19 @@ defmodule KeyboardButtonType do
 
   defstruct "@type": "KeyboardButtonType", "@extra": nil
 end
+defmodule StarPaymentOptions do
+  @moduledoc  """
+  Contains a list of options for buying Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | options | starPaymentOption | The list of options. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_payment_options.html).
+  """
+
+  defstruct "@type": "starPaymentOptions", "@extra": nil, options: nil
+end
 defmodule KeyboardButtonTypeText do
   @moduledoc  """
   A simple button, with text that must be sent when the button is pressed.
@@ -3488,26 +5160,41 @@ defmodule MessageSendOptions do
   | disable_notification | bool | Pass true to disable notification for the message. |
   | from_background | bool | Pass true if the message is sent from the background. |
   | protect_content | bool | Pass true if the content of the message must be protected from forwarding and saving; for bots only. |
+  | update_order_of_installed_sticker_sets | bool | Pass true if the user explicitly chosen a sticker or a custom emoji from an installed sticker set; applicable only to <a class="el" href="classtd_1_1td__api_1_1send_message.html">sendMessage</a> and <a class="el" href="classtd_1_1td__api_1_1send_message_album.html">sendMessageAlbum</a>. |
   | scheduling_state | MessageSchedulingState | Message scheduling state; pass null to send message immediately. Messages sent to a secret chat, live location messages and self-destructing messages can't be scheduled. |
+  | effect_id | int64 | Identifier of the effect to apply to the message; pass 0 if none; applicable only to <a class="el" href="classtd_1_1td__api_1_1send_message.html">sendMessage</a> and <a class="el" href="classtd_1_1td__api_1_1send_message_album.html">sendMessageAlbum</a> in private chats. |
+  | sending_id | int32 | Non-persistent identifier, which will be returned back in <a class="el" href="classtd_1_1td__api_1_1message_sending_state_pending.html">messageSendingStatePending</a> object and can be used to match sent messages and corresponding <a class="el" href="classtd_1_1td__api_1_1update_new_message.html">updateNewMessage</a> updates. |
+  | only_preview | bool | Pass true to get a fake message instead of actually sending them. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_send_options.html).
   """
 
-  defstruct "@type": "messageSendOptions", "@extra": nil, disable_notification: nil, from_background: nil, protect_content: nil, scheduling_state: nil
+  defstruct "@type": "messageSendOptions", "@extra": nil, disable_notification: nil, from_background: nil, protect_content: nil, update_order_of_installed_sticker_sets: nil, scheduling_state: nil, effect_id: nil, sending_id: nil, only_preview: nil
 end
-defmodule UpdateChatFilters do
+defmodule PublicForwards do
   @moduledoc  """
-  The list of chat filters or a chat filter has changed.
+  Represents a list of public forwards and reposts as a story of a message or a story.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | chat_filters | chatFilterInfo | The new list of chat filters. |
-  | main_chat_list_position | int32 | Position of the main chat list among chat filters, 0-based. |
+  | total_count | int32 | Approximate total number of messages and stories found. |
+  | forwards | PublicForward | List of found public forwards and reposts. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_filters.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1public_forwards.html).
   """
 
-  defstruct "@type": "updateChatFilters", "@extra": nil, chat_filters: nil, main_chat_list_position: nil
+  defstruct "@type": "publicForwards", "@extra": nil, total_count: nil, forwards: nil, next_offset: nil
+end
+defmodule MessageSourceChatEventLog do
+  @moduledoc  """
+  The message is from a chat event log.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_chat_event_log.html).
+  """
+
+  defstruct "@type": "messageSourceChatEventLog", "@extra": nil
 end
 defmodule SuggestedActionCheckPhoneNumber do
   @moduledoc  """
@@ -3558,7 +5245,7 @@ defmodule MaskPointForehead do
 end
 defmodule AuthenticationCodeTypeSms do
   @moduledoc  """
-  An authentication code is delivered via an SMS message to the specified phone number.
+  A digit-only authentication code is delivered via an SMS message to the specified phone number; non-official applications may not receive this type of code.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -3606,6 +5293,25 @@ defmodule PremiumSourceLimitExceeded do
 
   defstruct "@type": "premiumSourceLimitExceeded", "@extra": nil, limit_type: nil
 end
+defmodule BusinessRecipients do
+  @moduledoc  """
+  Describes private chats chosen for automatic interaction with a business.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_ids | int53 | Identifiers of selected private chats. |
+  | excluded_chat_ids | int53 | Identifiers of private chats that are always excluded; for <a class="el" href="classtd_1_1td__api_1_1business_connected_bot.html">businessConnectedBot</a> only. |
+  | select_existing_chats | bool | True, if all existing private chats are selected. |
+  | select_new_chats | bool | True, if all new private chats are selected. |
+  | select_contacts | bool | True, if all private chats with contacts are selected. |
+  | select_non_contacts | bool | True, if all private chats with non-contacts are selected. |
+  | exclude_selected | bool | If true, then all private chats except the selected are chosen. Otherwise, only the selected chats are chosen. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_recipients.html).
+  """
+
+  defstruct "@type": "businessRecipients", "@extra": nil, chat_ids: nil, excluded_chat_ids: nil, select_existing_chats: nil, select_new_chats: nil, select_contacts: nil, select_non_contacts: nil, exclude_selected: nil
+end
 defmodule OrderInfo do
   @moduledoc  """
   Order information.
@@ -3621,6 +5327,16 @@ defmodule OrderInfo do
   """
 
   defstruct "@type": "orderInfo", "@extra": nil, name: nil, phone_number: nil, email_address: nil, shipping_address: nil
+end
+defmodule BusinessFeatureGreetingMessage do
+  @moduledoc  """
+  The ability to set up a greeting message.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_greeting_message.html).
+  """
+
+  defstruct "@type": "businessFeatureGreetingMessage", "@extra": nil
 end
 defmodule InputPassportElementBankStatement do
   @moduledoc  """
@@ -3658,6 +5374,19 @@ defmodule ResetPasswordResultOk do
 
   defstruct "@type": "resetPasswordResultOk", "@extra": nil
 end
+defmodule UpdateActiveEmojiReactions do
+  @moduledoc  """
+  The list of active emoji reactions has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emojis | string | The new list of active emoji reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_active_emoji_reactions.html).
+  """
+
+  defstruct "@type": "updateActiveEmojiReactions", "@extra": nil, emojis: nil
+end
 defmodule ConnectedWebsites do
   @moduledoc  """
   Contains a list of websites the current user is logged in with Telegram.
@@ -3684,6 +5413,20 @@ defmodule PassportElementBankStatement do
 
   defstruct "@type": "passportElementBankStatement", "@extra": nil, bank_statement: nil
 end
+defmodule ChatEventActiveUsernamesChanged do
+  @moduledoc  """
+  The chat active usernames were changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_usernames | string | Previous list of active usernames. |
+  | new_usernames | string | New list of active usernames. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_active_usernames_changed.html).
+  """
+
+  defstruct "@type": "chatEventActiveUsernamesChanged", "@extra": nil, old_usernames: nil, new_usernames: nil
+end
 defmodule CheckStickerSetNameResult do
   @moduledoc  """
 
@@ -3695,13 +5438,23 @@ defmodule CheckStickerSetNameResult do
 end
 defmodule ConnectionStateWaitingForNetwork do
   @moduledoc  """
-  Currently waiting for the network to become available. Use setNetworkType to change the available network type.
+  Waiting for the network to become available. Use setNetworkType to change the available network type.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1connection_state_waiting_for_network.html).
   """
 
   defstruct "@type": "connectionStateWaitingForNetwork", "@extra": nil
+end
+defmodule PremiumFeatureAccentColor do
+  @moduledoc  """
+  The ability to choose accent color for replies and user profile.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_accent_color.html).
+  """
+
+  defstruct "@type": "premiumFeatureAccentColor", "@extra": nil
 end
 defmodule NetworkTypeWiFi do
   @moduledoc  """
@@ -3713,6 +5466,36 @@ defmodule NetworkTypeWiFi do
 
   defstruct "@type": "networkTypeWiFi", "@extra": nil
 end
+defmodule FoundStories do
+  @moduledoc  """
+  Contains a list of stories found by a search.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Approximate total number of stories found. |
+  | stories | story | List of stories. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_stories.html).
+  """
+
+  defstruct "@type": "foundStories", "@extra": nil, total_count: nil, stories: nil, next_offset: nil
+end
+defmodule TimeZone do
+  @moduledoc  """
+  Describes a time zone.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | string | Unique time zone identifier. |
+  | name | string | Time zone name. |
+  | utc_time_offset | int32 | Current UTC time offset for the time zone. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1time_zone.html).
+  """
+
+  defstruct "@type": "timeZone", "@extra": nil, id: nil, name: nil, utc_time_offset: nil
+end
 defmodule ChatActionBarSharePhoneNumber do
   @moduledoc  """
   The chat is a private or secret chat with a mutual contact and the user's phone number can be shared with the other user using the method sharePhoneNumber.
@@ -3723,6 +5506,20 @@ defmodule ChatActionBarSharePhoneNumber do
 
   defstruct "@type": "chatActionBarSharePhoneNumber", "@extra": nil
 end
+defmodule UpdateChatIsTranslatable do
+  @moduledoc  """
+  Translation of chat messages was enabled or disabled.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | is_translatable | bool | New value of is_translatable. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_is_translatable.html).
+  """
+
+  defstruct "@type": "updateChatIsTranslatable", "@extra": nil, chat_id: nil, is_translatable: nil
+end
 defmodule MessageThreadInfo do
   @moduledoc  """
   Contains information about a message thread.
@@ -3731,15 +5528,44 @@ defmodule MessageThreadInfo do
   |------|------| ------------|
   | chat_id | int53 | Identifier of the chat to which the message thread belongs. |
   | message_thread_id | int53 | Message thread identifier, unique within the chat. |
-  | reply_info | messageReplyInfo | Information about the message thread. |
+  | reply_info | messageReplyInfo | Information about the message thread; may be null for forum topic threads. |
   | unread_message_count | int32 | Approximate number of unread messages in the message thread. |
   | messages | message | The messages from which the thread starts. The messages are returned in a reverse chronological order (i.e., in order of decreasing message_id). |
-  | draft_message | draftMessage | A draft of a message in the message thread; may be null. |
+  | draft_message | draftMessage | A draft of a message in the message thread; may be null if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_thread_info.html).
   """
 
   defstruct "@type": "messageThreadInfo", "@extra": nil, chat_id: nil, message_thread_id: nil, reply_info: nil, unread_message_count: nil, messages: nil, draft_message: nil
+end
+defmodule ReactionNotificationSourceContacts do
+  @moduledoc  """
+  Notifications for reactions are shown only for reactions from contacts.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_notification_source_contacts.html).
+  """
+
+  defstruct "@type": "reactionNotificationSourceContacts", "@extra": nil
+end
+defmodule PremiumGiveawayParameters do
+  @moduledoc  """
+  Describes parameters of a Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boosted_chat_id | int53 | Identifier of the supergroup or channel chat, which will be automatically boosted by the winners of the giveaway for duration of the Premium subscription. If the chat is a channel, then can_post_messages right is required in the channel, otherwise, the user must be an administrator in the supergroup. |
+  | additional_chat_ids | int53 | Identifiers of other supergroup or channel chats that must be subscribed by the users to be eligible for the giveaway. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("giveaway_additional_chat_count_max") additional chats. |
+  | winners_selection_date | int32 | Point in time (Unix timestamp) when the giveaway is expected to be performed; must be 60-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("giveaway_duration_max") seconds in the future in scheduled giveaways. |
+  | only_new_members | bool | True, if only new members of the chats will be eligible for the giveaway. |
+  | has_public_winners | bool | True, if the list of winners of the giveaway will be available to everyone. |
+  | country_codes | string | The list of two-letter ISO 3166-1 alpha-2 codes of countries, users from which will be eligible for the giveaway. If empty, then all users can participate in the giveaway. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("giveaway_country_count_max") chosen countries. Users with phone number that was bought at <a href="https://fragment.com">https://fragment.com</a> can participate in any giveaway and the country code "FT" must not be specified in the list. |
+  | prize_description | string | Additional description of the giveaway prize; 0-128 characters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_parameters.html).
+  """
+
+  defstruct "@type": "premiumGiveawayParameters", "@extra": nil, boosted_chat_id: nil, additional_chat_ids: nil, winners_selection_date: nil, only_new_members: nil, has_public_winners: nil, country_codes: nil, prize_description: nil
 end
 defmodule LoginUrlInfo do
   @moduledoc  """
@@ -3758,6 +5584,16 @@ defmodule TopChatCategory do
   """
 
   defstruct "@type": "TopChatCategory", "@extra": nil
+end
+defmodule PremiumLimitTypeShareableChatFolderCount do
+  @moduledoc  """
+  The maximum number of added shareable chat folders.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_shareable_chat_folder_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeShareableChatFolderCount", "@extra": nil
 end
 defmodule SessionTypeXbox do
   @moduledoc  """
@@ -3841,6 +5677,36 @@ defmodule ChatEventPollStopped do
 
   defstruct "@type": "chatEventPollStopped", "@extra": nil, message: nil
 end
+defmodule ChatRevenueAmount do
+  @moduledoc  """
+  Contains information about revenue earned from sponsored messages in a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | cryptocurrency | string | Cryptocurrency in which revenue is calculated. |
+  | total_amount | int64 | Total amount of the cryptocurrency earned, in the smallest units of the cryptocurrency. |
+  | balance_amount | int64 | Amount of the cryptocurrency that isn't withdrawn yet, in the smallest units of the cryptocurrency. |
+  | available_amount | int64 | Amount of the cryptocurrency available for withdrawal, in the smallest units of the cryptocurrency. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_amount.html).
+  """
+
+  defstruct "@type": "chatRevenueAmount", "@extra": nil, cryptocurrency: nil, total_amount: nil, balance_amount: nil, available_amount: nil
+end
+defmodule StoryRepostInfo do
+  @moduledoc  """
+  Contains information about original story that was reposted.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | origin | StoryOrigin | Origin of the story that was reposted. |
+  | is_content_modified | bool | True, if story content was modified during reposting; otherwise, story wasn't modified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_repost_info.html).
+  """
+
+  defstruct "@type": "storyRepostInfo", "@extra": nil, origin: nil, is_content_modified: nil
+end
 defmodule UpdateFileDownloads do
   @moduledoc  """
   The state of the file download list has changed.
@@ -3869,13 +5735,23 @@ defmodule LanguagePackStrings do
 
   defstruct "@type": "languagePackStrings", "@extra": nil, strings: nil
 end
+defmodule PushMessageContentSuggestProfilePhoto do
+  @moduledoc  """
+  A profile photo was suggested to the user.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_suggest_profile_photo.html).
+  """
+
+  defstruct "@type": "pushMessageContentSuggestProfilePhoto", "@extra": nil
+end
 defmodule CallbackQueryPayloadDataWithPassword do
   @moduledoc  """
   The payload for a callback button requiring password.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | password | string | The password for the current user. |
+  | password | string | The 2-step verification password for the current user. |
   | data | bytes | Data that was attached to the callback button. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1callback_query_payload_data_with_password.html).
@@ -3937,6 +5813,19 @@ defmodule SessionTypeIpad do
 
   defstruct "@type": "sessionTypeIpad", "@extra": nil
 end
+defmodule ChatFolderInviteLinks do
+  @moduledoc  """
+  Represents a list of chat folder invite links.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invite_links | chatFolderInviteLink | List of the invite links. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder_invite_links.html).
+  """
+
+  defstruct "@type": "chatFolderInviteLinks", "@extra": nil, invite_links: nil
+end
 defmodule CallbackQueryPayloadGame do
   @moduledoc  """
   The payload for a game callback button.
@@ -3950,6 +5839,20 @@ defmodule CallbackQueryPayloadGame do
 
   defstruct "@type": "callbackQueryPayloadGame", "@extra": nil, game_short_name: nil
 end
+defmodule StoryAreaTypeMessage do
+  @moduledoc  """
+  An area pointing to a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat with the message. |
+  | message_id | int53 | Identifier of the message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_type_message.html).
+  """
+
+  defstruct "@type": "storyAreaTypeMessage", "@extra": nil, chat_id: nil, message_id: nil
+end
 defmodule PageBlockChatLink do
   @moduledoc  """
   A link to a chat.
@@ -3958,12 +5861,30 @@ defmodule PageBlockChatLink do
   |------|------| ------------|
   | title | string | Chat title. |
   | photo | chatPhotoInfo | Chat photo; may be null. |
+  | accent_color_id | int32 | Identifier of the accent color for chat title and background of chat photo. |
   | username | string | Chat username by which all other information about the chat can be resolved. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1page_block_chat_link.html).
   """
 
-  defstruct "@type": "pageBlockChatLink", "@extra": nil, title: nil, photo: nil, username: nil
+  defstruct "@type": "pageBlockChatLink", "@extra": nil, title: nil, photo: nil, accent_color_id: nil, username: nil
+end
+defmodule ChatActiveStories do
+  @moduledoc  """
+  Describes active stories posted by a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat that posted the stories. |
+  | list | StoryList | Identifier of the story list in which the stories are shown; may be null if the stories aren't shown in a story list. |
+  | order | int53 | A parameter used to determine order of the stories in the story list; 0 if the stories doesn't need to be shown in the story list. Stories must be sorted by the pair (order, story_sender_chat_id) in descending order. |
+  | max_read_story_id | int32 | Identifier of the last read active story. |
+  | stories | storyInfo | Basic information about the stories; use <a class="el" href="classtd_1_1td__api_1_1get_story.html">getStory</a> to get full information about the stories. The stories are in a chronological order (i.e., in order of increasing story identifiers). |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_active_stories.html).
+  """
+
+  defstruct "@type": "chatActiveStories", "@extra": nil, chat_id: nil, list: nil, order: nil, max_read_story_id: nil, stories: nil
 end
 defmodule BankCardActionOpenUrl do
   @moduledoc  """
@@ -3988,6 +5909,26 @@ defmodule UserStatus do
 
   defstruct "@type": "UserStatus", "@extra": nil
 end
+defmodule PaymentFormTypeRegular do
+  @moduledoc  """
+  The payment form is for a regular payment.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invoice | invoice | Full information about the invoice. |
+  | payment_provider_user_id | int53 | User identifier of the payment provider bot. |
+  | payment_provider | PaymentProvider | Information about the payment provider. |
+  | additional_payment_options | paymentOption | The list of additional payment options. |
+  | saved_order_info | orderInfo | Saved server-side order information; may be null. |
+  | saved_credentials | savedCredentials | The list of saved payment credentials. |
+  | can_save_credentials | bool | True, if the user can choose to save credentials. |
+  | need_password | bool | True, if the user will be able to save credentials, if sets up a 2-step verification password. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_form_type_regular.html).
+  """
+
+  defstruct "@type": "paymentFormTypeRegular", "@extra": nil, invoice: nil, payment_provider_user_id: nil, payment_provider: nil, additional_payment_options: nil, saved_order_info: nil, saved_credentials: nil, can_save_credentials: nil, need_password: nil
+end
 defmodule MessageSchedulingState do
   @moduledoc  """
 
@@ -4006,6 +5947,35 @@ defmodule InternalLinkTypeSettings do
   """
 
   defstruct "@type": "internalLinkTypeSettings", "@extra": nil
+end
+defmodule PremiumFeatureEmojiStatus do
+  @moduledoc  """
+  The ability to show an emoji status along with the user's name.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_emoji_status.html).
+  """
+
+  defstruct "@type": "premiumFeatureEmojiStatus", "@extra": nil
+end
+defmodule MessageGiftedPremium do
+  @moduledoc  """
+  Telegram Premium was gifted to the user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | gifter_user_id | int53 | The identifier of a user that gifted Telegram Premium; 0 if the gift was anonymous. |
+  | currency | string | Currency for the paid amount. |
+  | amount | int53 | The paid amount, in the smallest units of the currency. |
+  | cryptocurrency | string | Cryptocurrency used to pay for the gift; may be empty if none. |
+  | cryptocurrency_amount | int64 | The paid amount, in the smallest units of the cryptocurrency; 0 if none. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active. |
+  | sticker | sticker | A sticker to be shown in the message; may be null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_gifted_premium.html).
+  """
+
+  defstruct "@type": "messageGiftedPremium", "@extra": nil, gifter_user_id: nil, currency: nil, amount: nil, cryptocurrency: nil, cryptocurrency_amount: nil, month_count: nil, sticker: nil
 end
 defmodule GameHighScores do
   @moduledoc  """
@@ -4034,6 +6004,16 @@ defmodule UpdateSuggestedActions do
 
   defstruct "@type": "updateSuggestedActions", "@extra": nil, added_actions: nil, removed_actions: nil
 end
+defmodule InternalLinkTypeChatFolderSettings do
+  @moduledoc  """
+  The link is a link to the folder section of the app settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_chat_folder_settings.html).
+  """
+
+  defstruct "@type": "internalLinkTypeChatFolderSettings", "@extra": nil
+end
 defmodule PremiumFeatureUniqueStickers do
   @moduledoc  """
   Allowed to use premium stickers with unique effects.
@@ -4058,6 +6038,25 @@ defmodule RichTextEmailAddress do
 
   defstruct "@type": "richTextEmailAddress", "@extra": nil, text: nil, email_address: nil
 end
+defmodule MessageSourceMessageThreadHistory do
+  @moduledoc  """
+  The message is from a message thread history.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_message_thread_history.html).
+  """
+
+  defstruct "@type": "messageSourceMessageThreadHistory", "@extra": nil
+end
+defmodule ReportReason do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_report_reason.html).
+  """
+
+  defstruct "@type": "ReportReason", "@extra": nil
+end
 defmodule ChatTheme do
   @moduledoc  """
   Describes a chat theme.
@@ -4073,6 +6072,29 @@ defmodule ChatTheme do
 
   defstruct "@type": "chatTheme", "@extra": nil, name: nil, light_settings: nil, dark_settings: nil
 end
+defmodule EmojiCategoryTypeRegularStickers do
+  @moduledoc  """
+  The category must be used by default for regular sticker selection. It may contain greeting emoji category and premium stickers.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_type_regular_stickers.html).
+  """
+
+  defstruct "@type": "emojiCategoryTypeRegularStickers", "@extra": nil
+end
+defmodule PremiumSourceStoryFeature do
+  @moduledoc  """
+  A user tried to use a Premium story feature.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | feature | PremiumStoryFeature | The used feature. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_source_story_feature.html).
+  """
+
+  defstruct "@type": "premiumSourceStoryFeature", "@extra": nil, feature: nil
+end
 defmodule SupergroupMembersFilterContacts do
   @moduledoc  """
   Returns contacts of the user, which are members of the supergroup or channel.
@@ -4086,6 +6108,45 @@ defmodule SupergroupMembersFilterContacts do
 
   defstruct "@type": "supergroupMembersFilterContacts", "@extra": nil, query: nil
 end
+defmodule PushMessageContentStory do
+  @moduledoc  """
+  A message with a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_pinned | bool | True, if the message is a pinned message with the specified content. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_story.html).
+  """
+
+  defstruct "@type": "pushMessageContentStory", "@extra": nil, is_pinned: nil
+end
+defmodule TimeZones do
+  @moduledoc  """
+  Contains a list of time zones.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | time_zones | timeZone | A list of time zones. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1time_zones.html).
+  """
+
+  defstruct "@type": "timeZones", "@extra": nil, time_zones: nil
+end
+defmodule UpdateSavedMessagesTopic do
+  @moduledoc  """
+  Basic information about a Saved Messages topic has changed. This update is guaranteed to come before the topic identifier is returned to the application.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic | savedMessagesTopic | New data about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_saved_messages_topic.html).
+  """
+
+  defstruct "@type": "updateSavedMessagesTopic", "@extra": nil, topic: nil
+end
 defmodule ChatTypeSecret do
   @moduledoc  """
   A secret chat with a user.
@@ -4093,7 +6154,7 @@ defmodule ChatTypeSecret do
   | Name | Type | Description |
   |------|------| ------------|
   | secret_chat_id | int32 | Secret chat identifier. |
-  | user_id | int53 | User identifier of the secret chat peer. |
+  | user_id | int53 | User identifier of the other user in the secret chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_type_secret.html).
   """
@@ -4139,7 +6200,7 @@ defmodule ChatMemberStatusAdministrator do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | custom_title | string | A custom title of the administrator; 0-16 characters without emojis; applicable to supergroups only. |
+  | custom_title | string | A custom title of the administrator; 0-16 characters without emoji; applicable to supergroups only. |
   | can_be_edited | bool | True, if the current user can edit the administrator privileges for the called user. |
   | rights | chatAdministratorRights | Rights of the administrator. |
 
@@ -4147,6 +6208,19 @@ defmodule ChatMemberStatusAdministrator do
   """
 
   defstruct "@type": "chatMemberStatusAdministrator", "@extra": nil, custom_title: nil, can_be_edited: nil, rights: nil
+end
+defmodule PremiumGiveawayParticipantStatusAlreadyWasMember do
+  @moduledoc  """
+  The user can't participate in the giveaway, because they have already been member of the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | joined_chat_date | int32 | Point in time (Unix timestamp) when the user joined the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_participant_status_already_was_member.html).
+  """
+
+  defstruct "@type": "premiumGiveawayParticipantStatusAlreadyWasMember", "@extra": nil, joined_chat_date: nil
 end
 defmodule AuthenticationCodeType do
   @moduledoc  """
@@ -4156,6 +6230,20 @@ defmodule AuthenticationCodeType do
   """
 
   defstruct "@type": "AuthenticationCodeType", "@extra": nil
+end
+defmodule UpdateChatViewAsTopics do
+  @moduledoc  """
+  A chat default appearance has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | view_as_topics | bool | New value of view_as_topics. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_view_as_topics.html).
+  """
+
+  defstruct "@type": "updateChatViewAsTopics", "@extra": nil, chat_id: nil, view_as_topics: nil
 end
 defmodule UpdateChatDefaultDisableNotification do
   @moduledoc  """
@@ -4170,6 +6258,22 @@ defmodule UpdateChatDefaultDisableNotification do
   """
 
   defstruct "@type": "updateChatDefaultDisableNotification", "@extra": nil, chat_id: nil, default_disable_notification: nil
+end
+defmodule ReactionNotificationSettings do
+  @moduledoc  """
+  Contains information about notification settings for reactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_reaction_source | ReactionNotificationSource | Source of message reactions for which notifications are shown. |
+  | story_reaction_source | ReactionNotificationSource | Source of story reactions for which notifications are shown. |
+  | sound_id | int64 | Identifier of the notification sound to be played; 0 if sound is disabled. |
+  | show_preview | bool | True, if reaction sender and emoji must be displayed in notifications. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_notification_settings.html).
+  """
+
+  defstruct "@type": "reactionNotificationSettings", "@extra": nil, message_reaction_source: nil, story_reaction_source: nil, sound_id: nil, show_preview: nil
 end
 defmodule PageBlockSubtitle do
   @moduledoc  """
@@ -4198,6 +6302,20 @@ defmodule CallStatePending do
 
   defstruct "@type": "callStatePending", "@extra": nil, is_created: nil, is_received: nil
 end
+defmodule RevenueWithdrawalStateSucceeded do
+  @moduledoc  """
+  Withdrawal succeeded.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | date | int32 | Point in time (Unix timestamp) when the withdrawal was completed. |
+  | url | string | The URL where the withdrawal transaction can be viewed. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1revenue_withdrawal_state_succeeded.html).
+  """
+
+  defstruct "@type": "revenueWithdrawalStateSucceeded", "@extra": nil, date: nil, url: nil
+end
 defmodule InternalLinkTypeUnknownDeepLink do
   @moduledoc  """
   The link is an unknown tg: link. Call getDeepLinkInfo to process the link.
@@ -4211,42 +6329,15 @@ defmodule InternalLinkTypeUnknownDeepLink do
 
   defstruct "@type": "internalLinkTypeUnknownDeepLink", "@extra": nil, link: nil
 end
-defmodule ChatReportReasonFake do
+defmodule PremiumFeatureUpgradedStories do
   @moduledoc  """
-  The chat represents a fake account.
+  Allowed to use many additional features for stories.
 
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_fake.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_upgraded_stories.html).
   """
 
-  defstruct "@type": "chatReportReasonFake", "@extra": nil
-end
-defmodule TdlibParameters do
-  @moduledoc  """
-  Contains parameters for TDLib initialization.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | use_test_dc | bool | If set to true, the Telegram test environment will be used instead of the production environment. |
-  | database_directory | string | The path to the directory for the persistent database; if empty, the current working directory will be used. |
-  | files_directory | string | The path to the directory for storing files; if empty, database_directory will be used. |
-  | use_file_database | bool | If set to true, information about downloaded and uploaded files will be saved between application restarts. |
-  | use_chat_info_database | bool | If set to true, the library will maintain a cache of users, basic groups, supergroups, channels and secret chats. Implies use_file_database. |
-  | use_message_database | bool | If set to true, the library will maintain a cache of chats and messages. Implies use_chat_info_database. |
-  | use_secret_chats | bool | If set to true, support for secret chats will be enabled. |
-  | api_id | int32 | Application identifier for Telegram API access, which can be obtained at <a href="https://my.telegram.org">https://my.telegram.org</a>. |
-  | api_hash | string | Application identifier hash for Telegram API access, which can be obtained at <a href="https://my.telegram.org">https://my.telegram.org</a>. |
-  | system_language_code | string | IETF language tag of the user's operating system language; must be non-empty. |
-  | device_model | string | Model of the device the application is being run on; must be non-empty. |
-  | system_version | string | Version of the operating system the application is being run on. If empty, the version is automatically detected by TDLib. |
-  | application_version | string | Application version; must be non-empty. |
-  | enable_storage_optimizer | bool | If set to true, old files will automatically be deleted. |
-  | ignore_file_names | bool | If set to true, original file names will be ignored. Otherwise, downloaded files will be saved under names as close as possible to the original name. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1tdlib_parameters.html).
-  """
-
-  defstruct "@type": "tdlibParameters", "@extra": nil, use_test_dc: nil, database_directory: nil, files_directory: nil, use_file_database: nil, use_chat_info_database: nil, use_message_database: nil, use_secret_chats: nil, api_id: nil, api_hash: nil, system_language_code: nil, device_model: nil, system_version: nil, application_version: nil, enable_storage_optimizer: nil, ignore_file_names: nil
+  defstruct "@type": "premiumFeatureUpgradedStories", "@extra": nil
 end
 defmodule ChatEventTitleChanged do
   @moduledoc  """
@@ -4261,6 +6352,46 @@ defmodule ChatEventTitleChanged do
   """
 
   defstruct "@type": "chatEventTitleChanged", "@extra": nil, old_title: nil, new_title: nil
+end
+defmodule PushMessageContentChatSetBackground do
+  @moduledoc  """
+  A chat background was edited.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_same | bool | True, if the set background is the same as the background of the current user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_chat_set_background.html).
+  """
+
+  defstruct "@type": "pushMessageContentChatSetBackground", "@extra": nil, is_same: nil
+end
+defmodule CollectibleItemTypePhoneNumber do
+  @moduledoc  """
+  A phone number.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | phone_number | string | The phone number. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1collectible_item_type_phone_number.html).
+  """
+
+  defstruct "@type": "collectibleItemTypePhoneNumber", "@extra": nil, phone_number: nil
+end
+defmodule MessageExtendedMediaPhoto do
+  @moduledoc  """
+  The media is a photo.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | photo | photo | The photo. |
+  | caption | formattedText | Photo caption. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_extended_media_photo.html).
+  """
+
+  defstruct "@type": "messageExtendedMediaPhoto", "@extra": nil, photo: nil, caption: nil
 end
 defmodule ChatActionTyping do
   @moduledoc  """
@@ -4287,7 +6418,7 @@ defmodule PageBlockHeader do
 end
 defmodule UpdateChatPosition do
   @moduledoc  """
-  The position of a chat in a chat list has changed. Instead of this update updateChatLastMessage or updateChatDraftMessage might be sent.
+  The position of a chat in a chat list has changed. An updateChatLastMessage or updateChatDraftMessage update might be sent instead of the update.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -4298,6 +6429,36 @@ defmodule UpdateChatPosition do
   """
 
   defstruct "@type": "updateChatPosition", "@extra": nil, chat_id: nil, position: nil
+end
+defmodule StorePaymentPurposePremiumSubscription do
+  @moduledoc  """
+  The user subscribing to Telegram Premium.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_restore | bool | Pass true if this is a restore of a Telegram Premium purchase; only for App Store. |
+  | is_upgrade | bool | Pass true if this is an upgrade from a monthly subscription to early subscription; only for App Store. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1store_payment_purpose_premium_subscription.html).
+  """
+
+  defstruct "@type": "storePaymentPurposePremiumSubscription", "@extra": nil, is_restore: nil, is_upgrade: nil
+end
+defmodule AutosaveSettings do
+  @moduledoc  """
+  Describes autosave settings.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | private_chat_settings | scopeAutosaveSettings | Default autosave settings for private chats. |
+  | group_settings | scopeAutosaveSettings | Default autosave settings for basic group and supergroup chats. |
+  | channel_settings | scopeAutosaveSettings | Default autosave settings for channel chats. |
+  | exceptions | autosaveSettingsException | Autosave settings for specific chats. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings.html).
+  """
+
+  defstruct "@type": "autosaveSettings", "@extra": nil, private_chat_settings: nil, group_settings: nil, channel_settings: nil, exceptions: nil
 end
 defmodule InternalLinkTypeUnsupportedProxy do
   @moduledoc  """
@@ -4324,6 +6485,16 @@ defmodule InternalLinkTypeBotStart do
 
   defstruct "@type": "internalLinkTypeBotStart", "@extra": nil, bot_username: nil, start_parameter: nil, autostart: nil
 end
+defmodule PhoneNumberCodeTypeChange do
+  @moduledoc  """
+  Checks ownership of a new phone number to change the user's authentication phone number; for official Android and iOS applications only.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1phone_number_code_type_change.html).
+  """
+
+  defstruct "@type": "phoneNumberCodeTypeChange", "@extra": nil
+end
 defmodule BasicGroup do
   @moduledoc  """
   Represents a basic group of 0-200 users (must be upgraded to a supergroup to accommodate more than 200 users).
@@ -4341,9 +6512,23 @@ defmodule BasicGroup do
 
   defstruct "@type": "basicGroup", "@extra": nil, id: nil, member_count: nil, status: nil, is_active: nil, upgraded_to_supergroup_id: nil
 end
+defmodule ChatBackground do
+  @moduledoc  """
+  Describes a background set for a specific chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | background | background | The background. |
+  | dark_theme_dimming | int32 | Dimming of the background in dark themes, as a percentage; 0-100. Applied only to Wallpaper and Fill types of background. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_background.html).
+  """
+
+  defstruct "@type": "chatBackground", "@extra": nil, background: nil, dark_theme_dimming: nil
+end
 defmodule MessageFileTypeUnknown do
   @moduledoc  """
-  The messages was exported from a chat of unknown type.
+  The messages were exported from a chat of unknown type.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_file_type_unknown.html).
@@ -4380,9 +6565,25 @@ defmodule ChatInviteLinkCount do
 
   defstruct "@type": "chatInviteLinkCount", "@extra": nil, user_id: nil, invite_link_count: nil, revoked_invite_link_count: nil
 end
+defmodule BusinessChatLink do
+  @moduledoc  """
+  Contains information about a business chat link.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link | string | The HTTPS link. |
+  | text | formattedText | Message draft text that will be added to the input field. |
+  | title | string | Link title. |
+  | view_count | int32 | Number of times the link was used. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_chat_link.html).
+  """
+
+  defstruct "@type": "businessChatLink", "@extra": nil, link: nil, text: nil, title: nil, view_count: nil
+end
 defmodule AuthorizationStateWaitCode do
   @moduledoc  """
-  TDLib needs the user's authentication code to authorize.
+  TDLib needs the user's authentication code to authorize. Call checkAuthenticationCode to check the code.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -4403,6 +6604,20 @@ defmodule PremiumLimitTypeCaptionLength do
 
   defstruct "@type": "premiumLimitTypeCaptionLength", "@extra": nil
 end
+defmodule BusinessFeaturePromotionAnimation do
+  @moduledoc  """
+  Describes a promotion animation for a Business feature.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | feature | BusinessFeature | Business feature. |
+  | animation | animation | Promotion animation for the feature. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_promotion_animation.html).
+  """
+
+  defstruct "@type": "businessFeaturePromotionAnimation", "@extra": nil, feature: nil, animation: nil
+end
 defmodule BackgroundFillGradient do
   @moduledoc  """
   Describes a gradient fill of a background.
@@ -4411,7 +6626,7 @@ defmodule BackgroundFillGradient do
   |------|------| ------------|
   | top_color | int32 | A top color of the background in the RGB24 format. |
   | bottom_color | int32 | A bottom color of the background in the RGB24 format. |
-  | rotation_angle | int32 | Clockwise rotation angle of the gradient, in degrees; 0-359. Must be always divisible by 45. |
+  | rotation_angle | int32 | Clockwise rotation angle of the gradient, in degrees; 0-359. Must always be divisible by 45. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1background_fill_gradient.html).
   """
@@ -4463,8 +6678,8 @@ defmodule MessageDice do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | initial_state | DiceStickers | The animated stickers with the initial dice animation; may be null if unknown. <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> will be sent when the sticker became known. |
-  | final_state | DiceStickers | The animated stickers with the final dice animation; may be null if unknown. <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> will be sent when the sticker became known. |
+  | initial_state | DiceStickers | The animated stickers with the initial dice animation; may be null if unknown. The update <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> will be sent when the sticker became known. |
+  | final_state | DiceStickers | The animated stickers with the final dice animation; may be null if unknown. The update <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> will be sent when the sticker became known. |
   | emoji | string | Emoji on which the dice throw animation is based. |
   | value | int32 | The dice value. If the value is 0, the dice don't have final state yet. |
   | success_animation_frame_number | int32 | Number of frame after which a success animation like a shower of confetti needs to be shown on <a class="el" href="classtd_1_1td__api_1_1update_message_send_succeeded.html">updateMessageSendSucceeded</a>. |
@@ -4518,6 +6733,33 @@ defmodule UpdateMessageInteractionInfo do
 
   defstruct "@type": "updateMessageInteractionInfo", "@extra": nil, chat_id: nil, message_id: nil, interaction_info: nil
 end
+defmodule TextEntityTypeCustomEmoji do
+  @moduledoc  """
+  A custom emoji. The text behind a custom emoji must be an emoji. Only premium users can use premium custom emoji.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_id | int64 | Unique identifier of the custom emoji. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_custom_emoji.html).
+  """
+
+  defstruct "@type": "textEntityTypeCustomEmoji", "@extra": nil, custom_emoji_id: nil
+end
+defmodule UpdateProfileAccentColors do
+  @moduledoc  """
+  The list of supported accent colors for user profiles has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | colors | profileAccentColor | Information about supported colors. |
+  | available_accent_color_ids | int32 | The list of accent color identifiers, which can be set through <a class="el" href="classtd_1_1td__api_1_1set_profile_accent_color.html">setProfileAccentColor</a> and <a class="el" href="classtd_1_1td__api_1_1set_chat_profile_accent_color.html">setChatProfileAccentColor</a>. The colors must be shown in the specififed order. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_profile_accent_colors.html).
+  """
+
+  defstruct "@type": "updateProfileAccentColors", "@extra": nil, colors: nil, available_accent_color_ids: nil
+end
 defmodule UserPrivacySettingRule do
   @moduledoc  """
 
@@ -4526,6 +6768,23 @@ defmodule UserPrivacySettingRule do
   """
 
   defstruct "@type": "UserPrivacySettingRule", "@extra": nil
+end
+defmodule ChatBoost do
+  @moduledoc  """
+  Describes a boost applied to a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | string | Unique identifier of the boost. |
+  | count | int32 | The number of identical boosts applied. |
+  | source | ChatBoostSource | Source of the boost. |
+  | start_date | int32 | Point in time (Unix timestamp) when the chat was boosted. |
+  | expiration_date | int32 | Point in time (Unix timestamp) when the boost will expire. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost.html).
+  """
+
+  defstruct "@type": "chatBoost", "@extra": nil, id: nil, count: nil, source: nil, start_date: nil, expiration_date: nil
 end
 defmodule SessionTypeLinux do
   @moduledoc  """
@@ -4536,6 +6795,33 @@ defmodule SessionTypeLinux do
   """
 
   defstruct "@type": "sessionTypeLinux", "@extra": nil
+end
+defmodule PremiumGiftCodePaymentOptions do
+  @moduledoc  """
+  Contains a list of options for creating Telegram Premium gift codes.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | options | premiumGiftCodePaymentOption | The list of options. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_gift_code_payment_options.html).
+  """
+
+  defstruct "@type": "premiumGiftCodePaymentOptions", "@extra": nil, options: nil
+end
+defmodule MessageChatShared do
+  @moduledoc  """
+  The current user shared a chat, which was requested by the bot.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat | sharedChat | The shared chat. |
+  | button_id | int32 | Identifier of the keyboard button with the request. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_shared.html).
+  """
+
+  defstruct "@type": "messageChatShared", "@extra": nil, chat: nil, button_id: nil
 end
 defmodule MessagePaymentSuccessfulBot do
   @moduledoc  """
@@ -4558,6 +6844,29 @@ defmodule MessagePaymentSuccessfulBot do
 
   defstruct "@type": "messagePaymentSuccessfulBot", "@extra": nil, currency: nil, total_amount: nil, is_recurring: nil, is_first_recurring: nil, invoice_payload: nil, shipping_option_id: nil, order_info: nil, telegram_payment_charge_id: nil, provider_payment_charge_id: nil
 end
+defmodule MessagePremiumGiveawayWinners do
+  @moduledoc  """
+  A Telegram Premium giveaway with public winners has been completed for the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boosted_chat_id | int53 | Identifier of the channel chat, which was automatically boosted by the winners of the giveaway for duration of the Premium subscription. |
+  | giveaway_message_id | int53 | Identifier of the message with the giveaway in the boosted chat. |
+  | additional_chat_count | int32 | Number of other chats that participated in the giveaway. |
+  | actual_winners_selection_date | int32 | Point in time (Unix timestamp) when the winners were selected. May be bigger than winners selection date specified in parameters of the giveaway. |
+  | only_new_members | bool | True, if only new members of the chats were eligible for the giveaway. |
+  | was_refunded | bool | True, if the giveaway was canceled and was fully refunded. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+  | prize_description | string | Additional description of the giveaway prize. |
+  | winner_count | int32 | Total number of winners in the giveaway. |
+  | winner_user_ids | int53 | Up to 100 user identifiers of the winners of the giveaway. |
+  | unclaimed_prize_count | int32 | Number of undistributed prizes. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_premium_giveaway_winners.html).
+  """
+
+  defstruct "@type": "messagePremiumGiveawayWinners", "@extra": nil, boosted_chat_id: nil, giveaway_message_id: nil, additional_chat_count: nil, actual_winners_selection_date: nil, only_new_members: nil, was_refunded: nil, month_count: nil, prize_description: nil, winner_count: nil, winner_user_ids: nil, unclaimed_prize_count: nil
+end
 defmodule UpdateChatAvailableReactions do
   @moduledoc  """
   The chat available reactions were changed.
@@ -4565,7 +6874,7 @@ defmodule UpdateChatAvailableReactions do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | available_reactions | string | The new list of reactions, available in the chat. |
+  | available_reactions | ChatAvailableReactions | The new reactions, available in the chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_available_reactions.html).
   """
@@ -4598,20 +6907,54 @@ defmodule UpdateChatThemes do
 
   defstruct "@type": "updateChatThemes", "@extra": nil, chat_themes: nil
 end
+defmodule ReportReasonChildAbuse do
+  @moduledoc  """
+  The chat has child abuse related content.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_child_abuse.html).
+  """
+
+  defstruct "@type": "reportReasonChildAbuse", "@extra": nil
+end
 defmodule MessageCopyOptions do
   @moduledoc  """
-  Options to be used when a message content is copied without reference to the original sender. Service messages and messageInvoice can't be copied.
+  Options to be used when a message content is copied without reference to the original sender. Service messages, messages with messageInvoice, messagePremiumGiveaway, or messagePremiumGiveawayWinners content can't be copied.
 
   | Name | Type | Description |
   |------|------| ------------|
   | send_copy | bool | True, if content of the message needs to be copied without reference to the original sender. Always true if the message is forwarded to a secret chat or is local. |
   | replace_caption | bool | True, if media caption of the message copy needs to be replaced. Ignored if send_copy is false. |
   | new_caption | formattedText | New message caption; pass null to copy message without caption. Ignored if replace_caption is false. |
+  | new_show_caption_above_media | bool | True, if new caption must be shown above the animation; otherwise, new caption must be shown below the animation; not supported in secret chats. Ignored if replace_caption is false. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_copy_options.html).
   """
 
-  defstruct "@type": "messageCopyOptions", "@extra": nil, send_copy: nil, replace_caption: nil, new_caption: nil
+  defstruct "@type": "messageCopyOptions", "@extra": nil, send_copy: nil, replace_caption: nil, new_caption: nil, new_show_caption_above_media: nil
+end
+defmodule ReadDatePrivacySettings do
+  @moduledoc  """
+  Contains privacy settings for message read date in private chats. Read dates are always shown to the users that can see online status of the current user regardless of this setting.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | show_read_date | bool | True, if message read date is shown to other users in private chats. If false and the current user isn't a Telegram Premium user, then they will not be able to see other's message read date. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1read_date_privacy_settings.html).
+  """
+
+  defstruct "@type": "readDatePrivacySettings", "@extra": nil, show_read_date: nil
+end
+defmodule MessageSourceHistoryPreview do
+  @moduledoc  """
+  The message is from chat, message thread or forum topic history preview.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_history_preview.html).
+  """
+
+  defstruct "@type": "messageSourceHistoryPreview", "@extra": nil
 end
 defmodule InputSticker do
   @moduledoc  """
@@ -4619,14 +6962,26 @@ defmodule InputSticker do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sticker | InputFile | File with the sticker; must fit in a 512x512 square. For WEBP stickers and masks the file must be in PNG format, which will be converted to WEBP server-side. Otherwise, the file must be local or uploaded within a week. See <a href="https://core.telegram.org/animated_stickers">https://core.telegram.org/animated_stickers</a>#technical-requirements for technical requirements. |
-  | emojis | string | Emojis corresponding to the sticker. |
-  | type | StickerType | Sticker type. |
+  | sticker | InputFile | File with the sticker; must fit in a 512x512 square. For WEBP stickers the file must be in WEBP or PNG format, which will be converted to WEBP server-side. See <a href="https://core.telegram.org/animated_stickers">https://core.telegram.org/animated_stickers</a>#technical-requirements for technical requirements. |
+  | format | StickerFormat | Format of the sticker. |
+  | emojis | string | String with 1-20 emoji corresponding to the sticker. |
+  | mask_position | maskPosition | Position where the mask is placed; pass null if not specified. |
+  | keywords | string | List of up to 20 keywords with total length up to 64 characters, which can be used to find the sticker. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_sticker.html).
   """
 
-  defstruct "@type": "inputSticker", "@extra": nil, sticker: nil, emojis: nil, type: nil
+  defstruct "@type": "inputSticker", "@extra": nil, sticker: nil, format: nil, emojis: nil, mask_position: nil, keywords: nil
+end
+defmodule PremiumLimitTypeSimilarChatCount do
+  @moduledoc  """
+  The maximum number of received similar chats.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_similar_chat_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeSimilarChatCount", "@extra": nil
 end
 defmodule CallProblemDropped do
   @moduledoc  """
@@ -4645,12 +7000,26 @@ defmodule MessageText do
   | Name | Type | Description |
   |------|------| ------------|
   | text | formattedText | Text of the message. |
-  | web_page | webPage | A preview of the web page that's mentioned in the text; may be null. |
+  | web_page | webPage | A link preview attached to the message; may be null. |
+  | link_preview_options | linkPreviewOptions | Options which were used for generation of the link preview; may be null if default options were used. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_text.html).
   """
 
-  defstruct "@type": "messageText", "@extra": nil, text: nil, web_page: nil
+  defstruct "@type": "messageText", "@extra": nil, text: nil, web_page: nil, link_preview_options: nil
+end
+defmodule ChatStatisticsObjectTypeStory do
+  @moduledoc  """
+  Describes a story sent by the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_id | int32 | Story identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_statistics_object_type_story.html).
+  """
+
+  defstruct "@type": "chatStatisticsObjectTypeStory", "@extra": nil, story_id: nil
 end
 defmodule GroupCallId do
   @moduledoc  """
@@ -4664,6 +7033,88 @@ defmodule GroupCallId do
   """
 
   defstruct "@type": "groupCallId", "@extra": nil, id: nil
+end
+defmodule CheckChatUsernameResultPublicChatsTooMany do
+  @moduledoc  """
+  The user has too many chats with username, one of them must be made private first.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_chat_username_result_public_chats_too_many.html).
+  """
+
+  defstruct "@type": "checkChatUsernameResultPublicChatsTooMany", "@extra": nil
+end
+defmodule UpdateMessageReactions do
+  @moduledoc  """
+  Reactions added to a message with anonymous reactions have changed; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_id | int53 | Message identifier. |
+  | date | int32 | Point in time (Unix timestamp) when the reactions were changed. |
+  | reactions | messageReaction | The list of reactions added to the message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_message_reactions.html).
+  """
+
+  defstruct "@type": "updateMessageReactions", "@extra": nil, chat_id: nil, message_id: nil, date: nil, reactions: nil
+end
+defmodule ReactionTypeCustomEmoji do
+  @moduledoc  """
+  A reaction with a custom emoji.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_id | int64 | Unique identifier of the custom emoji. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_type_custom_emoji.html).
+  """
+
+  defstruct "@type": "reactionTypeCustomEmoji", "@extra": nil, custom_emoji_id: nil
+end
+defmodule StoryContentPhoto do
+  @moduledoc  """
+  A photo story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | photo | photo | The photo. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_content_photo.html).
+  """
+
+  defstruct "@type": "storyContentPhoto", "@extra": nil, photo: nil
+end
+defmodule SharedUser do
+  @moduledoc  """
+  Contains information about a user shared with a bot.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | first_name | string | First name of the user; for bots only. |
+  | last_name | string | Last name of the user; for bots only. |
+  | username | string | Username of the user; for bots only. |
+  | photo | photo | Profile photo of the user; for bots only; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1shared_user.html).
+  """
+
+  defstruct "@type": "sharedUser", "@extra": nil, user_id: nil, first_name: nil, last_name: nil, username: nil, photo: nil
+end
+defmodule BusinessChatLinks do
+  @moduledoc  """
+  Contains a list of business chat links created by the user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | links | businessChatLink | List of links. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_chat_links.html).
+  """
+
+  defstruct "@type": "businessChatLinks", "@extra": nil, links: nil
 end
 defmodule PageBlockHorizontalAlignmentCenter do
   @moduledoc  """
@@ -4685,6 +7136,15 @@ defmodule NotificationGroupTypeSecretChat do
 
   defstruct "@type": "notificationGroupTypeSecretChat", "@extra": nil
 end
+defmodule EmailAddressAuthentication do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_email_address_authentication.html).
+  """
+
+  defstruct "@type": "EmailAddressAuthentication", "@extra": nil
+end
 defmodule TMeUrlTypeUser do
   @moduledoc  """
   A URL linking to a user.
@@ -4704,18 +7164,28 @@ defmodule InputMessageText do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | text | formattedText | Formatted text to be sent; 1-GetOption("message_text_length_max") characters. Only Bold, Italic, Underline, Strikethrough, Spoiler, Code, Pre, PreCode, TextUrl and MentionName entities are allowed to be specified manually. |
-  | disable_web_page_preview | bool | True, if rich web page previews for URLs in the message text must be disabled. |
+  | text | formattedText | Formatted text to be sent; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_text_length_max") characters. Only Bold, Italic, Underline, Strikethrough, Spoiler, CustomEmoji, BlockQuote, ExpandableBlockQuote, Code, Pre, PreCode, TextUrl and MentionName entities are allowed to be specified manually. |
+  | link_preview_options | linkPreviewOptions | Options to be used for generation of a link preview; may be null if none; pass null to use default link preview options. |
   | clear_draft | bool | True, if a chat message draft must be deleted. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_text.html).
   """
 
-  defstruct "@type": "inputMessageText", "@extra": nil, text: nil, disable_web_page_preview: nil, clear_draft: nil
+  defstruct "@type": "inputMessageText", "@extra": nil, text: nil, link_preview_options: nil, clear_draft: nil
+end
+defmodule MessageExpiredVoiceNote do
+  @moduledoc  """
+  A self-destructed voice note message.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_expired_voice_note.html).
+  """
+
+  defstruct "@type": "messageExpiredVoiceNote", "@extra": nil
 end
 defmodule PushMessageContentRecurringPayment do
   @moduledoc  """
-  A new recurrent payment was made by the current user.
+  A new recurring payment was made by the current user.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -4725,6 +7195,35 @@ defmodule PushMessageContentRecurringPayment do
   """
 
   defstruct "@type": "pushMessageContentRecurringPayment", "@extra": nil, amount: nil
+end
+defmodule StorePaymentPurposeStars do
+  @moduledoc  """
+  The user buying Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+  | star_count | int53 | Number of bought stars. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1store_payment_purpose_stars.html).
+  """
+
+  defstruct "@type": "storePaymentPurposeStars", "@extra": nil, currency: nil, amount: nil, star_count: nil
+end
+defmodule MessageOriginChat do
+  @moduledoc  """
+  The message was originally sent on behalf of a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_chat_id | int53 | Identifier of the chat that originally sent the message. |
+  | author_signature | string | For messages originally sent by an anonymous chat administrator, original message author signature. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_origin_chat.html).
+  """
+
+  defstruct "@type": "messageOriginChat", "@extra": nil, sender_chat_id: nil, author_signature: nil
 end
 defmodule ChatMemberStatusLeft do
   @moduledoc  """
@@ -4746,14 +7245,46 @@ defmodule PushMessageContentChatChangePhoto do
 
   defstruct "@type": "pushMessageContentChatChangePhoto", "@extra": nil
 end
-defmodule MessageForwardOrigin do
+defmodule InlineQueryResultsButtonTypeWebApp do
   @moduledoc  """
+  Describes the button that opens a Web App by calling getWebAppUrl.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | An HTTP URL to pass to <a class="el" href="classtd_1_1td__api_1_1get_web_app_url.html">getWebAppUrl</a>. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_forward_origin.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1inline_query_results_button_type_web_app.html).
   """
 
-  defstruct "@type": "MessageForwardOrigin", "@extra": nil
+  defstruct "@type": "inlineQueryResultsButtonTypeWebApp", "@extra": nil, url: nil
+end
+defmodule ReportReasonCopyright do
+  @moduledoc  """
+  The chat contains copyrighted content.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_copyright.html).
+  """
+
+  defstruct "@type": "reportReasonCopyright", "@extra": nil
+end
+defmodule SavedMessagesTopic do
+  @moduledoc  """
+  Contains information about a Saved Messages topic.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int53 | Unique topic identifier. |
+  | type | SavedMessagesTopicType | Type of the topic. |
+  | is_pinned | bool | True, if the topic is pinned. |
+  | order | int64 | A parameter used to determine order of the topic in the topic list. Topics must be sorted by the order in descending order. |
+  | last_message | message | Last message in the topic; may be null if none or unknown. |
+  | draft_message | draftMessage | A draft of a message in the topic; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_topic.html).
+  """
+
+  defstruct "@type": "savedMessagesTopic", "@extra": nil, id: nil, type: nil, is_pinned: nil, order: nil, last_message: nil, draft_message: nil
 end
 defmodule UpdateSecretChat do
   @moduledoc  """
@@ -4811,24 +7342,9 @@ defmodule MessageChatDeleteMember do
 
   defstruct "@type": "messageChatDeleteMember", "@extra": nil, user_id: nil
 end
-defmodule MessageForwardOriginChannel do
-  @moduledoc  """
-  The message was originally a post in a channel.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_id | int53 | Identifier of the chat from which the message was originally forwarded. |
-  | message_id | int53 | Message identifier of the original message. |
-  | author_signature | string | Original post author signature. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_origin_channel.html).
-  """
-
-  defstruct "@type": "messageForwardOriginChannel", "@extra": nil, chat_id: nil, message_id: nil, author_signature: nil
-end
 defmodule MessageInviteVideoChatParticipants do
   @moduledoc  """
-  A message with information about an invite to a video chat.
+  A message with information about an invitation to a video chat.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -4873,14 +7389,15 @@ defmodule InputMessageInvoice do
   | photo_width | int32 | Product photo width. |
   | photo_height | int32 | Product photo height. |
   | payload | bytes | The invoice payload. |
-  | provider_token | string | Payment provider token. |
+  | provider_token | string | Payment provider token; may be empty for payments in Telegram Stars. |
   | provider_data | string | JSON-encoded data about the invoice, which will be shared with the payment provider. |
   | start_parameter | string | Unique invoice bot deep link parameter for the generation of this invoice. If empty, it would be possible to pay directly from forwards of the invoice message. |
+  | extended_media_content | InputMessageContent | The content of extended media attached to the invoice. The content of the message to be sent. Must be one of the following types: <a class="el" href="classtd_1_1td__api_1_1input_message_photo.html">inputMessagePhoto</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_video.html">inputMessageVideo</a>. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_invoice.html).
   """
 
-  defstruct "@type": "inputMessageInvoice", "@extra": nil, invoice: nil, title: nil, description: nil, photo_url: nil, photo_size: nil, photo_width: nil, photo_height: nil, payload: nil, provider_token: nil, provider_data: nil, start_parameter: nil
+  defstruct "@type": "inputMessageInvoice", "@extra": nil, invoice: nil, title: nil, description: nil, photo_url: nil, photo_size: nil, photo_width: nil, photo_height: nil, payload: nil, provider_token: nil, provider_data: nil, start_parameter: nil, extended_media_content: nil
 end
 defmodule TextEntityType do
   @moduledoc  """
@@ -4914,6 +7431,19 @@ defmodule UserPrivacySettingRuleRestrictUsers do
 
   defstruct "@type": "userPrivacySettingRuleRestrictUsers", "@extra": nil, user_ids: nil
 end
+defmodule PremiumGiveawayParticipantStatusAdministrator do
+  @moduledoc  """
+  The user can't participate in the giveaway, because they are an administrator in one of the chats that created the giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat administered by the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_participant_status_administrator.html).
+  """
+
+  defstruct "@type": "premiumGiveawayParticipantStatusAdministrator", "@extra": nil, chat_id: nil
+end
 defmodule CallServer do
   @moduledoc  """
   Describes a server for relaying call data.
@@ -4945,6 +7475,16 @@ defmodule BotMenuButton do
 
   defstruct "@type": "botMenuButton", "@extra": nil, text: nil, url: nil
 end
+defmodule ReportChatSponsoredMessageResultPremiumRequired do
+  @moduledoc  """
+  The user asked to hide sponsored messages, but Telegram Premium is required for this.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_result_premium_required.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageResultPremiumRequired", "@extra": nil
+end
 defmodule InputFileLocal do
   @moduledoc  """
   A file defined by a local path.
@@ -4967,6 +7507,16 @@ defmodule PremiumFeatureProfileBadge do
   """
 
   defstruct "@type": "premiumFeatureProfileBadge", "@extra": nil
+end
+defmodule MessageSourceChatHistory do
+  @moduledoc  """
+  The message is from a chat history.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_chat_history.html).
+  """
+
+  defstruct "@type": "messageSourceChatHistory", "@extra": nil
 end
 defmodule ChatEventMessagePinned do
   @moduledoc  """
@@ -5006,6 +7556,20 @@ defmodule PushMessageContentChatDeleteMember do
 
   defstruct "@type": "pushMessageContentChatDeleteMember", "@extra": nil, member_name: nil, is_current_user: nil, is_left: nil
 end
+defmodule StickerFullTypeCustomEmoji do
+  @moduledoc  """
+  The sticker is a custom emoji to be used inside message text and caption. Currently, only Telegram Premium users can use custom emoji.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_id | int64 | Identifier of the custom emoji. |
+  | needs_repainting | bool | True, if the sticker must be repainted to a text color in messages, the color of the Telegram Premium badge in emoji status, white color on chat photos, or another appropriate color in other places. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_full_type_custom_emoji.html).
+  """
+
+  defstruct "@type": "stickerFullTypeCustomEmoji", "@extra": nil, custom_emoji_id: nil, needs_repainting: nil
+end
 defmodule BotCommandScopeAllChatAdministrators do
   @moduledoc  """
   A scope covering all group and supergroup chat administrators.
@@ -5016,9 +7580,34 @@ defmodule BotCommandScopeAllChatAdministrators do
 
   defstruct "@type": "botCommandScopeAllChatAdministrators", "@extra": nil
 end
+defmodule KeyboardButtonTypeRequestChat do
+  @moduledoc  """
+  A button that requests a chat to be shared by the current user; available only in private chats. Use the method shareChatWithBot to complete the request.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Unique button identifier. |
+  | chat_is_channel | bool | True, if the chat must be a channel; otherwise, a basic group or a supergroup chat is shared. |
+  | restrict_chat_is_forum | bool | True, if the chat must or must not be a forum supergroup. |
+  | chat_is_forum | bool | True, if the chat must be a forum supergroup; otherwise, the chat must not be a forum supergroup. Ignored if restrict_chat_is_forum is false. |
+  | restrict_chat_has_username | bool | True, if the chat must or must not have a username. |
+  | chat_has_username | bool | True, if the chat must have a username; otherwise, the chat must not have a username. Ignored if restrict_chat_has_username is false. |
+  | chat_is_created | bool | True, if the chat must be created by the current user. |
+  | user_administrator_rights | chatAdministratorRights | Expected user administrator rights in the chat; may be null if they aren't restricted. |
+  | bot_administrator_rights | chatAdministratorRights | Expected bot administrator rights in the chat; may be null if they aren't restricted. |
+  | bot_is_member | bool | True, if the bot must be a member of the chat; for basic group and supergroup chats only. |
+  | request_title | bool | Pass true to request title of the chat; bots only. |
+  | request_username | bool | Pass true to request username of the chat; bots only. |
+  | request_photo | bool | Pass true to request photo of the chat; bots only. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1keyboard_button_type_request_chat.html).
+  """
+
+  defstruct "@type": "keyboardButtonTypeRequestChat", "@extra": nil, id: nil, chat_is_channel: nil, restrict_chat_is_forum: nil, chat_is_forum: nil, restrict_chat_has_username: nil, chat_has_username: nil, chat_is_created: nil, user_administrator_rights: nil, bot_administrator_rights: nil, bot_is_member: nil, request_title: nil, request_username: nil, request_photo: nil
+end
 defmodule InlineKeyboardButtonTypeCallbackWithPassword do
   @moduledoc  """
-  A button that asks for password of the current user and then sends a callback query to a bot.
+  A button that asks for the 2-step verification password of the current user and then sends a callback query to a bot.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -5105,6 +7694,26 @@ defmodule UpdateNewMessage do
 
   defstruct "@type": "updateNewMessage", "@extra": nil, message: nil
 end
+defmodule SavedMessagesTopicTypeAuthorHidden do
+  @moduledoc  """
+  Topic containing messages forwarded from a user with hidden privacy.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_topic_type_author_hidden.html).
+  """
+
+  defstruct "@type": "savedMessagesTopicTypeAuthorHidden", "@extra": nil
+end
+defmodule InviteLinkChatTypeChannel do
+  @moduledoc  """
+  The link is an invite link for a channel.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1invite_link_chat_type_channel.html).
+  """
+
+  defstruct "@type": "inviteLinkChatTypeChannel", "@extra": nil
+end
 defmodule ConnectionStateReady do
   @moduledoc  """
   There is a working connection to the Telegram servers.
@@ -5117,7 +7726,7 @@ defmodule ConnectionStateReady do
 end
 defmodule UpdateChatPermissions do
   @moduledoc  """
-  Chat permissions was changed.
+  Chat permissions were changed.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -5128,6 +7737,23 @@ defmodule UpdateChatPermissions do
   """
 
   defstruct "@type": "updateChatPermissions", "@extra": nil, chat_id: nil, permissions: nil
+end
+defmodule ProfileAccentColor do
+  @moduledoc  """
+  Contains information about supported accent color for user profile photo background.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Profile accent color identifier. |
+  | light_theme_colors | profileAccentColors | Accent colors expected to be used in light themes. |
+  | dark_theme_colors | profileAccentColors | Accent colors expected to be used in dark themes. |
+  | min_supergroup_chat_boost_level | int32 | The minimum chat boost level required to use the color in a supergroup chat. |
+  | min_channel_chat_boost_level | int32 | The minimum chat boost level required to use the color in a channel chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1profile_accent_color.html).
+  """
+
+  defstruct "@type": "profileAccentColor", "@extra": nil, id: nil, light_theme_colors: nil, dark_theme_colors: nil, min_supergroup_chat_boost_level: nil, min_channel_chat_boost_level: nil
 end
 defmodule InlineQueryResultDocument do
   @moduledoc  """
@@ -5158,11 +7784,14 @@ defmodule UserStatusRecently do
   @moduledoc  """
   The user was online recently.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | by_my_privacy_settings | bool | Exact user's status is hidden because the current user enabled <a class="el" href="classtd_1_1td__api_1_1user_privacy_setting_show_status.html">userPrivacySettingShowStatus</a> privacy setting for the user and has no Telegram Premium. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_status_recently.html).
   """
 
-  defstruct "@type": "userStatusRecently", "@extra": nil
+  defstruct "@type": "userStatusRecently", "@extra": nil, by_my_privacy_settings: nil
 end
 defmodule BankCardInfo do
   @moduledoc  """
@@ -5223,13 +7852,28 @@ defmodule PremiumLimitTypeSavedAnimationCount do
 end
 defmodule TextEntityTypeSpoiler do
   @moduledoc  """
-  A spoiler text. Not supported in secret chats.
+  A spoiler text.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_spoiler.html).
   """
 
   defstruct "@type": "textEntityTypeSpoiler", "@extra": nil
+end
+defmodule ArchiveChatListSettings do
+  @moduledoc  """
+  Contains settings for automatic moving of chats to and from the Archive chat lists.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | archive_and_mute_new_chats_from_unknown_users | bool | True, if new chats from non-contacts will be automatically archived and muted. Can be set to true only if the option "can_archive_and_mute_new_chats_from_unknown_users" is true. |
+  | keep_unmuted_chats_archived | bool | True, if unmuted chats will be kept in the Archive chat list when they get a new message. |
+  | keep_chats_from_folders_archived | bool | True, if unmuted chats, that are always included or pinned in a folder, will be kept in the Archive chat list when they get a new message. Ignored if keep_unmuted_chats_archived == true. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1archive_chat_list_settings.html).
+  """
+
+  defstruct "@type": "archiveChatListSettings", "@extra": nil, archive_and_mute_new_chats_from_unknown_users: nil, keep_unmuted_chats_archived: nil, keep_chats_from_folders_archived: nil
 end
 defmodule InlineQueryResultVoiceNote do
   @moduledoc  """
@@ -5258,12 +7902,14 @@ defmodule InputMessageAnimation do
   | duration | int32 | Duration of the animation, in seconds. |
   | width | int32 | Width of the animation; may be replaced by the server. |
   | height | int32 | Height of the animation; may be replaced by the server. |
-  | caption | formattedText | Animation caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
+  | caption | formattedText | Animation caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | show_caption_above_media | bool | True, if caption must be shown above the animation; otherwise, caption must be shown below the animation; not supported in secret chats. |
+  | has_spoiler | bool | True, if the animation preview must be covered by a spoiler animation; not supported in secret chats. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_animation.html).
   """
 
-  defstruct "@type": "inputMessageAnimation", "@extra": nil, animation: nil, thumbnail: nil, added_sticker_file_ids: nil, duration: nil, width: nil, height: nil, caption: nil
+  defstruct "@type": "inputMessageAnimation", "@extra": nil, animation: nil, thumbnail: nil, added_sticker_file_ids: nil, duration: nil, width: nil, height: nil, caption: nil, show_caption_above_media: nil, has_spoiler: nil
 end
 defmodule PassportElementsWithErrors do
   @moduledoc  """
@@ -5292,6 +7938,19 @@ defmodule LogVerbosityLevel do
 
   defstruct "@type": "logVerbosityLevel", "@extra": nil, verbosity_level: nil
 end
+defmodule UpdateOwnedStarCount do
+  @moduledoc  """
+  The number of Telegram stars owned by the current user has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | star_count | int53 | The new number of Telegram stars owned. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_owned_star_count.html).
+  """
+
+  defstruct "@type": "updateOwnedStarCount", "@extra": nil, star_count: nil
+end
 defmodule InlineKeyboardButtonTypeUser do
   @moduledoc  """
   A button with a user reference to be handled in the same way as textEntityTypeMentionName entities.
@@ -5304,6 +7963,19 @@ defmodule InlineKeyboardButtonTypeUser do
   """
 
   defstruct "@type": "inlineKeyboardButtonTypeUser", "@extra": nil, user_id: nil
+end
+defmodule SpeechRecognitionResultError do
+  @moduledoc  """
+  The speech recognition failed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | error | error | Recognition error. An error with a message "MSG_VOICE_TOO_LONG" is returned when media duration is too big to be recognized. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1speech_recognition_result_error.html).
+  """
+
+  defstruct "@type": "speechRecognitionResultError", "@extra": nil, error: nil
 end
 defmodule TestVectorStringObject do
   @moduledoc  """
@@ -5357,6 +8029,20 @@ defmodule PushMessageContentContactRegistered do
 
   defstruct "@type": "pushMessageContentContactRegistered", "@extra": nil
 end
+defmodule MessageImportInfo do
+  @moduledoc  """
+  Contains information about a message created with importMessages.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_name | string | Name of the original sender. |
+  | date | int32 | Point in time (Unix timestamp) when the message was originally sent. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_import_info.html).
+  """
+
+  defstruct "@type": "messageImportInfo", "@extra": nil, sender_name: nil, date: nil
+end
 defmodule PassportElementEmailAddress do
   @moduledoc  """
   A Telegram Passport element containing the user's email address.
@@ -5370,19 +8056,59 @@ defmodule PassportElementEmailAddress do
 
   defstruct "@type": "passportElementEmailAddress", "@extra": nil, email_address: nil
 end
-defmodule MessageForwardOriginChat do
+defmodule BusinessMessage do
   @moduledoc  """
-  The message was originally sent on behalf of a chat.
+  Describes a message from a business account as received by a bot.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sender_chat_id | int53 | Identifier of the chat that originally sent the message. |
-  | author_signature | string | For messages originally sent by an anonymous chat administrator, original message author signature. |
+  | message | message | The message. |
+  | reply_to_message | message | Message that is replied by the message in the same chat; may be null if none. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_origin_chat.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_message.html).
   """
 
-  defstruct "@type": "messageForwardOriginChat", "@extra": nil, sender_chat_id: nil, author_signature: nil
+  defstruct "@type": "businessMessage", "@extra": nil, message: nil, reply_to_message: nil
+end
+defmodule EmailAddressAuthenticationAppleId do
+  @moduledoc  """
+  An authentication token received through Apple ID.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | The token. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1email_address_authentication_apple_id.html).
+  """
+
+  defstruct "@type": "emailAddressAuthenticationAppleId", "@extra": nil, token: nil
+end
+defmodule ReactionTypeEmoji do
+  @moduledoc  """
+  A reaction with an emoji.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji | string | Text representation of the reaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_type_emoji.html).
+  """
+
+  defstruct "@type": "reactionTypeEmoji", "@extra": nil, emoji: nil
+end
+defmodule StoryOriginPublicStory do
+  @moduledoc  """
+  The original story was a public story with known sender.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat that posted original story. |
+  | story_id | int32 | Story identifier of the original story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_origin_public_story.html).
+  """
+
+  defstruct "@type": "storyOriginPublicStory", "@extra": nil, chat_id: nil, story_id: nil
 end
 defmodule UserType do
   @moduledoc  """
@@ -5413,32 +8139,35 @@ defmodule InputMessageAudio do
   | duration | int32 | Duration of the audio, in seconds; may be replaced by the server. |
   | title | string | Title of the audio; 0-64 characters; may be replaced by the server. |
   | performer | string | Performer of the audio; 0-64 characters, may be replaced by the server. |
-  | caption | formattedText | Audio caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
+  | caption | formattedText | Audio caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_audio.html).
   """
 
   defstruct "@type": "inputMessageAudio", "@extra": nil, audio: nil, album_cover_thumbnail: nil, duration: nil, title: nil, performer: nil, caption: nil
 end
+defmodule MessageSelfDestructTypeTimer do
+  @moduledoc  """
+  The message will be self-destructed in the specified time after its content was opened.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | self_destruct_time | int32 | The message's self-destruct time, in seconds; must be between 0 and 60 in private chats. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_self_destruct_type_timer.html).
+  """
+
+  defstruct "@type": "messageSelfDestructTypeTimer", "@extra": nil, self_destruct_time: nil
+end
 defmodule ConnectionStateConnectingToProxy do
   @moduledoc  """
-  Currently establishing a connection with a proxy server.
+  Establishing a connection with a proxy server.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1connection_state_connecting_to_proxy.html).
   """
 
   defstruct "@type": "connectionStateConnectingToProxy", "@extra": nil
-end
-defmodule ChatReportReasonIllegalDrugs do
-  @moduledoc  """
-  The chat has illegal drugs related content.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_illegal_drugs.html).
-  """
-
-  defstruct "@type": "chatReportReasonIllegalDrugs", "@extra": nil
 end
 defmodule PushMessageContentSticker do
   @moduledoc  """
@@ -5463,6 +8192,16 @@ defmodule InputPassportElementErrorSource do
   """
 
   defstruct "@type": "InputPassportElementErrorSource", "@extra": nil
+end
+defmodule ReportChatSponsoredMessageResultFailed do
+  @moduledoc  """
+  The sponsored message is too old or not found.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_result_failed.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageResultFailed", "@extra": nil
 end
 defmodule PassportElementTypeRentalAgreement do
   @moduledoc  """
@@ -5514,29 +8253,6 @@ defmodule SupergroupMembersFilterMention do
 
   defstruct "@type": "supergroupMembersFilterMention", "@extra": nil, query: nil, message_thread_id: nil
 end
-defmodule ChatListFilter do
-  @moduledoc  """
-  A list of chats belonging to a chat filter.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_filter_id | int32 | Chat filter identifier. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_list_filter.html).
-  """
-
-  defstruct "@type": "chatListFilter", "@extra": nil, chat_filter_id: nil
-end
-defmodule StickerTypeAnimated do
-  @moduledoc  """
-  The sticker is an animation in TGS format.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_animated.html).
-  """
-
-  defstruct "@type": "stickerTypeAnimated", "@extra": nil
-end
 defmodule InputPassportElementInternalPassport do
   @moduledoc  """
   A Telegram Passport element to be saved containing the user's internal passport.
@@ -5549,6 +8265,25 @@ defmodule InputPassportElementInternalPassport do
   """
 
   defstruct "@type": "inputPassportElementInternalPassport", "@extra": nil, internal_passport: nil
+end
+defmodule BusinessAwayMessageSchedule do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_business_away_message_schedule.html).
+  """
+
+  defstruct "@type": "BusinessAwayMessageSchedule", "@extra": nil
+end
+defmodule TextEntityTypeBlockQuote do
+  @moduledoc  """
+  Text that must be formatted as if inside a blockquote HTML tag; not supported in secret chats.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_block_quote.html).
+  """
+
+  defstruct "@type": "textEntityTypeBlockQuote", "@extra": nil
 end
 defmodule MessageCalendarDay do
   @moduledoc  """
@@ -5586,6 +8321,26 @@ defmodule InputInlineQueryResultAnimation do
   """
 
   defstruct "@type": "inputInlineQueryResultAnimation", "@extra": nil, id: nil, title: nil, thumbnail_url: nil, thumbnail_mime_type: nil, video_url: nil, video_mime_type: nil, video_duration: nil, video_width: nil, video_height: nil, reply_markup: nil, input_message_content: nil
+end
+defmodule MessageReadDateUserPrivacyRestricted do
+  @moduledoc  """
+  The read date is unknown due to privacy settings of the other user.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_read_date_user_privacy_restricted.html).
+  """
+
+  defstruct "@type": "messageReadDateUserPrivacyRestricted", "@extra": nil
+end
+defmodule PremiumFeatureLastSeenTimes do
+  @moduledoc  """
+  The ability to view last seen and read times of other users even they can't view last seen or read time for the current user.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_last_seen_times.html).
+  """
+
+  defstruct "@type": "premiumFeatureLastSeenTimes", "@extra": nil
 end
 defmodule ChatListArchive do
   @moduledoc  """
@@ -5636,18 +8391,33 @@ defmodule MessageSupergroupChatCreate do
 
   defstruct "@type": "messageSupergroupChatCreate", "@extra": nil, title: nil
 end
-defmodule MessageForwardOriginHiddenUser do
+defmodule ChatFolderInfo do
   @moduledoc  """
-  The message was originally sent by a user, which is hidden by their privacy settings.
+  Contains basic information about a chat folder.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sender_name | string | Name of the sender. |
+  | id | int32 | Unique chat folder identifier. |
+  | title | string | The title of the folder; 1-12 characters without line feeds. |
+  | icon | chatFolderIcon | The chosen or default icon for the chat folder. |
+  | color_id | int32 | The identifier of the chosen color for the chat folder icon; from -1 to 6. If -1, then color is disabled. |
+  | is_shareable | bool | True, if at least one link has been created for the folder. |
+  | has_my_invite_links | bool | True, if the chat folder has invite links created by the current user. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_origin_hidden_user.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder_info.html).
   """
 
-  defstruct "@type": "messageForwardOriginHiddenUser", "@extra": nil, sender_name: nil
+  defstruct "@type": "chatFolderInfo", "@extra": nil, id: nil, title: nil, icon: nil, color_id: nil, is_shareable: nil, has_my_invite_links: nil
+end
+defmodule PremiumLimitTypeStoryCaptionLength do
+  @moduledoc  """
+  The maximum length of captions of sent stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_story_caption_length.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeStoryCaptionLength", "@extra": nil
 end
 defmodule TestString do
   @moduledoc  """
@@ -5685,13 +8455,17 @@ defmodule ScopeNotificationSettings do
   | mute_for | int32 | Time left before notifications will be unmuted, in seconds. |
   | sound_id | int64 | Identifier of the notification sound to be played; 0 if sound is disabled. |
   | show_preview | bool | True, if message content must be displayed in notifications. |
+  | use_default_mute_stories | bool | If true, story notifications are received only for the first 5 chats from <a class="el" href="classtd_1_1td__api_1_1top_chat_category_users.html">topChatCategoryUsers</a> regardless of the value of mute_stories. |
+  | mute_stories | bool | True, if story notifications are disabled. |
+  | story_sound_id | int64 | Identifier of the notification sound to be played for stories; 0 if sound is disabled. |
+  | show_story_sender | bool | True, if the sender of stories must be displayed in notifications. |
   | disable_pinned_message_notifications | bool | True, if notifications for incoming pinned messages will be created as for an ordinary unread message. |
   | disable_mention_notifications | bool | True, if notifications for messages with mentions will be created as for an ordinary unread message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1scope_notification_settings.html).
   """
 
-  defstruct "@type": "scopeNotificationSettings", "@extra": nil, mute_for: nil, sound_id: nil, show_preview: nil, disable_pinned_message_notifications: nil, disable_mention_notifications: nil
+  defstruct "@type": "scopeNotificationSettings", "@extra": nil, mute_for: nil, sound_id: nil, show_preview: nil, use_default_mute_stories: nil, mute_stories: nil, story_sound_id: nil, show_story_sender: nil, disable_pinned_message_notifications: nil, disable_mention_notifications: nil
 end
 defmodule LogTags do
   @moduledoc  """
@@ -5722,7 +8496,7 @@ defmodule MessagePassportDataReceived do
 end
 defmodule InternalLinkTypeMessage do
   @moduledoc  """
-  The link is a link to a Telegram message. Call getMessageLinkInfo with the given URL to process the link.
+  The link is a link to a Telegram message or a forum topic. Call getMessageLinkInfo with the given URL to process the link, and then open received forum topic or chat and show the message there.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -5733,18 +8507,65 @@ defmodule InternalLinkTypeMessage do
 
   defstruct "@type": "internalLinkTypeMessage", "@extra": nil, url: nil
 end
+defmodule AutosaveSettingsScope do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_autosave_settings_scope.html).
+  """
+
+  defstruct "@type": "AutosaveSettingsScope", "@extra": nil
+end
+defmodule UpdateStoryStealthMode do
+  @moduledoc  """
+  Story stealth mode settings have changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | active_until_date | int32 | Point in time (Unix timestamp) until stealth mode is active; 0 if it is disabled. |
+  | cooldown_until_date | int32 | Point in time (Unix timestamp) when stealth mode can be enabled again; 0 if there is no active cooldown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story_stealth_mode.html).
+  """
+
+  defstruct "@type": "updateStoryStealthMode", "@extra": nil, active_until_date: nil, cooldown_until_date: nil
+end
 defmodule InternalLinkTypeUserPhoneNumber do
   @moduledoc  """
-  The link is a link to a user by its phone number. Call searchUserByPhoneNumber with the given phone number to process the link.
+  The link is a link to a user by its phone number. Call searchUserByPhoneNumber with the given phone number to process the link. If the user is found, then call createPrivateChat and open the chat. If draft text isn't empty, then put the draft text in the input field.
 
   | Name | Type | Description |
   |------|------| ------------|
   | phone_number | string | Phone number of the user. |
+  | draft_text | string | Draft text for message to send in the chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_user_phone_number.html).
   """
 
-  defstruct "@type": "internalLinkTypeUserPhoneNumber", "@extra": nil, phone_number: nil
+  defstruct "@type": "internalLinkTypeUserPhoneNumber", "@extra": nil, phone_number: nil, draft_text: nil
+end
+defmodule ChatRevenueTransactions do
+  @moduledoc  """
+  Contains a list of chat revenue transactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Total number of transactions. |
+  | transactions | chatRevenueTransaction | List of transactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_transactions.html).
+  """
+
+  defstruct "@type": "chatRevenueTransactions", "@extra": nil, total_count: nil, transactions: nil
+end
+defmodule ReactionUnavailabilityReason do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_reaction_unavailability_reason.html).
+  """
+
+  defstruct "@type": "ReactionUnavailabilityReason", "@extra": nil
 end
 defmodule TextEntityTypePre do
   @moduledoc  """
@@ -5780,6 +8601,38 @@ defmodule ChatStatisticsMessageSenderInfo do
 
   defstruct "@type": "chatStatisticsMessageSenderInfo", "@extra": nil, user_id: nil, sent_message_count: nil, average_character_count: nil
 end
+defmodule StorePaymentPurposePremiumGiftCodes do
+  @moduledoc  """
+  The user creating Telegram Premium gift codes for other users.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boosted_chat_id | int53 | Identifier of the supergroup or channel chat, which will be automatically boosted by the users for duration of the Premium subscription and which is administered by the user; 0 if none. |
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+  | user_ids | int53 | Identifiers of the users which can activate the gift codes. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1store_payment_purpose_premium_gift_codes.html).
+  """
+
+  defstruct "@type": "storePaymentPurposePremiumGiftCodes", "@extra": nil, boosted_chat_id: nil, currency: nil, amount: nil, user_ids: nil
+end
+defmodule ChatEventProfileAccentColorChanged do
+  @moduledoc  """
+  The chat's profile accent color or profile background custom emoji were changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_profile_accent_color_id | int32 | Previous identifier of chat's profile accent color; -1 if none. |
+  | old_profile_background_custom_emoji_id | int64 | Previous identifier of the custom emoji; 0 if none. |
+  | new_profile_accent_color_id | int32 | New identifier of chat's profile accent color; -1 if none. |
+  | new_profile_background_custom_emoji_id | int64 | New identifier of the custom emoji; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_profile_accent_color_changed.html).
+  """
+
+  defstruct "@type": "chatEventProfileAccentColorChanged", "@extra": nil, old_profile_accent_color_id: nil, old_profile_background_custom_emoji_id: nil, new_profile_accent_color_id: nil, new_profile_background_custom_emoji_id: nil
+end
 defmodule PushMessageContent do
   @moduledoc  """
 
@@ -5802,6 +8655,29 @@ defmodule Text do
 
   defstruct "@type": "text", "@extra": nil, text: nil
 end
+defmodule ChatEventIsForumToggled do
+  @moduledoc  """
+  The is_forum setting of a channel was toggled.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_forum | bool | New value of is_forum. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_is_forum_toggled.html).
+  """
+
+  defstruct "@type": "chatEventIsForumToggled", "@extra": nil, is_forum: nil
+end
+defmodule BusinessFeatureOpeningHours do
+  @moduledoc  """
+  The ability to set opening hours.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_opening_hours.html).
+  """
+
+  defstruct "@type": "businessFeatureOpeningHours", "@extra": nil
+end
 defmodule MessageCalendar do
   @moduledoc  """
   Contains information about found messages, split by days according to the option "utc_time_offset".
@@ -5816,6 +8692,23 @@ defmodule MessageCalendar do
 
   defstruct "@type": "messageCalendar", "@extra": nil, total_count: nil, days: nil
 end
+defmodule ForumTopics do
+  @moduledoc  """
+  Describes a list of forum topics.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Approximate total number of forum topics found. |
+  | topics | forumTopic | List of forum topics. |
+  | next_offset_date | int32 | Offset date for the next <a class="el" href="classtd_1_1td__api_1_1get_forum_topics.html">getForumTopics</a> request. |
+  | next_offset_message_id | int53 | Offset message identifier for the next <a class="el" href="classtd_1_1td__api_1_1get_forum_topics.html">getForumTopics</a> request. |
+  | next_offset_message_thread_id | int53 | Offset message thread identifier for the next <a class="el" href="classtd_1_1td__api_1_1get_forum_topics.html">getForumTopics</a> request. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forum_topics.html).
+  """
+
+  defstruct "@type": "forumTopics", "@extra": nil, total_count: nil, topics: nil, next_offset_date: nil, next_offset_message_id: nil, next_offset_message_thread_id: nil
+end
 defmodule FileTypeVideo do
   @moduledoc  """
   The file is a video.
@@ -5825,6 +8718,19 @@ defmodule FileTypeVideo do
   """
 
   defstruct "@type": "fileTypeVideo", "@extra": nil
+end
+defmodule StarTransactionPartnerFragment do
+  @moduledoc  """
+  The transaction is a transaction with Fragment.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | withdrawal_state | RevenueWithdrawalState | State of the withdrawal; may be null for refunds from Fragment. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_fragment.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerFragment", "@extra": nil, withdrawal_state: nil
 end
 defmodule ChatTypeBasicGroup do
   @moduledoc  """
@@ -5839,6 +8745,16 @@ defmodule ChatTypeBasicGroup do
 
   defstruct "@type": "chatTypeBasicGroup", "@extra": nil, basic_group_id: nil
 end
+defmodule BusinessAwayMessageScheduleAlways do
+  @moduledoc  """
+  Send away messages always.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_away_message_schedule_always.html).
+  """
+
+  defstruct "@type": "businessAwayMessageScheduleAlways", "@extra": nil
+end
 defmodule LanguagePackStringValueDeleted do
   @moduledoc  """
   A deleted language pack string, the value must be taken from the built-in English language pack.
@@ -5848,6 +8764,20 @@ defmodule LanguagePackStringValueDeleted do
   """
 
   defstruct "@type": "languagePackStringValueDeleted", "@extra": nil
+end
+defmodule EmojiKeyword do
+  @moduledoc  """
+  Represents an emoji with its keyword.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji | string | The emoji. |
+  | keyword | string | The keyword. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_keyword.html).
+  """
+
+  defstruct "@type": "emojiKeyword", "@extra": nil, emoji: nil, keyword: nil
 end
 defmodule TextEntityTypeTextUrl do
   @moduledoc  """
@@ -5874,17 +8804,27 @@ defmodule CallDiscardReasonMissed do
 end
 defmodule ChatActionBarReportAddBlock do
   @moduledoc  """
-  The chat is a private or secret chat, which can be reported using the method reportChat, or the other user can be blocked using the method toggleMessageSenderIsBlocked, or the other user can be added to the contact list using the method addContact.
+  The chat is a private or secret chat, which can be reported using the method reportChat, or the other user can be blocked using the method setMessageSenderBlockList, or the other user can be added to the contact list using the method addContact. If the chat is a private chat with a user with an emoji status, then a notice about emoji status usage must be shown.
 
   | Name | Type | Description |
   |------|------| ------------|
   | can_unarchive | bool | If true, the chat was automatically archived and can be moved back to the main chat list using <a class="el" href="classtd_1_1td__api_1_1add_chat_to_list.html">addChatToList</a> simultaneously with setting chat notification settings to default using <a class="el" href="classtd_1_1td__api_1_1set_chat_notification_settings.html">setChatNotificationSettings</a>. |
-  | distance | int32 | If non-negative, the current user was found by the peer through <a class="el" href="classtd_1_1td__api_1_1search_chats_nearby.html">searchChatsNearby</a> and this is the distance between the users. |
+  | distance | int32 | If non-negative, the current user was found by the other user through <a class="el" href="classtd_1_1td__api_1_1search_chats_nearby.html">searchChatsNearby</a> and this is the distance between the users. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_action_bar_report_add_block.html).
   """
 
   defstruct "@type": "chatActionBarReportAddBlock", "@extra": nil, can_unarchive: nil, distance: nil
+end
+defmodule ReportChatSponsoredMessageResultAdsHidden do
+  @moduledoc  """
+  Sponsored messages were hidden for the user in all chats.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_result_ads_hidden.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageResultAdsHidden", "@extra": nil
 end
 defmodule StorageStatisticsByFileType do
   @moduledoc  """
@@ -5921,6 +8861,29 @@ defmodule NotificationSettingsScopePrivateChats do
 
   defstruct "@type": "notificationSettingsScopePrivateChats", "@extra": nil
 end
+defmodule UserPrivacySettingAllowPrivateVoiceAndVideoNoteMessages do
+  @moduledoc  """
+  A privacy setting for managing whether the user can receive voice and video messages in private chats; for Telegram Premium users only.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_allow_private_voice_and_video_note_messages.html).
+  """
+
+  defstruct "@type": "userPrivacySettingAllowPrivateVoiceAndVideoNoteMessages", "@extra": nil
+end
+defmodule MessageAutoDeleteTime do
+  @moduledoc  """
+  Contains default auto-delete timer setting for new chats.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | time | int32 | Message auto-delete time, in seconds. If 0, then messages aren't deleted automatically. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_auto_delete_time.html).
+  """
+
+  defstruct "@type": "messageAutoDeleteTime", "@extra": nil, time: nil
+end
 defmodule PageBlockEmbedded do
   @moduledoc  """
   An embedded web page.
@@ -5954,6 +8917,58 @@ defmodule LocalizationTargetInfo do
 
   defstruct "@type": "localizationTargetInfo", "@extra": nil, language_packs: nil
 end
+defmodule BotWriteAccessAllowReasonLaunchedWebApp do
+  @moduledoc  """
+  The user launched a Web App using getWebAppLinkUrl.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | web_app | webApp | Information about the Web App. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1bot_write_access_allow_reason_launched_web_app.html).
+  """
+
+  defstruct "@type": "botWriteAccessAllowReasonLaunchedWebApp", "@extra": nil, web_app: nil
+end
+defmodule PaymentFormTypeStars do
+  @moduledoc  """
+  The payment form is for a payment in Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | star_count | int53 | Number of Telegram stars that will be paid. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_form_type_stars.html).
+  """
+
+  defstruct "@type": "paymentFormTypeStars", "@extra": nil, star_count: nil
+end
+defmodule ChatBoostLevelFeatures do
+  @moduledoc  """
+  Contains a list of features available on a specific chat boost level.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | level | int32 | Target chat boost level. |
+  | story_per_day_count | int32 | Number of stories that the chat can publish daily. |
+  | custom_emoji_reaction_count | int32 | Number of custom emoji reactions that can be added to the list of available reactions. |
+  | title_color_count | int32 | Number of custom colors for chat title. |
+  | profile_accent_color_count | int32 | Number of custom colors for profile photo background. |
+  | can_set_profile_background_custom_emoji | bool | True, if custom emoji for profile background can be set. |
+  | accent_color_count | int32 | Number of custom colors for background of empty chat photo, replies to messages and link previews. |
+  | can_set_background_custom_emoji | bool | True, if custom emoji for reply header and link preview background can be set. |
+  | can_set_emoji_status | bool | True, if emoji status can be set. |
+  | chat_theme_background_count | int32 | Number of chat theme backgrounds that can be set as chat background. |
+  | can_set_custom_background | bool | True, if custom background can be set in the chat for all users. |
+  | can_set_custom_emoji_sticker_set | bool | True, if custom emoji sticker set can be set for the chat. |
+  | can_recognize_speech | bool | True, if speech recognition can be used for video note and voice note messages by all users. |
+  | can_disable_sponsored_messages | bool | True, if sponsored messages can be disabled in the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_level_features.html).
+  """
+
+  defstruct "@type": "chatBoostLevelFeatures", "@extra": nil, level: nil, story_per_day_count: nil, custom_emoji_reaction_count: nil, title_color_count: nil, profile_accent_color_count: nil, can_set_profile_background_custom_emoji: nil, accent_color_count: nil, can_set_background_custom_emoji: nil, can_set_emoji_status: nil, chat_theme_background_count: nil, can_set_custom_background: nil, can_set_custom_emoji_sticker_set: nil, can_recognize_speech: nil, can_disable_sponsored_messages: nil
+end
 defmodule PageBlockMap do
   @moduledoc  """
   A map.
@@ -5971,6 +8986,22 @@ defmodule PageBlockMap do
 
   defstruct "@type": "pageBlockMap", "@extra": nil, location: nil, zoom: nil, width: nil, height: nil, caption: nil
 end
+defmodule StoryAreaTypeSuggestedReaction do
+  @moduledoc  """
+  An area pointing to a suggested reaction. App needs to show a clickable reaction on the area and call setStoryReaction when the are is clicked.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reaction_type | ReactionType | Type of the reaction. |
+  | total_count | int32 | Number of times the reaction was added. |
+  | is_dark | bool | True, if reaction has a dark background. |
+  | is_flipped | bool | True, if reaction corner is flipped. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_type_suggested_reaction.html).
+  """
+
+  defstruct "@type": "storyAreaTypeSuggestedReaction", "@extra": nil, reaction_type: nil, total_count: nil, is_dark: nil, is_flipped: nil
+end
 defmodule UserPrivacySettingAllowPeerToPeerCalls do
   @moduledoc  """
   A privacy setting for managing whether peer-to-peer connections can be used for calls.
@@ -5981,9 +9012,40 @@ defmodule UserPrivacySettingAllowPeerToPeerCalls do
 
   defstruct "@type": "userPrivacySettingAllowPeerToPeerCalls", "@extra": nil
 end
+defmodule CollectibleItemInfo do
+  @moduledoc  """
+  Contains information about a collectible item and its last purchase.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | purchase_date | int32 | Point in time (Unix timestamp) when the item was purchased. |
+  | currency | string | Currency for the paid amount. |
+  | amount | int53 | The paid amount, in the smallest units of the currency. |
+  | cryptocurrency | string | Cryptocurrency used to pay for the item. |
+  | cryptocurrency_amount | int64 | The paid amount, in the smallest units of the cryptocurrency. |
+  | url | string | Individual URL for the item on <a href="https://fragment.com">https://fragment.com</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1collectible_item_info.html).
+  """
+
+  defstruct "@type": "collectibleItemInfo", "@extra": nil, purchase_date: nil, currency: nil, amount: nil, cryptocurrency: nil, cryptocurrency_amount: nil, url: nil
+end
+defmodule StoryInteractionTypeForward do
+  @moduledoc  """
+  A forward of the story as a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message | message | The message with story forward. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interaction_type_forward.html).
+  """
+
+  defstruct "@type": "storyInteractionTypeForward", "@extra": nil, message: nil
+end
 defmodule UpdateAnimationSearchParameters do
   @moduledoc  """
-  The parameters of animation search through GetOption("animation_search_bot_username") bot has changed.
+  The parameters of animation search through getOption("animation_search_bot_username") bot has changed.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -6047,6 +9109,20 @@ defmodule ChatJoinRequest do
 
   defstruct "@type": "chatJoinRequest", "@extra": nil, user_id: nil, date: nil, bio: nil
 end
+defmodule UpdateNewBusinessMessage do
+  @moduledoc  """
+  A new message was added to a business account; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | connection_id | string | Unique identifier of the business connection. |
+  | message | businessMessage | The new message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_new_business_message.html).
+  """
+
+  defstruct "@type": "updateNewBusinessMessage", "@extra": nil, connection_id: nil, message: nil
+end
 defmodule InputMessageDocument do
   @moduledoc  """
   A document message (general file).
@@ -6055,8 +9131,8 @@ defmodule InputMessageDocument do
   |------|------| ------------|
   | document | InputFile | Document to be sent. |
   | thumbnail | inputThumbnail | Document thumbnail; pass null to skip thumbnail uploading. |
-  | disable_content_type_detection | bool | If true, automatic file type detection will be disabled and the document will be always sent as file. Always true for files sent to secret chats. |
-  | caption | formattedText | Document caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
+  | disable_content_type_detection | bool | Pass true to disable automatic file type detection and send the document as a file. Always true for files sent to secret chats. |
+  | caption | formattedText | Document caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_document.html).
   """
@@ -6072,6 +9148,19 @@ defmodule KeyboardButtonTypeRequestLocation do
   """
 
   defstruct "@type": "keyboardButtonTypeRequestLocation", "@extra": nil
+end
+defmodule UpdateSpeedLimitNotification do
+  @moduledoc  """
+  Download or upload file speed for the user was limited, but it can be restored by subscription to Telegram Premium. The notification can be postponed until a being downloaded or uploaded file is visible to the user Use getOption("premium_download_speedup") or getOption("premium_upload_speedup") to get expected speedup after subscription to Telegram Premium.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_upload | bool | True, if upload speed was limited; false, if download speed was limited. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_speed_limit_notification.html).
+  """
+
+  defstruct "@type": "updateSpeedLimitNotification", "@extra": nil, is_upload: nil
 end
 defmodule UpdateNewCallSignalingData do
   @moduledoc  """
@@ -6102,27 +9191,50 @@ defmodule UpdateChatReadInbox do
 
   defstruct "@type": "updateChatReadInbox", "@extra": nil, chat_id: nil, last_read_inbox_message_id: nil, unread_count: nil
 end
+defmodule PhoneNumberCodeTypeConfirmOwnership do
+  @moduledoc  """
+  Confirms ownership of a phone number to prevent account deletion while handling links of the type internalLinkTypePhoneNumberConfirmation.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | hash | string | Hash value from the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1phone_number_code_type_confirm_ownership.html).
+  """
+
+  defstruct "@type": "phoneNumberCodeTypeConfirmOwnership", "@extra": nil, hash: nil
+end
 defmodule UserFullInfo do
   @moduledoc  """
   Contains full information about a user.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | photo | chatPhoto | User profile photo; may be null. |
-  | is_blocked | bool | True, if the user is blocked by the current user. |
+  | personal_photo | chatPhoto | User profile photo set by the current user for the contact; may be null. If null and user.profile_photo is null, then the photo is empty; otherwise, it is unknown. If non-null, then it is the same photo as in user.profile_photo and chat.photo. This photo isn't returned in the list of user photos. |
+  | photo | chatPhoto | User profile photo; may be null. If null and user.profile_photo is null, then the photo is empty; otherwise, it is unknown. If non-null and personal_photo is null, then it is the same photo as in user.profile_photo and chat.photo. |
+  | public_photo | chatPhoto | User profile photo visible if the main photo is hidden by privacy settings; may be null. If null and user.profile_photo is null, then the photo is empty; otherwise, it is unknown. If non-null and both photo and personal_photo are null, then it is the same photo as in user.profile_photo and chat.photo. This photo isn't returned in the list of user photos. |
+  | block_list | BlockList | Block list to which the user is added; may be null if none. |
   | can_be_called | bool | True, if the user can be called. |
   | supports_video_calls | bool | True, if a video call can be created with the user. |
   | has_private_calls | bool | True, if the user can't be called due to their privacy settings. |
   | has_private_forwards | bool | True, if the user can't be linked in forwarded messages due to their privacy settings. |
+  | has_restricted_voice_and_video_note_messages | bool | True, if voice and video notes can't be sent or forwarded to the user. |
+  | has_posted_to_profile_stories | bool | True, if the user has posted to profile stories. |
+  | has_sponsored_messages_enabled | bool | True, if the user always enabled sponsored messages; known only for the current user. |
   | need_phone_number_privacy_exception | bool | True, if the current user needs to explicitly allow to share their phone number with the user when the method <a class="el" href="classtd_1_1td__api_1_1add_contact.html">addContact</a> is used. |
+  | set_chat_background | bool | True, if the user set chat background for both chat users and it wasn't reverted yet. |
   | bio | formattedText | A short user bio; may be null for bots. |
+  | birthdate | birthdate | Birthdate of the user; may be null if unknown. |
+  | personal_chat_id | int53 | Identifier of the personal chat of the user; 0 if none. |
+  | premium_gift_options | premiumPaymentOption | The list of available options for gifting Telegram Premium to the user. |
   | group_in_common_count | int32 | Number of group chats where both the other user and the current user are a member; 0 for the current user. |
-  | bot_info | botInfo | For bots, information about the bot; may be null. |
+  | business_info | businessInfo | Information about business settings for Telegram Business accounts; may be null if none. |
+  | bot_info | botInfo | For bots, information about the bot; may be null if the user isn't a bot. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_full_info.html).
   """
 
-  defstruct "@type": "userFullInfo", "@extra": nil, photo: nil, is_blocked: nil, can_be_called: nil, supports_video_calls: nil, has_private_calls: nil, has_private_forwards: nil, need_phone_number_privacy_exception: nil, bio: nil, group_in_common_count: nil, bot_info: nil
+  defstruct "@type": "userFullInfo", "@extra": nil, personal_photo: nil, photo: nil, public_photo: nil, block_list: nil, can_be_called: nil, supports_video_calls: nil, has_private_calls: nil, has_private_forwards: nil, has_restricted_voice_and_video_note_messages: nil, has_posted_to_profile_stories: nil, has_sponsored_messages_enabled: nil, need_phone_number_privacy_exception: nil, set_chat_background: nil, bio: nil, birthdate: nil, personal_chat_id: nil, premium_gift_options: nil, group_in_common_count: nil, business_info: nil, bot_info: nil
 end
 defmodule InputPassportElementErrorSourceFile do
   @moduledoc  """
@@ -6164,6 +9276,31 @@ defmodule CallStateExchangingKeys do
 
   defstruct "@type": "callStateExchangingKeys", "@extra": nil
 end
+defmodule PremiumGiveawayInfoOngoing do
+  @moduledoc  """
+  Describes an ongoing giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | creation_date | int32 | Point in time (Unix timestamp) when the giveaway was created. |
+  | status | PremiumGiveawayParticipantStatus | Status of the current user in the giveaway. |
+  | is_ended | bool | True, if the giveaway has ended and results are being prepared. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_info_ongoing.html).
+  """
+
+  defstruct "@type": "premiumGiveawayInfoOngoing", "@extra": nil, creation_date: nil, status: nil, is_ended: nil
+end
+defmodule ReactionUnavailabilityReasonAnonymousAdministrator do
+  @moduledoc  """
+  The user is an anonymous administrator in the supergroup, but isn't a creator of it, so they can't vote on behalf of the supergroup.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_unavailability_reason_anonymous_administrator.html).
+  """
+
+  defstruct "@type": "reactionUnavailabilityReasonAnonymousAdministrator", "@extra": nil
+end
 defmodule SessionTypeIphone do
   @moduledoc  """
   The session is running on an iPhone device.
@@ -6184,7 +9321,7 @@ defmodule Contact do
   | first_name | string | First name of the user; 1-255 characters in length. |
   | last_name | string | Last name of the user. |
   | vcard | string | Additional data about the user in a form of vCard; 0-2048 bytes in length. |
-  | user_id | int53 | Identifier of the user, if known; otherwise 0. |
+  | user_id | int53 | Identifier of the user, if known; 0 otherwise. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1contact.html).
   """
@@ -6198,19 +9335,28 @@ defmodule MessageLocation do
   | Name | Type | Description |
   |------|------| ------------|
   | location | location | The location description. |
-  | live_period | int32 | Time relative to the message send date, for which the location can be updated, in seconds. |
-  | expires_in | int32 | Left time for which the location can be updated, in seconds. <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> is not sent when this field changes. |
+  | live_period | int32 | Time relative to the message send date, for which the location can be updated, in seconds; if 0x7FFFFFFF, then location can be updated forever. |
+  | expires_in | int32 | Left time for which the location can be updated, in seconds. If 0, then the location can't be updated anymore. The update <a class="el" href="classtd_1_1td__api_1_1update_message_content.html">updateMessageContent</a> is not sent when this field changes. |
   | heading | int32 | For live locations, a direction in which the location moves, in degrees; 1-360. If 0 the direction is unknown. |
-  | proximity_alert_radius | int32 | For live locations, a maximum distance to another chat member for proximity alerts, in meters (0-100000). 0 if the notification is disabled. Available only for the message sender. |
+  | proximity_alert_radius | int32 | For live locations, a maximum distance to another chat member for proximity alerts, in meters (0-100000). 0 if the notification is disabled. Available only to the message sender. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_location.html).
   """
 
   defstruct "@type": "messageLocation", "@extra": nil, location: nil, live_period: nil, expires_in: nil, heading: nil, proximity_alert_radius: nil
 end
+defmodule TelegramPaymentPurpose do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_telegram_payment_purpose.html).
+  """
+
+  defstruct "@type": "TelegramPaymentPurpose", "@extra": nil
+end
 defmodule UpdateActiveNotifications do
   @moduledoc  """
-  Contains active notifications that was shown on previous application launches. This update is sent only if the message database is used. In that case it comes once before any updateNotification and updateNotificationGroup update.
+  Contains active notifications that were shown on previous application launches. This update is sent only if the message database is used. In that case it comes once before any updateNotification and updateNotificationGroup update.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -6220,6 +9366,19 @@ defmodule UpdateActiveNotifications do
   """
 
   defstruct "@type": "updateActiveNotifications", "@extra": nil, groups: nil
+end
+defmodule InlineQueryResultsButtonTypeStartBot do
+  @moduledoc  """
+  Describes the button that opens a private chat with the bot and sends a start message to the bot with the given parameter.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | parameter | string | The parameter for the bot start message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1inline_query_results_button_type_start_bot.html).
+  """
+
+  defstruct "@type": "inlineQueryResultsButtonTypeStartBot", "@extra": nil, parameter: nil
 end
 defmodule UpdateHavePendingNotifications do
   @moduledoc  """
@@ -6250,6 +9409,30 @@ defmodule AuthenticationCodeInfo do
   """
 
   defstruct "@type": "authenticationCodeInfo", "@extra": nil, phone_number: nil, type: nil, next_type: nil, timeout: nil
+end
+defmodule FoundPositions do
+  @moduledoc  """
+  Contains 0-based positions of matched objects.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Total number of matched objects. |
+  | positions | int32 | The positions of the matched objects. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_positions.html).
+  """
+
+  defstruct "@type": "foundPositions", "@extra": nil, total_count: nil, positions: nil
+end
+defmodule BotWriteAccessAllowReasonAddedToAttachmentMenu do
+  @moduledoc  """
+  The user added the bot to attachment or side menu using toggleBotIsAddedToAttachmentMenu.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1bot_write_access_allow_reason_added_to_attachment_menu.html).
+  """
+
+  defstruct "@type": "botWriteAccessAllowReasonAddedToAttachmentMenu", "@extra": nil
 end
 defmodule InternalLinkTypeTheme do
   @moduledoc  """
@@ -6293,7 +9476,7 @@ defmodule PushMessageContentChatSetTheme do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | theme_name | string | If non-empty, name of a new theme, set for the chat. Otherwise chat theme was reset to the default one. |
+  | theme_name | string | If non-empty, name of a new theme, set for the chat. Otherwise, the chat theme was reset to the default one. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_chat_set_theme.html).
   """
@@ -6336,6 +9519,15 @@ defmodule AuthenticationCodeTypeFlashCall do
 
   defstruct "@type": "authenticationCodeTypeFlashCall", "@extra": nil, pattern: nil
 end
+defmodule ChatRevenueTransactionType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_revenue_transaction_type.html).
+  """
+
+  defstruct "@type": "ChatRevenueTransactionType", "@extra": nil
+end
 defmodule UpdateChatDraftMessage do
   @moduledoc  """
   A chat draft has changed. Be aware that the update may come in the currently opened chat but with old content of the draft. If the user has changed the content of the draft, this update mustn't be applied.
@@ -6343,13 +9535,23 @@ defmodule UpdateChatDraftMessage do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | draft_message | draftMessage | The new draft message; may be null. |
+  | draft_message | draftMessage | The new draft message; may be null if none. |
   | positions | chatPosition | The new chat positions in the chat lists. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_draft_message.html).
   """
 
   defstruct "@type": "updateChatDraftMessage", "@extra": nil, chat_id: nil, draft_message: nil, positions: nil
+end
+defmodule PremiumLimitTypeChatFolderCount do
+  @moduledoc  """
+  The maximum number of chat folders.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_chat_folder_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeChatFolderCount", "@extra": nil
 end
 defmodule UpdateMessageUnreadReactions do
   @moduledoc  """
@@ -6392,7 +9594,7 @@ defmodule PassportElementErrorSourceFiles do
 end
 defmodule AuthorizationStateReady do
   @moduledoc  """
-  The user has been successfully authorized. TDLib is now ready to answer queries.
+  The user has been successfully authorized. TDLib is now ready to answer general requests.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_ready.html).
@@ -6408,7 +9610,8 @@ defmodule Session do
   |------|------| ------------|
   | id | int64 | Session identifier. |
   | is_current | bool | True, if this session is the current session. |
-  | is_password_pending | bool | True, if a password is needed to complete authorization of the session. |
+  | is_password_pending | bool | True, if a 2-step verification password is needed to complete authorization of the session. |
+  | is_unconfirmed | bool | True, if the session wasn't confirmed from another session. |
   | can_accept_secret_chats | bool | True, if incoming secret chats can be accepted by the session. |
   | can_accept_calls | bool | True, if incoming calls can be accepted by the session. |
   | type | SessionType | Session type based on the system and application version, which can be used to display a corresponding icon. |
@@ -6421,14 +9624,23 @@ defmodule Session do
   | system_version | string | Version of the operating system the application has been run or is running on, as provided by the application. |
   | log_in_date | int32 | Point in time (Unix timestamp) when the user has logged in. |
   | last_active_date | int32 | Point in time (Unix timestamp) when the session was last used. |
-  | ip | string | IP address from which the session was created, in human-readable format. |
-  | country | string | A two-letter country code for the country from which the session was created, based on the IP address. |
-  | region | string | Region code from which the session was created, based on the IP address. |
+  | ip_address | string | IP address from which the session was created, in human-readable format. |
+  | location | string | A human-readable description of the location from which the session was created, based on the IP address. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1session.html).
   """
 
-  defstruct "@type": "session", "@extra": nil, id: nil, is_current: nil, is_password_pending: nil, can_accept_secret_chats: nil, can_accept_calls: nil, type: nil, api_id: nil, application_name: nil, application_version: nil, is_official_application: nil, device_model: nil, platform: nil, system_version: nil, log_in_date: nil, last_active_date: nil, ip: nil, country: nil, region: nil
+  defstruct "@type": "session", "@extra": nil, id: nil, is_current: nil, is_password_pending: nil, is_unconfirmed: nil, can_accept_secret_chats: nil, can_accept_calls: nil, type: nil, api_id: nil, application_name: nil, application_version: nil, is_official_application: nil, device_model: nil, platform: nil, system_version: nil, log_in_date: nil, last_active_date: nil, ip_address: nil, location: nil
+end
+defmodule MessageReadDateUnread do
+  @moduledoc  """
+  The message is unread yet.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_read_date_unread.html).
+  """
+
+  defstruct "@type": "messageReadDateUnread", "@extra": nil
 end
 defmodule ChatEventMemberRestricted do
   @moduledoc  """
@@ -6452,22 +9664,14 @@ defmodule PaymentForm do
   | Name | Type | Description |
   |------|------| ------------|
   | id | int64 | The payment form identifier. |
-  | invoice | invoice | Full information about the invoice. |
+  | type | PaymentFormType | Type of the payment form. |
   | seller_bot_user_id | int53 | User identifier of the seller bot. |
-  | payment_provider_user_id | int53 | User identifier of the payment provider bot. |
-  | payment_provider | PaymentProvider | Information about the payment provider. |
-  | saved_order_info | orderInfo | Saved server-side order information; may be null. |
-  | saved_credentials | savedCredentials | Information about saved card credentials; may be null. |
-  | can_save_credentials | bool | True, if the user can choose to save credentials. |
-  | need_password | bool | True, if the user will be able to save credentials protected by a password they set up. |
-  | product_title | string | Product title. |
-  | product_description | formattedText | Product description. |
-  | product_photo | photo | Product photo; may be null. |
+  | product_info | productInfo | Information about the product. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_form.html).
   """
 
-  defstruct "@type": "paymentForm", "@extra": nil, id: nil, invoice: nil, seller_bot_user_id: nil, payment_provider_user_id: nil, payment_provider: nil, saved_order_info: nil, saved_credentials: nil, can_save_credentials: nil, need_password: nil, product_title: nil, product_description: nil, product_photo: nil
+  defstruct "@type": "paymentForm", "@extra": nil, id: nil, type: nil, seller_bot_user_id: nil, product_info: nil
 end
 defmodule JsonValueNull do
   @moduledoc  """
@@ -6490,18 +9694,21 @@ defmodule StickerSet do
   | name | string | Name of the sticker set. |
   | thumbnail | thumbnail | Sticker set thumbnail in WEBP, TGS, or WEBM format with width and height 100; may be null. The file can be downloaded only before the thumbnail is changed. |
   | thumbnail_outline | closedVectorPath | Sticker set thumbnail's outline represented as a list of closed vector paths; may be empty. The coordinate system origin is in the upper-left corner. |
+  | is_owned | bool | True, if the sticker set is owned by the current user. |
   | is_installed | bool | True, if the sticker set has been installed by the current user. |
   | is_archived | bool | True, if the sticker set has been archived. A sticker set can't be installed and archived simultaneously. |
   | is_official | bool | True, if the sticker set is official. |
   | sticker_type | StickerType | Type of the stickers in the set. |
+  | needs_repainting | bool | True, if stickers in the sticker set are custom emoji that must be repainted; for custom emoji sticker sets only. |
+  | is_allowed_as_chat_emoji_status | bool | True, if stickers in the sticker set are custom emoji that can be used as chat emoji status; for custom emoji sticker sets only. |
   | is_viewed | bool | True for already viewed trending sticker sets. |
   | stickers | sticker | List of stickers in this set. |
-  | emojis | emojis | A list of emoji corresponding to the stickers in the same order. The list is only for informational purposes, because a sticker is always sent with a fixed emoji from the corresponding Sticker object. |
+  | emojis | emojis | A list of emojis corresponding to the stickers in the same order. The list is only for informational purposes, because a sticker is always sent with a fixed emoji from the corresponding Sticker object. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_set.html).
   """
 
-  defstruct "@type": "stickerSet", "@extra": nil, id: nil, title: nil, name: nil, thumbnail: nil, thumbnail_outline: nil, is_installed: nil, is_archived: nil, is_official: nil, sticker_type: nil, is_viewed: nil, stickers: nil, emojis: nil
+  defstruct "@type": "stickerSet", "@extra": nil, id: nil, title: nil, name: nil, thumbnail: nil, thumbnail_outline: nil, is_owned: nil, is_installed: nil, is_archived: nil, is_official: nil, sticker_type: nil, needs_repainting: nil, is_allowed_as_chat_emoji_status: nil, is_viewed: nil, stickers: nil, emojis: nil
 end
 defmodule PasswordState do
   @moduledoc  """
@@ -6514,12 +9721,13 @@ defmodule PasswordState do
   | has_recovery_email_address | bool | True, if a recovery email is set. |
   | has_passport_data | bool | True, if some Telegram Passport elements were saved. |
   | recovery_email_address_code_info | emailAddressAuthenticationCodeInfo | Information about the recovery email address to which the confirmation email was sent; may be null. |
-  | pending_reset_date | int32 | If not 0, point in time (Unix timestamp) after which the password can be reset immediately using <a class="el" href="classtd_1_1td__api_1_1reset_password.html">resetPassword</a>. |
+  | login_email_address_pattern | string | Pattern of the email address set up for logging in. |
+  | pending_reset_date | int32 | If not 0, point in time (Unix timestamp) after which the 2-step verification password can be reset immediately using <a class="el" href="classtd_1_1td__api_1_1reset_password.html">resetPassword</a>. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1password_state.html).
   """
 
-  defstruct "@type": "passwordState", "@extra": nil, has_password: nil, password_hint: nil, has_recovery_email_address: nil, has_passport_data: nil, recovery_email_address_code_info: nil, pending_reset_date: nil
+  defstruct "@type": "passwordState", "@extra": nil, has_password: nil, password_hint: nil, has_recovery_email_address: nil, has_passport_data: nil, recovery_email_address_code_info: nil, login_email_address_pattern: nil, pending_reset_date: nil
 end
 defmodule UpdateMessageIsPinned do
   @moduledoc  """
@@ -6536,6 +9744,16 @@ defmodule UpdateMessageIsPinned do
 
   defstruct "@type": "updateMessageIsPinned", "@extra": nil, chat_id: nil, message_id: nil, is_pinned: nil
 end
+defmodule InviteLinkChatTypeSupergroup do
+  @moduledoc  """
+  The link is an invite link for a supergroup.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1invite_link_chat_type_supergroup.html).
+  """
+
+  defstruct "@type": "inviteLinkChatTypeSupergroup", "@extra": nil
+end
 defmodule ChatEventMessageDeleted do
   @moduledoc  """
   A message was deleted.
@@ -6543,11 +9761,27 @@ defmodule ChatEventMessageDeleted do
   | Name | Type | Description |
   |------|------| ------------|
   | message | message | Deleted message. |
+  | can_report_anti_spam_false_positive | bool | True, if the message deletion can be reported via <a class="el" href="classtd_1_1td__api_1_1report_supergroup_anti_spam_false_positive.html">reportSupergroupAntiSpamFalsePositive</a>. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_message_deleted.html).
   """
 
-  defstruct "@type": "chatEventMessageDeleted", "@extra": nil, message: nil
+  defstruct "@type": "chatEventMessageDeleted", "@extra": nil, message: nil, can_report_anti_spam_false_positive: nil
+end
+defmodule TelegramPaymentPurposeStars do
+  @moduledoc  """
+  The user buying Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+  | star_count | int53 | Number of bought stars. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1telegram_payment_purpose_stars.html).
+  """
+
+  defstruct "@type": "telegramPaymentPurposeStars", "@extra": nil, currency: nil, amount: nil, star_count: nil
 end
 defmodule InlineKeyboardButtonTypeLoginUrl do
   @moduledoc  """
@@ -6574,6 +9808,21 @@ defmodule FileTypeSecure do
 
   defstruct "@type": "fileTypeSecure", "@extra": nil
 end
+defmodule InputMessageReplyToExternalMessage do
+  @moduledoc  """
+  Describes a message to be replied that is from a different chat or a forum topic; not supported in secret chats.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | The identifier of the chat to which the message to be replied belongs. |
+  | message_id | int53 | The identifier of the message to be replied in the specified chat. A message can be replied in another chat or topic only if message.can_be_replied_in_another_chat. |
+  | quote | inputTextQuote | Quote from the message to be replied; pass null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_reply_to_external_message.html).
+  """
+
+  defstruct "@type": "inputMessageReplyToExternalMessage", "@extra": nil, chat_id: nil, message_id: nil, quote: nil
+end
 defmodule SessionTypeApple do
   @moduledoc  """
   The session is running on a generic Apple device.
@@ -6583,6 +9832,20 @@ defmodule SessionTypeApple do
   """
 
   defstruct "@type": "sessionTypeApple", "@extra": nil
+end
+defmodule UpdateQuickReplyShortcutMessages do
+  @moduledoc  """
+  The list of quick reply shortcut messages has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_id | int32 | The identifier of the shortcut. |
+  | messages | quickReplyMessage | The new list of quick reply messages for the shortcut in order from the first to the last sent. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_quick_reply_shortcut_messages.html).
+  """
+
+  defstruct "@type": "updateQuickReplyShortcutMessages", "@extra": nil, shortcut_id: nil, messages: nil
 end
 defmodule UserPrivacySettingRuleAllowUsers do
   @moduledoc  """
@@ -6618,6 +9881,20 @@ defmodule OptionValueString do
   """
 
   defstruct "@type": "optionValueString", "@extra": nil, value: nil
+end
+defmodule ChatEventMessageAutoDeleteTimeChanged do
+  @moduledoc  """
+  The message auto-delete timer was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_message_auto_delete_time | int32 | Previous value of message_auto_delete_time. |
+  | new_message_auto_delete_time | int32 | New value of message_auto_delete_time. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_message_auto_delete_time_changed.html).
+  """
+
+  defstruct "@type": "chatEventMessageAutoDeleteTimeChanged", "@extra": nil, old_message_auto_delete_time: nil, new_message_auto_delete_time: nil
 end
 defmodule DateRange do
   @moduledoc  """
@@ -6660,6 +9937,20 @@ defmodule RecoveryEmailAddress do
 
   defstruct "@type": "recoveryEmailAddress", "@extra": nil, recovery_email_address: nil
 end
+defmodule InputMessageReplyToStory do
+  @moduledoc  """
+  Describes a story to be replied.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | The identifier of the sender of the story. Currently, stories can be replied only in the sender's chat and channel stories can't be replied. |
+  | story_id | int32 | The identifier of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_reply_to_story.html).
+  """
+
+  defstruct "@type": "inputMessageReplyToStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
+end
 defmodule VectorPathCommandCubicBezierCurve do
   @moduledoc  """
   A cubic B�zier curve to a given point.
@@ -6674,6 +9965,30 @@ defmodule VectorPathCommandCubicBezierCurve do
   """
 
   defstruct "@type": "vectorPathCommandCubicBezierCurve", "@extra": nil, start_control_point: nil, end_control_point: nil, end_point: nil
+end
+defmodule MessageSourceSearch do
+  @moduledoc  """
+  The message is from search results, including file downloads, local file list, outgoing document messages, calendar.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_search.html).
+  """
+
+  defstruct "@type": "messageSourceSearch", "@extra": nil
+end
+defmodule CreatedBasicGroupChat do
+  @moduledoc  """
+  Contains information about a newly created basic group chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | failed_to_add_members | failedToAddMembers | Information about failed to add members. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1created_basic_group_chat.html).
+  """
+
+  defstruct "@type": "createdBasicGroupChat", "@extra": nil, chat_id: nil, failed_to_add_members: nil
 end
 defmodule InternalLinkType do
   @moduledoc  """
@@ -6693,6 +10008,37 @@ defmodule CallDiscardReasonDisconnected do
   """
 
   defstruct "@type": "callDiscardReasonDisconnected", "@extra": nil
+end
+defmodule TelegramPaymentPurposePremiumGiftCodes do
+  @moduledoc  """
+  The user creating Telegram Premium gift codes for other users.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | boosted_chat_id | int53 | Identifier of the supergroup or channel chat, which will be automatically boosted by the users for duration of the Premium subscription and which is administered by the user; 0 if none. |
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+  | user_ids | int53 | Identifiers of the users which can activate the gift codes. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active for the users. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1telegram_payment_purpose_premium_gift_codes.html).
+  """
+
+  defstruct "@type": "telegramPaymentPurposePremiumGiftCodes", "@extra": nil, boosted_chat_id: nil, currency: nil, amount: nil, user_ids: nil, month_count: nil
+end
+defmodule PaymentOption do
+  @moduledoc  """
+  Describes an additional payment option.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | title | string | Title for the payment option. |
+  | url | string | Payment form URL to be opened in a web view. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_option.html).
+  """
+
+  defstruct "@type": "paymentOption", "@extra": nil, title: nil, url: nil
 end
 defmodule Location do
   @moduledoc  """
@@ -6740,6 +10086,29 @@ defmodule InlineQueryResultArticle do
 
   defstruct "@type": "inlineQueryResultArticle", "@extra": nil, id: nil, url: nil, hide_url: nil, title: nil, description: nil, thumbnail: nil
 end
+defmodule UpdateChatEmojiStatus do
+  @moduledoc  """
+  Chat emoji status has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | emoji_status | emojiStatus | The new chat emoji status; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_emoji_status.html).
+  """
+
+  defstruct "@type": "updateChatEmojiStatus", "@extra": nil, chat_id: nil, emoji_status: nil
+end
+defmodule EmailAddressResetState do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_email_address_reset_state.html).
+  """
+
+  defstruct "@type": "EmailAddressResetState", "@extra": nil
+end
 defmodule FileDownload do
   @moduledoc  """
   Describes a file added to file download list.
@@ -6757,6 +10126,22 @@ defmodule FileDownload do
 
   defstruct "@type": "fileDownload", "@extra": nil, file_id: nil, message: nil, add_date: nil, complete_date: nil, is_paused: nil
 end
+defmodule MessagePremiumGiveaway do
+  @moduledoc  """
+  A Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | parameters | premiumGiveawayParameters | Giveaway parameters. |
+  | winner_count | int32 | Number of users which will receive Telegram Premium subscription gift codes. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+  | sticker | sticker | A sticker to be shown in the message; may be null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_premium_giveaway.html).
+  """
+
+  defstruct "@type": "messagePremiumGiveaway", "@extra": nil, parameters: nil, winner_count: nil, month_count: nil, sticker: nil
+end
 defmodule ReplyMarkupForceReply do
   @moduledoc  """
   Instructs application to force a reply to this message.
@@ -6770,6 +10155,36 @@ defmodule ReplyMarkupForceReply do
   """
 
   defstruct "@type": "replyMarkupForceReply", "@extra": nil, is_personal: nil, input_field_placeholder: nil
+end
+defmodule MessageOriginUser do
+  @moduledoc  """
+  The message was originally sent by a known user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_user_id | int53 | Identifier of the user that originally sent the message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_origin_user.html).
+  """
+
+  defstruct "@type": "messageOriginUser", "@extra": nil, sender_user_id: nil
+end
+defmodule LinkPreviewOptions do
+  @moduledoc  """
+  Options to be used for generation of a link preview.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_disabled | bool | True, if link preview must be disabled. |
+  | url | string | URL to use for link preview. If empty, then the first URL found in the message text will be used. |
+  | force_small_media | bool | True, if shown media preview must be small; ignored in secret chats or if the URL isn't explicitly specified. |
+  | force_large_media | bool | True, if shown media preview must be large; ignored in secret chats or if the URL isn't explicitly specified. |
+  | show_above_text | bool | True, if link preview must be shown above message text; otherwise, the link preview will be shown below the message text; ignored in secret chats. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1link_preview_options.html).
+  """
+
+  defstruct "@type": "linkPreviewOptions", "@extra": nil, is_disabled: nil, url: nil, force_small_media: nil, force_large_media: nil, show_above_text: nil
 end
 defmodule PollTypeQuiz do
   @moduledoc  """
@@ -6801,17 +10216,43 @@ defmodule BasicGroupFullInfo do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | photo | chatPhoto | Chat photo; may be null. |
+  | photo | chatPhoto | Chat photo; may be null if empty or unknown. If non-null, then it is the same photo as in chat.photo. |
   | description | string | Group description. Updated only after the basic group is opened. |
   | creator_user_id | int53 | User identifier of the creator of the group; 0 if unknown. |
   | members | chatMember | Group members. |
+  | can_hide_members | bool | True, if non-administrators and non-bots can be hidden in responses to <a class="el" href="classtd_1_1td__api_1_1get_supergroup_members.html">getSupergroupMembers</a> and <a class="el" href="classtd_1_1td__api_1_1search_chat_members.html">searchChatMembers</a> for non-administrators after upgrading the basic group to a supergroup. |
+  | can_toggle_aggressive_anti_spam | bool | True, if aggressive anti-spam checks can be enabled or disabled in the supergroup after upgrading the basic group to a supergroup. |
   | invite_link | chatInviteLink | Primary invite link for this group; may be null. For chat administrators with can_invite_users right only. Updated only after the basic group is opened. |
   | bot_commands | botCommands | List of commands of bots in the group. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1basic_group_full_info.html).
   """
 
-  defstruct "@type": "basicGroupFullInfo", "@extra": nil, photo: nil, description: nil, creator_user_id: nil, members: nil, invite_link: nil, bot_commands: nil
+  defstruct "@type": "basicGroupFullInfo", "@extra": nil, photo: nil, description: nil, creator_user_id: nil, members: nil, can_hide_members: nil, can_toggle_aggressive_anti_spam: nil, invite_link: nil, bot_commands: nil
+end
+defmodule BusinessFeatureChatFolderTags do
+  @moduledoc  """
+  The ability to display folder names for each chat in the chat list.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_chat_folder_tags.html).
+  """
+
+  defstruct "@type": "businessFeatureChatFolderTags", "@extra": nil
+end
+defmodule UpdateSavedMessagesTags do
+  @moduledoc  """
+  Tags used in Saved Messages or a Saved Messages topic have changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | saved_messages_topic_id | int53 | Identifier of Saved Messages topic which tags were changed; 0 if tags for the whole chat has changed. |
+  | tags | savedMessagesTags | The new tags. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_saved_messages_tags.html).
+  """
+
+  defstruct "@type": "updateSavedMessagesTags", "@extra": nil, saved_messages_topic_id: nil, tags: nil
 end
 defmodule CallServerTypeWebrtc do
   @moduledoc  """
@@ -6842,6 +10283,71 @@ defmodule InternalLinkTypeGame do
   """
 
   defstruct "@type": "internalLinkTypeGame", "@extra": nil, bot_username: nil, game_short_name: nil
+end
+defmodule UpdateReactionNotificationSettings do
+  @moduledoc  """
+  Notification settings for reactions were updated.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | notification_settings | reactionNotificationSettings | The new notification settings. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_reaction_notification_settings.html).
+  """
+
+  defstruct "@type": "updateReactionNotificationSettings", "@extra": nil, notification_settings: nil
+end
+defmodule ChatBoostFeatures do
+  @moduledoc  """
+  Contains a list of features available on the first chat boost levels.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | features | chatBoostLevelFeatures | The list of features. |
+  | min_profile_background_custom_emoji_boost_level | int32 | The minimum boost level required to set custom emoji for profile background. |
+  | min_background_custom_emoji_boost_level | int32 | The minimum boost level required to set custom emoji for reply header and link preview background; for channel chats only. |
+  | min_emoji_status_boost_level | int32 | The minimum boost level required to set emoji status. |
+  | min_chat_theme_background_boost_level | int32 | The minimum boost level required to set a chat theme background as chat background. |
+  | min_custom_background_boost_level | int32 | The minimum boost level required to set custom chat background. |
+  | min_custom_emoji_sticker_set_boost_level | int32 | The minimum boost level required to set custom emoji sticker set for the chat; for supergroup chats only. |
+  | min_speech_recognition_boost_level | int32 | The minimum boost level allowing to recognize speech in video note and voice note messages for non-Premium users; for supergroup chats only. |
+  | min_sponsored_message_disable_boost_level | int32 | The minimum boost level allowing to disable sponsored messages in the chat; for channel chats only. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_features.html).
+  """
+
+  defstruct "@type": "chatBoostFeatures", "@extra": nil, features: nil, min_profile_background_custom_emoji_boost_level: nil, min_background_custom_emoji_boost_level: nil, min_emoji_status_boost_level: nil, min_chat_theme_background_boost_level: nil, min_custom_background_boost_level: nil, min_custom_emoji_sticker_set_boost_level: nil, min_speech_recognition_boost_level: nil, min_sponsored_message_disable_boost_level: nil
+end
+defmodule BusinessConnection do
+  @moduledoc  """
+  Describes a connection of the bot with a business account.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | string | Unique identifier of the connection. |
+  | user_id | int53 | Identifier of the business user that created the connection. |
+  | user_chat_id | int53 | Chat identifier of the private chat with the user. |
+  | date | int32 | Point in time (Unix timestamp) when the connection was established. |
+  | can_reply | bool | True, if the bot can send messages to the connected user; false otherwise. |
+  | is_enabled | bool | True, if the connection is enabled; false otherwise. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_connection.html).
+  """
+
+  defstruct "@type": "businessConnection", "@extra": nil, id: nil, user_id: nil, user_chat_id: nil, date: nil, can_reply: nil, is_enabled: nil
+end
+defmodule MessageReadDateRead do
+  @moduledoc  """
+  Contains read date of the message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | read_date | int32 | Point in time (Unix timestamp) when the message was read by the other user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_read_date_read.html).
+  """
+
+  defstruct "@type": "messageReadDateRead", "@extra": nil, read_date: nil
 end
 defmodule InputPassportElementErrorSourceDataField do
   @moduledoc  """
@@ -6914,6 +10420,22 @@ defmodule UpdateChatHasScheduledMessages do
 
   defstruct "@type": "updateChatHasScheduledMessages", "@extra": nil, chat_id: nil, has_scheduled_messages: nil
 end
+defmodule UpdateSpeechRecognitionTrial do
+  @moduledoc  """
+  The parameters of speech recognition without Telegram Premium subscription has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | max_media_duration | int32 | The maximum allowed duration of media for speech recognition without Telegram Premium subscription, in seconds. |
+  | weekly_count | int32 | The total number of allowed speech recognitions per week; 0 if none. |
+  | left_count | int32 | Number of left speech recognition attempts this week. |
+  | next_reset_date | int32 | Point in time (Unix timestamp) when the weekly number of tries will reset; 0 if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_speech_recognition_trial.html).
+  """
+
+  defstruct "@type": "updateSpeechRecognitionTrial", "@extra": nil, max_media_duration: nil, weekly_count: nil, left_count: nil, next_reset_date: nil
+end
 defmodule TextEntityTypeCode do
   @moduledoc  """
   Text that must be formatted as if inside a code HTML tag.
@@ -6924,19 +10446,9 @@ defmodule TextEntityTypeCode do
 
   defstruct "@type": "textEntityTypeCode", "@extra": nil
 end
-defmodule ChatReportReasonPornography do
-  @moduledoc  """
-  The chat contains pornographic messages.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_pornography.html).
-  """
-
-  defstruct "@type": "chatReportReasonPornography", "@extra": nil
-end
 defmodule MessageFileTypeGroup do
   @moduledoc  """
-  The messages was exported from a group chat.
+  The messages were exported from a group chat.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -6975,6 +10487,16 @@ defmodule NotificationTypeNewCall do
 
   defstruct "@type": "notificationTypeNewCall", "@extra": nil, call_id: nil
 end
+defmodule MessageSourceForumTopicHistory do
+  @moduledoc  """
+  The message is from a forum topic history.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_forum_topic_history.html).
+  """
+
+  defstruct "@type": "messageSourceForumTopicHistory", "@extra": nil
+end
 defmodule UpdateMessageSendSucceeded do
   @moduledoc  """
   A message has been successfully sent.
@@ -7007,6 +10529,16 @@ defmodule TMeUrlType do
 
   defstruct "@type": "TMeUrlType", "@extra": nil
 end
+defmodule AutosaveSettingsScopeGroupChats do
+  @moduledoc  """
+  Autosave settings applied to all basic group and supergroup chats without chat-specific settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings_scope_group_chats.html).
+  """
+
+  defstruct "@type": "autosaveSettingsScopeGroupChats", "@extra": nil
+end
 defmodule PushMessageContentVideoNote do
   @moduledoc  """
   A video note message.
@@ -7027,12 +10559,39 @@ defmodule TextEntityTypeMediaTimestamp do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | media_timestamp | int32 | Timestamp from which a video/audio/video note/voice note playing must start, in seconds. The media can be in the content or the web page preview of the current message, or in the same places in the replied message. |
+  | media_timestamp | int32 | Timestamp from which a video/audio/video note/voice note/story playing must start, in seconds. The media can be in the content or the web page preview of the current message, or in the same places in the replied message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_media_timestamp.html).
   """
 
   defstruct "@type": "textEntityTypeMediaTimestamp", "@extra": nil, media_timestamp: nil
+end
+defmodule UpdateSavedMessagesTopicCount do
+  @moduledoc  """
+  Number of Saved Messages topics has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic_count | int32 | Approximate total number of Saved Messages topics. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_saved_messages_topic_count.html).
+  """
+
+  defstruct "@type": "updateSavedMessagesTopicCount", "@extra": nil, topic_count: nil
+end
+defmodule EmojiStatus do
+  @moduledoc  """
+  Describes a custom emoji to be shown instead of the Telegram Premium badge.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_id | int64 | Identifier of the custom emoji in <a class="el" href="classtd_1_1td__api_1_1sticker_format_tgs.html">stickerFormatTgs</a> format. |
+  | expiration_date | int32 | Point in time (Unix timestamp) when the status will expire; 0 if never. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_status.html).
+  """
+
+  defstruct "@type": "emojiStatus", "@extra": nil, custom_emoji_id: nil, expiration_date: nil
 end
 defmodule MessageSenderChat do
   @moduledoc  """
@@ -7091,6 +10650,25 @@ defmodule GroupCallParticipant do
 
   defstruct "@type": "groupCallParticipant", "@extra": nil, participant_id: nil, audio_source_id: nil, screen_sharing_audio_source_id: nil, video_info: nil, screen_sharing_video_info: nil, bio: nil, is_current_user: nil, is_speaking: nil, is_hand_raised: nil, can_be_muted_for_all_users: nil, can_be_unmuted_for_all_users: nil, can_be_muted_for_current_user: nil, can_be_unmuted_for_current_user: nil, is_muted_for_all_users: nil, is_muted_for_current_user: nil, can_unmute_self: nil, volume_level: nil, order: nil
 end
+defmodule StarTransactionPartnerGooglePlay do
+  @moduledoc  """
+  The transaction is a transaction with Google Play.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_google_play.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerGooglePlay", "@extra": nil
+end
+defmodule MessageExtendedMedia do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_extended_media.html).
+  """
+
+  defstruct "@type": "MessageExtendedMedia", "@extra": nil
+end
 defmodule CallProblemPixelatedVideo do
   @moduledoc  """
   The video was pixelated.
@@ -7100,6 +10678,21 @@ defmodule CallProblemPixelatedVideo do
   """
 
   defstruct "@type": "callProblemPixelatedVideo", "@extra": nil
+end
+defmodule BusinessConnectedBot do
+  @moduledoc  """
+  Describes a bot connected to a business account.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | User identifier of the bot. |
+  | recipients | businessRecipients | Private chats that will be accessible to the bot. |
+  | can_reply | bool | True, if the bot can send messages to the private chats; false otherwise. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_connected_bot.html).
+  """
+
+  defstruct "@type": "businessConnectedBot", "@extra": nil, bot_user_id: nil, recipients: nil, can_reply: nil
 end
 defmodule SessionTypeVivaldi do
   @moduledoc  """
@@ -7181,9 +10774,24 @@ defmodule StatisticalGraphAsync do
 
   defstruct "@type": "statisticalGraphAsync", "@extra": nil, token: nil
 end
+defmodule FailedToAddMember do
+  @moduledoc  """
+  Contains information about a user that has failed to be added to a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | User identifier. |
+  | premium_would_allow_invite | bool | True, if subscription to Telegram Premium would have allowed to add the user to the chat. |
+  | premium_required_to_send_messages | bool | True, if subscription to Telegram Premium is required to send the user chat invite link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1failed_to_add_member.html).
+  """
+
+  defstruct "@type": "failedToAddMember", "@extra": nil, user_id: nil, premium_would_allow_invite: nil, premium_required_to_send_messages: nil
+end
 defmodule InternalLinkTypeThemeSettings do
   @moduledoc  """
-  The link is a link to the theme settings section of the app.
+  The link is a link to the theme section of the app settings.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_theme_settings.html).
@@ -7203,21 +10811,6 @@ defmodule TestInt do
   """
 
   defstruct "@type": "testInt", "@extra": nil, value: nil
-end
-defmodule ChatFilterInfo do
-  @moduledoc  """
-  Contains basic information about a chat filter.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | id | int32 | Unique chat filter identifier. |
-  | title | string | The title of the filter; 1-12 characters without line feeds. |
-  | icon_name | string | The chosen or default icon name for short filter representation. One of "All", "Unread", "Unmuted", "Bots", "Channels", "Groups", "Private", "Custom", "Setup", "Cat", "Crown", "Favorite", "Flower", "Game", "Home", "Love", "Mask", "Party", "Sport", "Study", "Trade", "Travel", "Work", "Airplane", "Book", "Light", "Like", "Money", "Note", "Palette". |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_filter_info.html).
-  """
-
-  defstruct "@type": "chatFilterInfo", "@extra": nil, id: nil, title: nil, icon_name: nil
 end
 defmodule CheckChatUsernameResultUsernameInvalid do
   @moduledoc  """
@@ -7255,7 +10848,7 @@ defmodule SearchMessagesFilterPhotoAndVideo do
 end
 defmodule UpdateSavedNotificationSounds do
   @moduledoc  """
-  The list of saved notifications sounds was updated. This update may not be sent until information about a notification sound was requested for the first time.
+  The list of saved notification sounds was updated. This update may not be sent until information about a notification sound was requested for the first time.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -7275,9 +10868,9 @@ defmodule SecretChat do
   | id | int32 | Secret chat identifier. |
   | user_id | int53 | Identifier of the chat partner. |
   | state | SecretChatState | State of the secret chat. |
-  | is_outbound | bool | True, if the chat was created by the current user; otherwise false. |
+  | is_outbound | bool | True, if the chat was created by the current user; false otherwise. |
   | key_hash | bytes | Hash of the currently used key for comparison with the hash of the chat partner's key. This is a string of 36 little-endian bytes, which must be split into groups of 2 bits, each denoting a pixel of one of 4 colors FFFFFF, D5E6F3, 2D5775, and 2F99C9. The pixels must be used to make a 12x12 square image filled from left to right, top to bottom. Alternatively, the first 32 bytes of the hash can be converted to the hexadecimal format and printed as 32 2-digit hex numbers. |
-  | layer | int32 | Secret chat layer; determines features supported by the chat partner's application. Nested text entities and underline and strikethrough entities are supported if the layer >= 101, files bigger than 2000MB are supported if the layer >= 143. |
+  | layer | int32 | Secret chat layer; determines features supported by the chat partner's application. Nested text entities and underline and strikethrough entities are supported if the layer >= 101, files bigger than 2000MB are supported if the layer >= 143, spoiler and custom emoji text entities are supported if the layer >= 144. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1secret_chat.html).
   """
@@ -7311,6 +10904,30 @@ defmodule CustomRequestResult do
 
   defstruct "@type": "customRequestResult", "@extra": nil, result: nil
 end
+defmodule UpdateAvailableMessageEffects do
+  @moduledoc  """
+  The list of available message effects has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reaction_effect_ids | int64 | The new list of available message effects from emoji reactions. |
+  | sticker_effect_ids | int64 | The new list of available message effects from Premium stickers. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_available_message_effects.html).
+  """
+
+  defstruct "@type": "updateAvailableMessageEffects", "@extra": nil, reaction_effect_ids: nil, sticker_effect_ids: nil
+end
+defmodule BlockListMain do
+  @moduledoc  """
+  The main block list that disallows writing messages to the current user, receiving their status and photo, viewing of stories, and some other actions.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1block_list_main.html).
+  """
+
+  defstruct "@type": "blockListMain", "@extra": nil
+end
 defmodule ThumbnailFormatPng do
   @moduledoc  """
   The thumbnail is in PNG format. It will be used only for background patterns.
@@ -7320,6 +10937,16 @@ defmodule ThumbnailFormatPng do
   """
 
   defstruct "@type": "thumbnailFormatPng", "@extra": nil
+end
+defmodule StickerFormatTgs do
+  @moduledoc  """
+  The sticker is an animation in TGS format.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_format_tgs.html).
+  """
+
+  defstruct "@type": "stickerFormatTgs", "@extra": nil
 end
 defmodule ResetPasswordResultDeclined do
   @moduledoc  """
@@ -7355,14 +10982,15 @@ defmodule InputMessageVideoNote do
   | Name | Type | Description |
   |------|------| ------------|
   | video_note | InputFile | Video note to be sent. |
-  | thumbnail | inputThumbnail | Video thumbnail; pass null to skip thumbnail uploading. |
-  | duration | int32 | Duration of the video, in seconds. |
+  | thumbnail | inputThumbnail | Video thumbnail; may be null if empty; pass null to skip thumbnail uploading. |
+  | duration | int32 | Duration of the video, in seconds; 0-60. |
   | length | int32 | Video width and height; must be positive and not greater than 640. |
+  | self_destruct_type | MessageSelfDestructType | Video note self-destruct type; may be null if none; pass null if none; private chats only. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_video_note.html).
   """
 
-  defstruct "@type": "inputMessageVideoNote", "@extra": nil, video_note: nil, thumbnail: nil, duration: nil, length: nil
+  defstruct "@type": "inputMessageVideoNote", "@extra": nil, video_note: nil, thumbnail: nil, duration: nil, length: nil, self_destruct_type: nil
 end
 defmodule InlineQueryResultSticker do
   @moduledoc  """
@@ -7439,15 +11067,55 @@ defmodule AccountTtl do
 
   defstruct "@type": "accountTtl", "@extra": nil, days: nil
 end
+defmodule InternalLinkTypePremiumGift do
+  @moduledoc  """
+  The link is a link to the screen for gifting Telegram Premium subscriptions to friends via inputInvoiceTelegram payments or in-store purchases.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | referrer | string | Referrer specified in the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_premium_gift.html).
+  """
+
+  defstruct "@type": "internalLinkTypePremiumGift", "@extra": nil, referrer: nil
+end
+defmodule MessageEffectTypeEmojiReaction do
+  @moduledoc  """
+  An effect from an emoji reaction.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | select_animation | sticker | Select animation for the effect in TGS format. |
+  | effect_animation | sticker | Effect animation for the effect in TGS format. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_effect_type_emoji_reaction.html).
+  """
+
+  defstruct "@type": "messageEffectTypeEmojiReaction", "@extra": nil, select_animation: nil, effect_animation: nil
+end
+defmodule StoryListMain do
+  @moduledoc  """
+  The list of stories, shown in the main chat list and folder chat lists.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_list_main.html).
+  """
+
+  defstruct "@type": "storyListMain", "@extra": nil
+end
 defmodule MessageSendingStatePending do
   @moduledoc  """
   The message is being sent now, but has not yet been delivered to the server.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sending_id | int32 | Non-persistent message sending identifier, specified by the application. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_sending_state_pending.html).
   """
 
-  defstruct "@type": "messageSendingStatePending", "@extra": nil
+  defstruct "@type": "messageSendingStatePending", "@extra": nil, sending_id: nil
 end
 defmodule MessageVideoChatScheduled do
   @moduledoc  """
@@ -7469,7 +11137,7 @@ defmodule UpdateRecentStickers do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_attached | bool | True, if the list of stickers attached to photo or video files was updated, otherwise the list of sent stickers is updated. |
+  | is_attached | bool | True, if the list of stickers attached to photo or video files was updated; otherwise, the list of sent stickers is updated. |
   | sticker_ids | int32 | The new list of file identifiers of recently used stickers. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_recent_stickers.html).
@@ -7486,6 +11154,19 @@ defmodule InternalLinkTypeQrCodeAuthentication do
   """
 
   defstruct "@type": "internalLinkTypeQrCodeAuthentication", "@extra": nil
+end
+defmodule BusinessFeatures do
+  @moduledoc  """
+  Contains information about features, available to Business user accounts.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | features | BusinessFeature | The list of available business features. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_features.html).
+  """
+
+  defstruct "@type": "businessFeatures", "@extra": nil, features: nil
 end
 defmodule CallProblemNoise do
   @moduledoc  """
@@ -7513,22 +11194,15 @@ defmodule PaymentReceipt do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | title | string | Product title. |
-  | description | formattedText | Product description. |
-  | photo | photo | Product photo; may be null. |
+  | product_info | productInfo | Information about the product. |
   | date | int32 | Point in time (Unix timestamp) when the payment was made. |
   | seller_bot_user_id | int53 | User identifier of the seller bot. |
-  | payment_provider_user_id | int53 | User identifier of the payment provider bot. |
-  | invoice | invoice | Information about the invoice. |
-  | order_info | orderInfo | Order information; may be null. |
-  | shipping_option | shippingOption | Chosen shipping option; may be null. |
-  | credentials_title | string | Title of the saved credentials chosen by the buyer. |
-  | tip_amount | int53 | The amount of tip chosen by the buyer in the smallest units of the currency. |
+  | type | PaymentReceiptType | Type of the payment receipt. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_receipt.html).
   """
 
-  defstruct "@type": "paymentReceipt", "@extra": nil, title: nil, description: nil, photo: nil, date: nil, seller_bot_user_id: nil, payment_provider_user_id: nil, invoice: nil, order_info: nil, shipping_option: nil, credentials_title: nil, tip_amount: nil
+  defstruct "@type": "paymentReceipt", "@extra": nil, product_info: nil, date: nil, seller_bot_user_id: nil, type: nil
 end
 defmodule PhotoSize do
   @moduledoc  """
@@ -7553,16 +11227,31 @@ defmodule MessageChatSetTheme do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | theme_name | string | If non-empty, name of a new theme, set for the chat. Otherwise chat theme was reset to the default one. |
+  | theme_name | string | If non-empty, name of a new theme, set for the chat. Otherwise, chat theme was reset to the default one. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_chat_set_theme.html).
   """
 
   defstruct "@type": "messageChatSetTheme", "@extra": nil, theme_name: nil
 end
+defmodule ChatRevenueTransaction do
+  @moduledoc  """
+  Contains a chat revenue transactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | cryptocurrency | string | Cryptocurrency in which revenue is calculated. |
+  | cryptocurrency_amount | int64 | The withdrawn amount, in the smallest units of the cryptocurrency. |
+  | type | ChatRevenueTransactionType | Type of the transaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_transaction.html).
+  """
+
+  defstruct "@type": "chatRevenueTransaction", "@extra": nil, cryptocurrency: nil, cryptocurrency_amount: nil, type: nil
+end
 defmodule UpdateChatOnlineMemberCount do
   @moduledoc  """
-  The number of online group members has changed. This update with non-zero number of online group members is sent only for currently opened chats. There is no guarantee that it will be sent just after the number of online users has changed.
+  The number of online group members has changed. This update with non-zero number of online group members is sent only for currently opened chats. There is no guarantee that it is sent just after the number of online users has changed.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -7573,6 +11262,30 @@ defmodule UpdateChatOnlineMemberCount do
   """
 
   defstruct "@type": "updateChatOnlineMemberCount", "@extra": nil, chat_id: nil, online_member_count: nil
+end
+defmodule ReportReasonIllegalDrugs do
+  @moduledoc  """
+  The chat has illegal drugs related content.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_illegal_drugs.html).
+  """
+
+  defstruct "@type": "reportReasonIllegalDrugs", "@extra": nil
+end
+defmodule StoryContentVideo do
+  @moduledoc  """
+  A video story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | video | storyVideo | The video in MPEG4 format. |
+  | alternative_video | storyVideo | Alternative version of the video in MPEG4 format, encoded by x264 codec; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_content_video.html).
+  """
+
+  defstruct "@type": "storyContentVideo", "@extra": nil, video: nil, alternative_video: nil
 end
 defmodule UpdateChatUnreadMentionCount do
   @moduledoc  """
@@ -7588,6 +11301,19 @@ defmodule UpdateChatUnreadMentionCount do
 
   defstruct "@type": "updateChatUnreadMentionCount", "@extra": nil, chat_id: nil, unread_mention_count: nil
 end
+defmodule StoryInteractionTypeView do
+  @moduledoc  """
+  A view of the story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chosen_reaction_type | ReactionType | Type of the reaction that was chosen by the viewer; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interaction_type_view.html).
+  """
+
+  defstruct "@type": "storyInteractionTypeView", "@extra": nil, chosen_reaction_type: nil
+end
 defmodule RichTextStrikethrough do
   @moduledoc  """
   A strikethrough rich text.
@@ -7600,6 +11326,19 @@ defmodule RichTextStrikethrough do
   """
 
   defstruct "@type": "richTextStrikethrough", "@extra": nil, text: nil
+end
+defmodule MessageExtendedMediaUnsupported do
+  @moduledoc  """
+  The media is unsupported.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | caption | formattedText | Media caption. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_extended_media_unsupported.html).
+  """
+
+  defstruct "@type": "messageExtendedMediaUnsupported", "@extra": nil, caption: nil
 end
 defmodule UpdateFileDownload do
   @moduledoc  """
@@ -7619,7 +11358,7 @@ defmodule UpdateFileDownload do
 end
 defmodule AuthorizationStateWaitPhoneNumber do
   @moduledoc  """
-  TDLib needs the user's phone number to authorize. Call setAuthenticationPhoneNumber to provide the phone number, or use requestQrCodeAuthentication, or checkAuthenticationBotToken for other authentication options.
+  TDLib needs the user's phone number to authorize. Call setAuthenticationPhoneNumber to provide the phone number, or use requestQrCodeAuthentication or checkAuthenticationBotToken for other authentication options.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_phone_number.html).
@@ -7657,19 +11396,25 @@ defmodule ChatPermissions do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | can_send_messages | bool | True, if the user can send text messages, contacts, locations, and venues. |
-  | can_send_media_messages | bool | True, if the user can send audio files, documents, photos, videos, video notes, and voice notes. Implies can_send_messages permissions. |
-  | can_send_polls | bool | True, if the user can send polls. Implies can_send_messages permissions. |
-  | can_send_other_messages | bool | True, if the user can send animations, games, stickers, and dice and use inline bots. Implies can_send_messages permissions. |
-  | can_add_web_page_previews | bool | True, if the user may add a web page preview to their messages. Implies can_send_messages permissions. |
+  | can_send_basic_messages | bool | True, if the user can send text messages, contacts, giveaways, giveaway winners, invoices, locations, and venues. |
+  | can_send_audios | bool | True, if the user can send music files. |
+  | can_send_documents | bool | True, if the user can send documents. |
+  | can_send_photos | bool | True, if the user can send photos. |
+  | can_send_videos | bool | True, if the user can send videos. |
+  | can_send_video_notes | bool | True, if the user can send video notes. |
+  | can_send_voice_notes | bool | True, if the user can send voice notes. |
+  | can_send_polls | bool | True, if the user can send polls. |
+  | can_send_other_messages | bool | True, if the user can send animations, games, stickers, and dice and use inline bots. |
+  | can_add_web_page_previews | bool | True, if the user may add a web page preview to their messages. |
   | can_change_info | bool | True, if the user can change the chat title, photo, and other settings. |
   | can_invite_users | bool | True, if the user can invite new users to the chat. |
   | can_pin_messages | bool | True, if the user can pin messages. |
+  | can_create_topics | bool | True, if the user can create topics. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_permissions.html).
   """
 
-  defstruct "@type": "chatPermissions", "@extra": nil, can_send_messages: nil, can_send_media_messages: nil, can_send_polls: nil, can_send_other_messages: nil, can_add_web_page_previews: nil, can_change_info: nil, can_invite_users: nil, can_pin_messages: nil
+  defstruct "@type": "chatPermissions", "@extra": nil, can_send_basic_messages: nil, can_send_audios: nil, can_send_documents: nil, can_send_photos: nil, can_send_videos: nil, can_send_video_notes: nil, can_send_voice_notes: nil, can_send_polls: nil, can_send_other_messages: nil, can_add_web_page_previews: nil, can_change_info: nil, can_invite_users: nil, can_pin_messages: nil, can_create_topics: nil
 end
 defmodule UserPrivacySettingShowStatus do
   @moduledoc  """
@@ -7731,6 +11476,20 @@ defmodule MessageGameScore do
 
   defstruct "@type": "messageGameScore", "@extra": nil, game_message_id: nil, game_id: nil, score: nil
 end
+defmodule ChatMessageSender do
+  @moduledoc  """
+  Represents a message sender, which can be used to send messages in a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender | MessageSender | The message sender. |
+  | needs_premium | bool | True, if Telegram Premium is needed to use the message sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_message_sender.html).
+  """
+
+  defstruct "@type": "chatMessageSender", "@extra": nil, sender: nil, needs_premium: nil
+end
 defmodule ChatEventPhotoChanged do
   @moduledoc  """
   The chat photo was changed.
@@ -7754,6 +11513,15 @@ defmodule ChatMembersFilterContacts do
   """
 
   defstruct "@type": "chatMembersFilterContacts", "@extra": nil
+end
+defmodule ChatStatisticsObjectType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_statistics_object_type.html).
+  """
+
+  defstruct "@type": "ChatStatisticsObjectType", "@extra": nil
 end
 defmodule PassportElementTypePassport do
   @moduledoc  """
@@ -7795,6 +11563,39 @@ defmodule PassportElementPassportRegistration do
 
   defstruct "@type": "passportElementPassportRegistration", "@extra": nil, passport_registration: nil
 end
+defmodule FoundChatMessages do
+  @moduledoc  """
+  Contains a list of messages found by a search in a given chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Approximate total number of messages found; -1 if unknown. |
+  | messages | message | List of messages. |
+  | next_from_message_id | int53 | The offset for the next request. If 0, there are no more results. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_chat_messages.html).
+  """
+
+  defstruct "@type": "foundChatMessages", "@extra": nil, total_count: nil, messages: nil, next_from_message_id: nil
+end
+defmodule ForwardSource do
+  @moduledoc  """
+  Contains information about the last message from which a new message was forwarded last time.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat to which the message that was forwarded belonged; may be 0 if unknown. |
+  | message_id | int53 | Identifier of the message; may be 0 if unknown. |
+  | sender_id | MessageSender | Identifier of the sender of the message; may be null if unknown or the new message was forwarded not to Saved Messages. |
+  | sender_name | string | Name of the sender of the message if the sender is hidden by their privacy settings. |
+  | date | int32 | Point in time (Unix timestamp) when the message is sent; 0 if unknown. |
+  | is_outgoing | bool | True, if the message that was forwarded is outgoing; always false if sender is unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forward_source.html).
+  """
+
+  defstruct "@type": "forwardSource", "@extra": nil, chat_id: nil, message_id: nil, sender_id: nil, sender_name: nil, date: nil, is_outgoing: nil
+end
 defmodule PageBlockDetails do
   @moduledoc  """
   A collapsible block.
@@ -7827,7 +11628,7 @@ defmodule FoundMessages do
   |------|------| ------------|
   | total_count | int32 | Approximate total number of messages found; -1 if unknown. |
   | messages | message | List of messages. |
-  | next_offset | string | The offset for the next request. If empty, there are no more results. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_messages.html).
   """
@@ -7843,6 +11644,44 @@ defmodule PaymentProvider do
 
   defstruct "@type": "PaymentProvider", "@extra": nil
 end
+defmodule AuthenticationCodeTypeFirebaseIos do
+  @moduledoc  """
+  A digit-only authentication code is delivered via Firebase Authentication to the official iOS application.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | receipt | string | Receipt of successful application token validation to compare with receipt from push notification. |
+  | push_timeout | int32 | Time after the next authentication method is supposed to be used if verification push notification isn't received, in seconds. |
+  | length | int32 | Length of the code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authentication_code_type_firebase_ios.html).
+  """
+
+  defstruct "@type": "authenticationCodeTypeFirebaseIos", "@extra": nil, receipt: nil, push_timeout: nil, length: nil
+end
+defmodule BusinessMessages do
+  @moduledoc  """
+  Contains a list of messages from a business account as received by a bot.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | messages | businessMessage | List of business messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_messages.html).
+  """
+
+  defstruct "@type": "businessMessages", "@extra": nil, messages: nil
+end
+defmodule StoryListArchive do
+  @moduledoc  """
+  The list of stories, shown in the Arvhive chat list.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_list_archive.html).
+  """
+
+  defstruct "@type": "storyListArchive", "@extra": nil
+end
 defmodule ChatEventMemberJoinedByInviteLink do
   @moduledoc  """
   A new member joined the chat via an invite link.
@@ -7850,11 +11689,22 @@ defmodule ChatEventMemberJoinedByInviteLink do
   | Name | Type | Description |
   |------|------| ------------|
   | invite_link | chatInviteLink | Invite link used to join the chat. |
+  | via_chat_folder_invite_link | bool | True, if the user has joined the chat using an invite link for a chat folder. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_member_joined_by_invite_link.html).
   """
 
-  defstruct "@type": "chatEventMemberJoinedByInviteLink", "@extra": nil, invite_link: nil
+  defstruct "@type": "chatEventMemberJoinedByInviteLink", "@extra": nil, invite_link: nil, via_chat_folder_invite_link: nil
+end
+defmodule PremiumStoryFeatureSaveStories do
+  @moduledoc  """
+  The ability to save other's unprotected stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_save_stories.html).
+  """
+
+  defstruct "@type": "premiumStoryFeatureSaveStories", "@extra": nil
 end
 defmodule PollOption do
   @moduledoc  """
@@ -7862,7 +11712,7 @@ defmodule PollOption do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | text | string | Option text; 1-100 characters. |
+  | text | formattedText | Option text; 1-100 characters. Only custom emoji entities are allowed. |
   | voter_count | int32 | Number of voters for this option, available only for closed or voted polls. |
   | vote_percentage | int32 | The percentage of votes for this option; 0-100. |
   | is_chosen | bool | True, if the option was chosen by the user. |
@@ -7900,6 +11750,24 @@ defmodule InputPersonalDocument do
 
   defstruct "@type": "inputPersonalDocument", "@extra": nil, files: nil, translation: nil
 end
+defmodule PremiumPaymentOption do
+  @moduledoc  """
+  Describes an option for buying Telegram Premium to a user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | currency | string | ISO 4217 currency code for Telegram Premium subscription payment. |
+  | amount | int53 | The amount to pay, in the smallest units of the currency. |
+  | discount_percentage | int32 | The discount associated with this option, as a percentage. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active. |
+  | store_product_id | string | Identifier of the store product associated with the option. |
+  | payment_link | InternalLinkType | An internal link to be opened for buying Telegram Premium to the user if store payment isn't possible; may be null if direct payment isn't available. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_payment_option.html).
+  """
+
+  defstruct "@type": "premiumPaymentOption", "@extra": nil, currency: nil, amount: nil, discount_percentage: nil, month_count: nil, store_product_id: nil, payment_link: nil
+end
 defmodule CallId do
   @moduledoc  """
   Contains the call identifier.
@@ -7928,6 +11796,28 @@ defmodule LogStreamFile do
 
   defstruct "@type": "logStreamFile", "@extra": nil, path: nil, max_file_size: nil, redirect_stderr: nil
 end
+defmodule MessageOriginHiddenUser do
+  @moduledoc  """
+  The message was originally sent by a user, which is hidden by their privacy settings.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_name | string | Name of the sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_origin_hidden_user.html).
+  """
+
+  defstruct "@type": "messageOriginHiddenUser", "@extra": nil, sender_name: nil
+end
+defmodule StoryPrivacySettings do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_privacy_settings.html).
+  """
+
+  defstruct "@type": "StoryPrivacySettings", "@extra": nil
+end
 defmodule NotificationSettingsScope do
   @moduledoc  """
 
@@ -7944,7 +11834,7 @@ defmodule InputMessageLocation do
   | Name | Type | Description |
   |------|------| ------------|
   | location | location | Location to be sent. |
-  | live_period | int32 | Period for which the location can be updated, in seconds; must be between 60 and 86400 for a live location and 0 otherwise. |
+  | live_period | int32 | Period for which the location can be updated, in seconds; must be between 60 and 86400 for a temporary live location, 0x7FFFFFFF for permanent live location, and 0 otherwise. |
   | heading | int32 | For live locations, a direction in which the location moves, in degrees; 1-360. Pass 0 if unknown. |
   | proximity_alert_radius | int32 | For live locations, a maximum distance to another chat member for proximity alerts, in meters (0-100000). Pass 0 if the notification is disabled. Can't be enabled in channels and Saved Messages. |
 
@@ -7973,7 +11863,7 @@ defmodule PaymentResult do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | success | bool | True, if the payment request was successful; otherwise the verification_url will be non-empty. |
+  | success | bool | True, if the payment request was successful; otherwise, the verification_url will be non-empty. |
   | verification_url | string | URL for additional payment credentials verification. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_result.html).
@@ -7996,7 +11886,7 @@ defmodule DeviceTokenMicrosoftPushVoIP do
 end
 defmodule InternalLinkTypePhoneNumberConfirmation do
   @moduledoc  """
-  The link can be used to confirm ownership of a phone number to prevent account deletion. Call sendPhoneNumberConfirmationCode with the given hash and phone number to process the link.
+  The link can be used to confirm ownership of a phone number to prevent account deletion. Call sendPhoneNumberCode with the given phone number and with phoneNumberCodeTypeConfirmOwnership with the given hash to process the link. If succeeded, call checkPhoneNumberCode to check entered by the user code, or resendPhoneNumberCode to resend it.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -8010,7 +11900,7 @@ defmodule InternalLinkTypePhoneNumberConfirmation do
 end
 defmodule MessageFileTypePrivate do
   @moduledoc  """
-  The messages was exported from a private chat.
+  The messages were exported from a private chat.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -8021,20 +11911,73 @@ defmodule MessageFileTypePrivate do
 
   defstruct "@type": "messageFileTypePrivate", "@extra": nil, name: nil
 end
-defmodule AnimatedEmoji do
+defmodule StickerFormatWebm do
   @moduledoc  """
-  Describes an animated representation of an emoji.
+  The sticker is a video in WEBM format.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_format_webm.html).
+  """
+
+  defstruct "@type": "stickerFormatWebm", "@extra": nil
+end
+defmodule CanSendStoryResult do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_can_send_story_result.html).
+  """
+
+  defstruct "@type": "CanSendStoryResult", "@extra": nil
+end
+defmodule PublicForwardStory do
+  @moduledoc  """
+  Contains a public repost to a story.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sticker | sticker | Animated sticker for the emoji. |
+  | story | story | Information about the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1public_forward_story.html).
+  """
+
+  defstruct "@type": "publicForwardStory", "@extra": nil, story: nil
+end
+defmodule BotWriteAccessAllowReasonAcceptedRequest do
+  @moduledoc  """
+  The user accepted bot's request to send messages with allowBotToSendMessages.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1bot_write_access_allow_reason_accepted_request.html).
+  """
+
+  defstruct "@type": "botWriteAccessAllowReasonAcceptedRequest", "@extra": nil
+end
+defmodule AnimatedEmoji do
+  @moduledoc  """
+  Describes an animated or custom representation of an emoji.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker | sticker | Sticker for the emoji; may be null if yet unknown for a custom emoji. If the sticker is a custom emoji, then it can have arbitrary format. |
+  | sticker_width | int32 | Expected width of the sticker, which can be used if the sticker is null. |
+  | sticker_height | int32 | Expected height of the sticker, which can be used if the sticker is null. |
   | fitzpatrick_type | int32 | Emoji modifier fitzpatrick type; 0-6; 0 if none. |
-  | sound | file | File containing the sound to be played when the animated emoji is clicked; may be null. The sound is encoded with the Opus codec, and stored inside an OGG container. |
+  | sound | file | File containing the sound to be played when the sticker is clicked; may be null. The sound is encoded with the Opus codec, and stored inside an OGG container. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1animated_emoji.html).
   """
 
-  defstruct "@type": "animatedEmoji", "@extra": nil, sticker: nil, fitzpatrick_type: nil, sound: nil
+  defstruct "@type": "animatedEmoji", "@extra": nil, sticker: nil, sticker_width: nil, sticker_height: nil, fitzpatrick_type: nil, sound: nil
+end
+defmodule PremiumGiveawayParticipantStatus do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_premium_giveaway_participant_status.html).
+  """
+
+  defstruct "@type": "PremiumGiveawayParticipantStatus", "@extra": nil
 end
 defmodule CallServerTypeTelegramReflector do
   @moduledoc  """
@@ -8112,6 +12055,45 @@ defmodule NetworkTypeMobileRoaming do
 
   defstruct "@type": "networkTypeMobileRoaming", "@extra": nil
 end
+defmodule BusinessFeatureAccountLinks do
+  @moduledoc  """
+  The ability to create links to the business account with predefined message text.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_account_links.html).
+  """
+
+  defstruct "@type": "businessFeatureAccountLinks", "@extra": nil
+end
+defmodule ChatRevenueStatistics do
+  @moduledoc  """
+  A detailed statistics about revenue earned from sponsored messages in a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | revenue_by_hour_graph | StatisticalGraph | A graph containing amount of revenue in a given hour. |
+  | revenue_graph | StatisticalGraph | A graph containing amount of revenue. |
+  | revenue_amount | chatRevenueAmount | Amount of earned revenue. |
+  | usd_rate | double | Current conversion rate of the cryptocurrency in which revenue is calculated to USD. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_revenue_statistics.html).
+  """
+
+  defstruct "@type": "chatRevenueStatistics", "@extra": nil, revenue_by_hour_graph: nil, revenue_graph: nil, revenue_amount: nil, usd_rate: nil
+end
+defmodule ChatAvailableReactionsAll do
+  @moduledoc  """
+  All reactions are available in the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | max_reaction_count | int32 | The maximum allowed number of reactions per message; 1-11. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_available_reactions_all.html).
+  """
+
+  defstruct "@type": "chatAvailableReactionsAll", "@extra": nil, max_reaction_count: nil
+end
 defmodule GameHighScore do
   @moduledoc  """
   Contains one row of the game high score table.
@@ -8127,15 +12109,25 @@ defmodule GameHighScore do
 
   defstruct "@type": "gameHighScore", "@extra": nil, position: nil, user_id: nil, score: nil
 end
-defmodule ChatReportReasonSpam do
+defmodule PremiumGiveawayParticipantStatusParticipating do
   @moduledoc  """
-  The chat contains spam messages.
+  The user participates in the giveaway.
 
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_spam.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_participant_status_participating.html).
   """
 
-  defstruct "@type": "chatReportReasonSpam", "@extra": nil
+  defstruct "@type": "premiumGiveawayParticipantStatusParticipating", "@extra": nil
+end
+defmodule CanSendStoryResultOk do
+  @moduledoc  """
+  A story can be sent.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_ok.html).
+  """
+
+  defstruct "@type": "canSendStoryResultOk", "@extra": nil
 end
 defmodule UpdateChatMessageSender do
   @moduledoc  """
@@ -8150,6 +12142,15 @@ defmodule UpdateChatMessageSender do
   """
 
   defstruct "@type": "updateChatMessageSender", "@extra": nil, chat_id: nil, message_sender_id: nil
+end
+defmodule ReactionType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_reaction_type.html).
+  """
+
+  defstruct "@type": "ReactionType", "@extra": nil
 end
 defmodule ChatInviteLinkMembers do
   @moduledoc  """
@@ -8196,6 +12197,15 @@ defmodule InputMessageVenue do
   """
 
   defstruct "@type": "inputMessageVenue", "@extra": nil, venue: nil
+end
+defmodule StoryInteractionType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_interaction_type.html).
+  """
+
+  defstruct "@type": "StoryInteractionType", "@extra": nil
 end
 defmodule MessageGame do
   @moduledoc  """
@@ -8261,6 +12271,31 @@ defmodule ChatMemberStatus do
 
   defstruct "@type": "ChatMemberStatus", "@extra": nil
 end
+defmodule MessageSponsor do
+  @moduledoc  """
+  Information about the sponsor of a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | URL of the sponsor to be opened when the message is clicked. |
+  | photo | photo | Photo of the sponsor; may be null if must not be shown. |
+  | info | string | Additional optional information about the sponsor to be shown along with the message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_sponsor.html).
+  """
+
+  defstruct "@type": "messageSponsor", "@extra": nil, url: nil, photo: nil, info: nil
+end
+defmodule StarTransactionDirectionOutgoing do
+  @moduledoc  """
+  The transaction is outgoing and decreases the number of owned Telegram stars.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_direction_outgoing.html).
+  """
+
+  defstruct "@type": "starTransactionDirectionOutgoing", "@extra": nil
+end
 defmodule UpdateFile do
   @moduledoc  """
   Information about a file was updated.
@@ -8273,6 +12308,71 @@ defmodule UpdateFile do
   """
 
   defstruct "@type": "updateFile", "@extra": nil, file: nil
+end
+defmodule TextEntityTypeExpandableBlockQuote do
+  @moduledoc  """
+  Text that must be formatted as if inside a blockquote HTML tag and collapsed by default to 3 lines with the ability to show full text; not supported in secret chats.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_entity_type_expandable_block_quote.html).
+  """
+
+  defstruct "@type": "textEntityTypeExpandableBlockQuote", "@extra": nil
+end
+defmodule ForumTopic do
+  @moduledoc  """
+  Describes a forum topic.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | info | forumTopicInfo | Basic information about the topic. |
+  | last_message | message | Last message in the topic; may be null if unknown. |
+  | is_pinned | bool | True, if the topic is pinned in the topic list. |
+  | unread_count | int32 | Number of unread messages in the topic. |
+  | last_read_inbox_message_id | int53 | Identifier of the last read incoming message. |
+  | last_read_outbox_message_id | int53 | Identifier of the last read outgoing message. |
+  | unread_mention_count | int32 | Number of unread messages with a mention/reply in the topic. |
+  | unread_reaction_count | int32 | Number of messages with unread reactions in the topic. |
+  | notification_settings | chatNotificationSettings | Notification settings for the topic. |
+  | draft_message | draftMessage | A draft of a message in the topic; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forum_topic.html).
+  """
+
+  defstruct "@type": "forumTopic", "@extra": nil, info: nil, last_message: nil, is_pinned: nil, unread_count: nil, last_read_inbox_message_id: nil, last_read_outbox_message_id: nil, unread_mention_count: nil, unread_reaction_count: nil, notification_settings: nil, draft_message: nil
+end
+defmodule ResendCodeReason do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_resend_code_reason.html).
+  """
+
+  defstruct "@type": "ResendCodeReason", "@extra": nil
+end
+defmodule UpdateChatAddedToList do
+  @moduledoc  """
+  A chat was added to a chat list.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | chat_list | ChatList | The chat list to which the chat was added. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_added_to_list.html).
+  """
+
+  defstruct "@type": "updateChatAddedToList", "@extra": nil, chat_id: nil, chat_list: nil
+end
+defmodule PremiumStoryFeatureLinksAndFormatting do
+  @moduledoc  """
+  The ability to use links and formatting in story caption, and use inputStoryAreaTypeLink areas.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_links_and_formatting.html).
+  """
+
+  defstruct "@type": "premiumStoryFeatureLinksAndFormatting", "@extra": nil
 end
 defmodule SessionTypeUbuntu do
   @moduledoc  """
@@ -8297,28 +12397,78 @@ defmodule UpdateNewChat do
 
   defstruct "@type": "updateNewChat", "@extra": nil, chat: nil
 end
-defmodule Reaction do
+defmodule UpdateQuickReplyShortcutDeleted do
   @moduledoc  """
-  Contains stickers which must be used for reaction animation rendering.
+  A quick reply shortcut and all its messages were deleted.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reaction | string | Text representation of the reaction. |
-  | title | string | Reaction title. |
-  | is_active | bool | True, if the reaction can be added to new messages and enabled in chats. |
-  | is_premium | bool | True, if the reaction is available only for Premium users. |
-  | static_icon | sticker | Static icon for the reaction. |
-  | appear_animation | sticker | Appear animation for the reaction. |
-  | select_animation | sticker | Select animation for the reaction. |
-  | activate_animation | sticker | Activate animation for the reaction. |
-  | effect_animation | sticker | Effect animation for the reaction. |
-  | around_animation | sticker | Around animation for the reaction; may be null. |
-  | center_animation | sticker | Center animation for the reaction; may be null. |
+  | shortcut_id | int32 | The identifier of the deleted shortcut. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_quick_reply_shortcut_deleted.html).
   """
 
-  defstruct "@type": "reaction", "@extra": nil, reaction: nil, title: nil, is_active: nil, is_premium: nil, static_icon: nil, appear_animation: nil, select_animation: nil, activate_animation: nil, effect_animation: nil, around_animation: nil, center_animation: nil
+  defstruct "@type": "updateQuickReplyShortcutDeleted", "@extra": nil, shortcut_id: nil
+end
+defmodule InputStoryAreaType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_input_story_area_type.html).
+  """
+
+  defstruct "@type": "InputStoryAreaType", "@extra": nil
+end
+defmodule ResendCodeReasonVerificationFailed do
+  @moduledoc  """
+  The code is re-sent, because device verification has failed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | error_message | string | Cause of the verification failure, for example, PLAY_SERVICES_NOT_AVAILABLE, APNS_RECEIVE_TIMEOUT, APNS_INIT_FAILED, etc. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_code_reason_verification_failed.html).
+  """
+
+  defstruct "@type": "resendCodeReasonVerificationFailed", "@extra": nil, error_message: nil
+end
+defmodule UpdateChatBoost do
+  @moduledoc  """
+  A chat boost has changed; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | boost | chatBoost | New information about the boost. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_boost.html).
+  """
+
+  defstruct "@type": "updateChatBoost", "@extra": nil, chat_id: nil, boost: nil
+end
+defmodule StoryFullId do
+  @moduledoc  """
+  Contains identifier of a story along with identifier of its sender.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Unique story identifier among stories of the given sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_full_id.html).
+  """
+
+  defstruct "@type": "storyFullId", "@extra": nil, sender_chat_id: nil, story_id: nil
+end
+defmodule ResendCodeReasonUserRequest do
+  @moduledoc  """
+  The user requested to resend the code.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1resend_code_reason_user_request.html).
+  """
+
+  defstruct "@type": "resendCodeReasonUserRequest", "@extra": nil
 end
 defmodule AuthenticationCodeTypeMissedCall do
   @moduledoc  """
@@ -8346,7 +12496,7 @@ defmodule TopChatCategoryCalls do
 end
 defmodule PublicChatTypeHasUsername do
   @moduledoc  """
-  The chat is public, because it has username.
+  The chat is public, because it has an active username.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1public_chat_type_has_username.html).
@@ -8380,13 +12530,15 @@ defmodule InputMessageVideo do
   | width | int32 | Video width. |
   | height | int32 | Video height. |
   | supports_streaming | bool | True, if the video is supposed to be streamed. |
-  | caption | formattedText | Video caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
-  | ttl | int32 | Video TTL (Time To Live), in seconds (0-60). A non-zero TTL can be specified only in private chats. |
+  | caption | formattedText | Video caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | show_caption_above_media | bool | True, if caption must be shown above the video; otherwise, caption must be shown below the video; not supported in secret chats. |
+  | self_destruct_type | MessageSelfDestructType | Video self-destruct type; pass null if none; private chats only. |
+  | has_spoiler | bool | True, if the video preview must be covered by a spoiler animation; not supported in secret chats. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_video.html).
   """
 
-  defstruct "@type": "inputMessageVideo", "@extra": nil, video: nil, thumbnail: nil, added_sticker_file_ids: nil, duration: nil, width: nil, height: nil, supports_streaming: nil, caption: nil, ttl: nil
+  defstruct "@type": "inputMessageVideo", "@extra": nil, video: nil, thumbnail: nil, added_sticker_file_ids: nil, duration: nil, width: nil, height: nil, supports_streaming: nil, caption: nil, show_caption_above_media: nil, self_destruct_type: nil, has_spoiler: nil
 end
 defmodule VectorPathCommand do
   @moduledoc  """
@@ -8403,7 +12555,7 @@ defmodule SupergroupFullInfo do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | photo | chatPhoto | Chat photo; may be null. |
+  | photo | chatPhoto | Chat photo; may be null if empty or unknown. If non-null, then it is the same photo as in chat.photo. |
   | description | string | Supergroup or channel description. |
   | member_count | int32 | Number of members in the supergroup or channel; 0 if unknown. |
   | administrator_count | int32 | Number of privileged users in the supergroup or channel; 0 if unknown. |
@@ -8412,14 +12564,23 @@ defmodule SupergroupFullInfo do
   | linked_chat_id | int53 | Chat identifier of a discussion group for the channel, or a channel, for which the supergroup is the designated discussion group; 0 if none or unknown. |
   | slow_mode_delay | int32 | Delay between consecutive sent messages for non-administrator supergroup members, in seconds. |
   | slow_mode_delay_expires_in | double | Time left before next message can be sent in the supergroup, in seconds. An <a class="el" href="classtd_1_1td__api_1_1update_supergroup_full_info.html">updateSupergroupFullInfo</a> update is not triggered when value of this field changes, but both new and old values are non-zero. |
-  | can_get_members | bool | True, if members of the chat can be retrieved. |
-  | can_set_username | bool | True, if the chat username can be changed. |
+  | can_get_members | bool | True, if members of the chat can be retrieved via <a class="el" href="classtd_1_1td__api_1_1get_supergroup_members.html">getSupergroupMembers</a> or <a class="el" href="classtd_1_1td__api_1_1search_chat_members.html">searchChatMembers</a>. |
+  | has_hidden_members | bool | True, if non-administrators can receive only administrators and bots using <a class="el" href="classtd_1_1td__api_1_1get_supergroup_members.html">getSupergroupMembers</a> or <a class="el" href="classtd_1_1td__api_1_1search_chat_members.html">searchChatMembers</a>. |
+  | can_hide_members | bool | True, if non-administrators and non-bots can be hidden in responses to <a class="el" href="classtd_1_1td__api_1_1get_supergroup_members.html">getSupergroupMembers</a> and <a class="el" href="classtd_1_1td__api_1_1search_chat_members.html">searchChatMembers</a> for non-administrators. |
   | can_set_sticker_set | bool | True, if the supergroup sticker set can be changed. |
   | can_set_location | bool | True, if the supergroup location can be changed. |
   | can_get_statistics | bool | True, if the supergroup or channel statistics are available. |
-  | is_all_history_available | bool | True, if new chat members will have access to old messages. In public or discussion groups and both public and private channels, old messages are always available, so this option affects only private supergroups without a linked chat. The value of this field is only available for chat administrators. |
-  | sticker_set_id | int64 | Identifier of the supergroup sticker set; 0 if none. |
-  | location | chatLocation | Location to which the supergroup is connected; may be null. |
+  | can_get_revenue_statistics | bool | True, if the supergroup or channel revenue statistics are available. |
+  | can_toggle_aggressive_anti_spam | bool | True, if aggressive anti-spam checks can be enabled or disabled in the supergroup. |
+  | is_all_history_available | bool | True, if new chat members will have access to old messages. In public, discussion, of forum groups and all channels, old messages are always available, so this option affects only private non-forum supergroups without a linked chat. The value of this field is only available to chat administrators. |
+  | can_have_sponsored_messages | bool | True, if the chat can have sponsored messages. The value of this field is only available to the owner of the chat. |
+  | has_aggressive_anti_spam_enabled | bool | True, if aggressive anti-spam checks are enabled in the supergroup. The value of this field is only available to chat administrators. |
+  | has_pinned_stories | bool | True, if the supergroup or channel has pinned stories. |
+  | my_boost_count | int32 | Number of times the current user boosted the supergroup or channel. |
+  | unrestrict_boost_count | int32 | Number of times the supergroup must be boosted by a user to ignore slow mode and chat permission restrictions; 0 if unspecified. |
+  | sticker_set_id | int64 | Identifier of the supergroup sticker set that must be shown before user sticker sets; 0 if none. |
+  | custom_emoji_sticker_set_id | int64 | Identifier of the custom emoji sticker set that can be used in the supergroup without Telegram Premium subscription; 0 if none. |
+  | location | chatLocation | Location to which the supergroup is connected; may be null if none. |
   | invite_link | chatInviteLink | Primary invite link for the chat; may be null. For chat administrators with can_invite_users right only. |
   | bot_commands | botCommands | List of commands of bots in the group. |
   | upgraded_from_basic_group_id | int53 | Identifier of the basic group from which supergroup was upgraded; 0 if none. |
@@ -8428,7 +12589,7 @@ defmodule SupergroupFullInfo do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1supergroup_full_info.html).
   """
 
-  defstruct "@type": "supergroupFullInfo", "@extra": nil, photo: nil, description: nil, member_count: nil, administrator_count: nil, restricted_count: nil, banned_count: nil, linked_chat_id: nil, slow_mode_delay: nil, slow_mode_delay_expires_in: nil, can_get_members: nil, can_set_username: nil, can_set_sticker_set: nil, can_set_location: nil, can_get_statistics: nil, is_all_history_available: nil, sticker_set_id: nil, location: nil, invite_link: nil, bot_commands: nil, upgraded_from_basic_group_id: nil, upgraded_from_max_message_id: nil
+  defstruct "@type": "supergroupFullInfo", "@extra": nil, photo: nil, description: nil, member_count: nil, administrator_count: nil, restricted_count: nil, banned_count: nil, linked_chat_id: nil, slow_mode_delay: nil, slow_mode_delay_expires_in: nil, can_get_members: nil, has_hidden_members: nil, can_hide_members: nil, can_set_sticker_set: nil, can_set_location: nil, can_get_statistics: nil, can_get_revenue_statistics: nil, can_toggle_aggressive_anti_spam: nil, is_all_history_available: nil, can_have_sponsored_messages: nil, has_aggressive_anti_spam_enabled: nil, has_pinned_stories: nil, my_boost_count: nil, unrestrict_boost_count: nil, sticker_set_id: nil, custom_emoji_sticker_set_id: nil, location: nil, invite_link: nil, bot_commands: nil, upgraded_from_basic_group_id: nil, upgraded_from_max_message_id: nil
 end
 defmodule MessageChatJoinByRequest do
   @moduledoc  """
@@ -8456,35 +12617,54 @@ defmodule UpdateNewShippingQuery do
 
   defstruct "@type": "updateNewShippingQuery", "@extra": nil, id: nil, sender_user_id: nil, invoice_payload: nil, shipping_address: nil
 end
+defmodule FirebaseAuthenticationSettings do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_firebase_authentication_settings.html).
+  """
+
+  defstruct "@type": "FirebaseAuthenticationSettings", "@extra": nil
+end
 defmodule MessageForwardInfo do
   @moduledoc  """
   Contains information about a forwarded message.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | origin | MessageForwardOrigin | Origin of a forwarded message. |
+  | origin | MessageOrigin | Origin of the forwarded message. |
   | date | int32 | Point in time (Unix timestamp) when the message was originally sent. |
-  | public_service_announcement_type | string | The type of a public service announcement for the forwarded message. |
-  | from_chat_id | int53 | For messages forwarded to the chat with the current user (Saved Messages), to the Replies bot chat, or to the channel's discussion group, the identifier of the chat from which the message was forwarded last time; 0 if unknown. |
-  | from_message_id | int53 | For messages forwarded to the chat with the current user (Saved Messages), to the Replies bot chat, or to the channel's discussion group, the identifier of the original message from which the new message was forwarded last time; 0 if unknown. |
+  | source | forwardSource | For messages forwarded to the chat with the current user (Saved Messages), to the Replies bot chat, or to the channel's discussion group, information about the source message from which the message was forwarded last time; may be null for other forwards or if unknown. |
+  | public_service_announcement_type | string | The type of public service announcement for the forwarded message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_info.html).
   """
 
-  defstruct "@type": "messageForwardInfo", "@extra": nil, origin: nil, date: nil, public_service_announcement_type: nil, from_chat_id: nil, from_message_id: nil
+  defstruct "@type": "messageForwardInfo", "@extra": nil, origin: nil, date: nil, source: nil, public_service_announcement_type: nil
 end
-defmodule MessageForwardOriginUser do
+defmodule MessageViewer do
   @moduledoc  """
-  The message was originally sent by a known user.
+  Represents a viewer of a message.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sender_user_id | int53 | Identifier of the user that originally sent the message. |
+  | user_id | int53 | User identifier of the viewer. |
+  | view_date | int32 | Approximate point in time (Unix timestamp) when the message was viewed. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_origin_user.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_viewer.html).
   """
 
-  defstruct "@type": "messageForwardOriginUser", "@extra": nil, sender_user_id: nil
+  defstruct "@type": "messageViewer", "@extra": nil, user_id: nil, view_date: nil
+end
+defmodule RevenueWithdrawalStatePending do
+  @moduledoc  """
+  Withdrawal is pending.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1revenue_withdrawal_state_pending.html).
+  """
+
+  defstruct "@type": "revenueWithdrawalStatePending", "@extra": nil
 end
 defmodule MaskPointChin do
   @moduledoc  """
@@ -8541,6 +12721,20 @@ defmodule SuggestedActionViewChecksHint do
   """
 
   defstruct "@type": "suggestedActionViewChecksHint", "@extra": nil
+end
+defmodule ChatBoostLinkInfo do
+  @moduledoc  """
+  Contains information about a link to boost a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_public | bool | True, if the link will work for non-members of the chat. |
+  | chat_id | int53 | Identifier of the chat to which the link points; 0 if the chat isn't found. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_link_info.html).
+  """
+
+  defstruct "@type": "chatBoostLinkInfo", "@extra": nil, is_public: nil, chat_id: nil
 end
 defmodule VideoChat do
   @moduledoc  """
@@ -8601,12 +12795,22 @@ defmodule MessageInteractionInfo do
   | view_count | int32 | Number of times the message was viewed. |
   | forward_count | int32 | Number of times the message was forwarded. |
   | reply_info | messageReplyInfo | Information about direct or indirect replies to the message; may be null. Currently, available only in channels with a discussion supergroup and discussion supergroups for messages, which are not replies itself. |
-  | reactions | messageReaction | The list of reactions added to the message. |
+  | reactions | messageReactions | The list of reactions or tags added to the message; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_interaction_info.html).
   """
 
   defstruct "@type": "messageInteractionInfo", "@extra": nil, view_count: nil, forward_count: nil, reply_info: nil, reactions: nil
+end
+defmodule InternalLinkTypeRestorePurchases do
+  @moduledoc  """
+  The link forces restore of App Store purchases when opened. For official iOS application only.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_restore_purchases.html).
+  """
+
+  defstruct "@type": "internalLinkTypeRestorePurchases", "@extra": nil
 end
 defmodule ChatActionBarInviteMembers do
   @moduledoc  """
@@ -8617,6 +12821,16 @@ defmodule ChatActionBarInviteMembers do
   """
 
   defstruct "@type": "chatActionBarInviteMembers", "@extra": nil
+end
+defmodule StarTransactionPartnerTelegram do
+  @moduledoc  """
+  The transaction is a transaction with Telegram through a bot.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_telegram.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerTelegram", "@extra": nil
 end
 defmodule InlineQueryResultAnimation do
   @moduledoc  """
@@ -8639,7 +12853,7 @@ defmodule InternalLinkTypeProxy do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | server | string | Proxy server IP address. |
+  | server | string | Proxy server domain or IP address. |
   | port | int32 | Proxy server port. |
   | type | ProxyType | Type of the proxy. |
 
@@ -8671,18 +12885,81 @@ defmodule UpdateSupergroup do
 
   defstruct "@type": "updateSupergroup", "@extra": nil, supergroup: nil
 end
-defmodule UpdateAttachmentMenuBots do
+defmodule PremiumLimitTypeWeeklySentStoryCount do
   @moduledoc  """
-  The list of bots added to attachment menu has changed.
+  The maximum number of stories sent per week.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_weekly_sent_story_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeWeeklySentStoryCount", "@extra": nil
+end
+defmodule ChatFolder do
+  @moduledoc  """
+  Represents a folder for user chats.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | bots | attachmentMenuBot | The new list of bots added to attachment menu. The bots must not be shown on scheduled messages screen. |
+  | title | string | The title of the folder; 1-12 characters without line feeds. |
+  | icon | chatFolderIcon | The chosen icon for the chat folder; may be null. If null, use <a class="el" href="classtd_1_1td__api_1_1get_chat_folder_default_icon_name.html">getChatFolderDefaultIconName</a> to get default icon name for the folder. |
+  | color_id | int32 | The identifier of the chosen color for the chat folder icon; from -1 to 6. If -1, then color is disabled. Can't be changed if folder tags are disabled or the current user doesn't have Telegram Premium subscription. |
+  | is_shareable | bool | True, if at least one link has been created for the folder. |
+  | pinned_chat_ids | int53 | The chat identifiers of pinned chats in the folder. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("chat_folder_chosen_chat_count_max") pinned and always included non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
+  | included_chat_ids | int53 | The chat identifiers of always included chats in the folder. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("chat_folder_chosen_chat_count_max") pinned and always included non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
+  | excluded_chat_ids | int53 | The chat identifiers of always excluded chats in the folder. There can be up to <a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("chat_folder_chosen_chat_count_max") always excluded non-secret chats and the same number of secret chats, but the limit can be increased with Telegram Premium. |
+  | exclude_muted | bool | True, if muted chats need to be excluded. |
+  | exclude_read | bool | True, if read chats need to be excluded. |
+  | exclude_archived | bool | True, if archived chats need to be excluded. |
+  | include_contacts | bool | True, if contacts need to be included. |
+  | include_non_contacts | bool | True, if non-contact users need to be included. |
+  | include_bots | bool | True, if bots need to be included. |
+  | include_groups | bool | True, if basic groups and supergroups need to be included. |
+  | include_channels | bool | True, if channels need to be included. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder.html).
+  """
+
+  defstruct "@type": "chatFolder", "@extra": nil, title: nil, icon: nil, color_id: nil, is_shareable: nil, pinned_chat_ids: nil, included_chat_ids: nil, excluded_chat_ids: nil, exclude_muted: nil, exclude_read: nil, exclude_archived: nil, include_contacts: nil, include_non_contacts: nil, include_bots: nil, include_groups: nil, include_channels: nil
+end
+defmodule UpdateAttachmentMenuBots do
+  @moduledoc  """
+  The list of bots added to attachment or side menu has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bots | attachmentMenuBot | The new list of bots. The bots must not be shown on scheduled messages screen. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_attachment_menu_bots.html).
   """
 
   defstruct "@type": "updateAttachmentMenuBots", "@extra": nil, bots: nil
+end
+defmodule CanSendStoryResultMonthlyLimitExceeded do
+  @moduledoc  """
+  The monthly limit for the number of posted stories exceeded. The user needs to buy Telegram Premium or wait specified time.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | retry_after | int32 | Time left before the user can send the next story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_monthly_limit_exceeded.html).
+  """
+
+  defstruct "@type": "canSendStoryResultMonthlyLimitExceeded", "@extra": nil, retry_after: nil
+end
+defmodule ChatBoostSlots do
+  @moduledoc  """
+  Contains a list of chat boost slots.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | slots | chatBoostSlot | List of boost slots. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_slots.html).
+  """
+
+  defstruct "@type": "chatBoostSlots", "@extra": nil, slots: nil
 end
 defmodule PaymentProviderStripe do
   @moduledoc  """
@@ -8743,6 +13020,31 @@ defmodule PushMessageContentPhoto do
 
   defstruct "@type": "pushMessageContentPhoto", "@extra": nil, photo: nil, caption: nil, is_secret: nil, is_pinned: nil
 end
+defmodule UpdateChatFolders do
+  @moduledoc  """
+  The list of chat folders or a chat folder has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folders | chatFolderInfo | The new list of chat folders. |
+  | main_chat_list_position | int32 | Position of the main chat list among chat folders, 0-based. |
+  | are_tags_enabled | bool | True, if folder tags are enabled. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_folders.html).
+  """
+
+  defstruct "@type": "updateChatFolders", "@extra": nil, chat_folders: nil, main_chat_list_position: nil, are_tags_enabled: nil
+end
+defmodule ReportReasonPersonalDetails do
+  @moduledoc  """
+  The chat contains messages with personal details.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_personal_details.html).
+  """
+
+  defstruct "@type": "reportReasonPersonalDetails", "@extra": nil
+end
 defmodule PhoneNumberInfo do
   @moduledoc  """
   Contains information about a phone number.
@@ -8752,21 +13054,12 @@ defmodule PhoneNumberInfo do
   | country | countryInfo | Information about the country to which the phone number belongs; may be null. |
   | country_calling_code | string | The part of the phone number denoting country calling code or its part. |
   | formatted_phone_number | string | The phone number without country calling code formatted accordingly to local rules. Expected digits are returned as '-', but even more digits might be entered by the user. |
+  | is_anonymous | bool | True, if the phone number was bought at <a href="https://fragment.com">https://fragment.com</a> and isn't tied to a SIM card. Information about the phone number can be received using <a class="el" href="classtd_1_1td__api_1_1get_collectible_item_info.html">getCollectibleItemInfo</a>. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1phone_number_info.html).
   """
 
-  defstruct "@type": "phoneNumberInfo", "@extra": nil, country: nil, country_calling_code: nil, formatted_phone_number: nil
-end
-defmodule StickerTypeStatic do
-  @moduledoc  """
-  The sticker is an image in WEBP format.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_static.html).
-  """
-
-  defstruct "@type": "stickerTypeStatic", "@extra": nil
+  defstruct "@type": "phoneNumberInfo", "@extra": nil, country: nil, country_calling_code: nil, formatted_phone_number: nil, is_anonymous: nil
 end
 defmodule ChatEventLinkedChatChanged do
   @moduledoc  """
@@ -8826,6 +13119,7 @@ defmodule Invoice do
   | max_tip_amount | int53 | The maximum allowed amount of tip in the smallest units of the currency. |
   | suggested_tip_amounts | int53 | Suggested amounts of tip in the smallest units of the currency. |
   | recurring_payment_terms_of_service_url | string | An HTTP URL with terms of service for recurring payments. If non-empty, the invoice payment will result in recurring payments and the user must accept the terms of service before allowed to pay. |
+  | terms_of_service_url | string | An HTTP URL with terms of service for non-recurring payments. If non-empty, then the user must accept the terms of service before allowed to pay. |
   | is_test | bool | True, if the payment is a test payment. |
   | need_name | bool | True, if the user's name is needed for payment. |
   | need_phone_number | bool | True, if the user's phone number is needed for payment. |
@@ -8838,7 +13132,17 @@ defmodule Invoice do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1invoice.html).
   """
 
-  defstruct "@type": "invoice", "@extra": nil, currency: nil, price_parts: nil, max_tip_amount: nil, suggested_tip_amounts: nil, recurring_payment_terms_of_service_url: nil, is_test: nil, need_name: nil, need_phone_number: nil, need_email_address: nil, need_shipping_address: nil, send_phone_number_to_provider: nil, send_email_address_to_provider: nil, is_flexible: nil
+  defstruct "@type": "invoice", "@extra": nil, currency: nil, price_parts: nil, max_tip_amount: nil, suggested_tip_amounts: nil, recurring_payment_terms_of_service_url: nil, terms_of_service_url: nil, is_test: nil, need_name: nil, need_phone_number: nil, need_email_address: nil, need_shipping_address: nil, send_phone_number_to_provider: nil, send_email_address_to_provider: nil, is_flexible: nil
+end
+defmodule MessageSourceScreenshot do
+  @moduledoc  """
+  The message was screenshotted; the source must be used only if the message content was visible during the screenshot.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_screenshot.html).
+  """
+
+  defstruct "@type": "messageSourceScreenshot", "@extra": nil
 end
 defmodule PageBlockSubheader do
   @moduledoc  """
@@ -8862,6 +13166,19 @@ defmodule UserPrivacySettingAllowFindingByPhoneNumber do
   """
 
   defstruct "@type": "userPrivacySettingAllowFindingByPhoneNumber", "@extra": nil
+end
+defmodule PushMessageContentPremiumGiftCode do
+  @moduledoc  """
+  A message with a Telegram Premium gift code created for the user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1push_message_content_premium_gift_code.html).
+  """
+
+  defstruct "@type": "pushMessageContentPremiumGiftCode", "@extra": nil, month_count: nil
 end
 defmodule PremiumFeatureAdvancedChatManagement do
   @moduledoc  """
@@ -8888,6 +13205,35 @@ defmodule TrendingStickerSets do
 
   defstruct "@type": "trendingStickerSets", "@extra": nil, total_count: nil, sets: nil, is_premium: nil
 end
+defmodule UpdateBusinessMessagesDeleted do
+  @moduledoc  """
+  Messages in a business account were deleted; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | connection_id | string | Unique identifier of the business connection. |
+  | chat_id | int53 | Identifier of a chat in the business account in which messages were deleted. |
+  | message_ids | int53 | Unique message identifiers of the deleted messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_business_messages_deleted.html).
+  """
+
+  defstruct "@type": "updateBusinessMessagesDeleted", "@extra": nil, connection_id: nil, chat_id: nil, message_ids: nil
+end
+defmodule UpdateAccentColors do
+  @moduledoc  """
+  The list of supported accent colors has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | colors | accentColor | Information about supported colors; colors with identifiers 0 (red), 1 (orange), 2 (purple/violet), 3 (green), 4 (cyan), 5 (blue), 6 (pink) must always be supported and aren't included in the list. The exact colors for the accent colors with identifiers 0-6 must be taken from the app theme. |
+  | available_accent_color_ids | int32 | The list of accent color identifiers, which can be set through <a class="el" href="classtd_1_1td__api_1_1set_accent_color.html">setAccentColor</a> and <a class="el" href="classtd_1_1td__api_1_1set_chat_accent_color.html">setChatAccentColor</a>. The colors must be shown in the specififed order. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_accent_colors.html).
+  """
+
+  defstruct "@type": "updateAccentColors", "@extra": nil, colors: nil, available_accent_color_ids: nil
+end
 defmodule UpdateChatTheme do
   @moduledoc  """
   The chat theme was changed.
@@ -8902,18 +13248,27 @@ defmodule UpdateChatTheme do
 
   defstruct "@type": "updateChatTheme", "@extra": nil, chat_id: nil, theme_name: nil
 end
-defmodule UpdateReactions do
+defmodule BotWriteAccessAllowReasonConnectedWebsite do
   @moduledoc  """
-  The list of supported reactions has changed.
+  The user connected a website by logging in using Telegram Login Widget on it.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reactions | reaction | The new list of supported reactions. |
+  | domain_name | string | Domain name of the connected website. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_reactions.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1bot_write_access_allow_reason_connected_website.html).
   """
 
-  defstruct "@type": "updateReactions", "@extra": nil, reactions: nil
+  defstruct "@type": "botWriteAccessAllowReasonConnectedWebsite", "@extra": nil, domain_name: nil
+end
+defmodule MessageEffectType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_effect_type.html).
+  """
+
+  defstruct "@type": "MessageEffectType", "@extra": nil
 end
 defmodule ThumbnailFormatJpeg do
   @moduledoc  """
@@ -8934,33 +13289,50 @@ defmodule CallbackQueryPayload do
 
   defstruct "@type": "CallbackQueryPayload", "@extra": nil
 end
+defmodule CanSendStoryResultActiveStoryLimitExceeded do
+  @moduledoc  """
+  The limit for the number of active stories exceeded. The user can buy Telegram Premium, delete an active story, or wait for the oldest story to expire.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_active_story_limit_exceeded.html).
+  """
+
+  defstruct "@type": "canSendStoryResultActiveStoryLimitExceeded", "@extra": nil
+end
 defmodule AttachmentMenuBot do
   @moduledoc  """
-  Represents a bot added to attachment menu.
+  Represents a bot, which can be added to attachment or side menu.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | bot_user_id | int53 | User identifier of the bot added to attachment menu. |
+  | bot_user_id | int53 | User identifier of the bot. |
   | supports_self_chat | bool | True, if the bot supports opening from attachment menu in the chat with the bot. |
   | supports_user_chats | bool | True, if the bot supports opening from attachment menu in private chats with ordinary users. |
   | supports_bot_chats | bool | True, if the bot supports opening from attachment menu in private chats with other bots. |
   | supports_group_chats | bool | True, if the bot supports opening from attachment menu in basic group and supergroup chats. |
   | supports_channel_chats | bool | True, if the bot supports opening from attachment menu in channel chats. |
-  | supports_settings | bool | True, if the bot supports "settings_button_pressed" event. |
+  | request_write_access | bool | True, if the user must be asked for the permission to send messages to the bot. |
+  | is_added | bool | True, if the bot was explicitly added by the user. If the bot isn't added, then on the first bot launch <a class="el" href="classtd_1_1td__api_1_1toggle_bot_is_added_to_attachment_menu.html">toggleBotIsAddedToAttachmentMenu</a> must be called and the bot must be added or removed. |
+  | show_in_attachment_menu | bool | True, if the bot must be shown in the attachment menu. |
+  | show_in_side_menu | bool | True, if the bot must be shown in the side menu. |
+  | show_disclaimer_in_side_menu | bool | True, if a disclaimer, why the bot is shown in the side menu, is needed. |
   | name | string | Name for the bot in attachment menu. |
   | name_color | attachmentMenuBotColor | Color to highlight selected name of the bot if appropriate; may be null. |
-  | default_icon | file | Default attachment menu icon for the bot in SVG format; may be null. |
-  | ios_static_icon | file | Attachment menu icon for the bot in SVG format for the official iOS app; may be null. |
-  | ios_animated_icon | file | Attachment menu icon for the bot in TGS format for the official iOS app; may be null. |
-  | android_icon | file | Attachment menu icon for the bot in TGS format for the official Android app; may be null. |
-  | macos_icon | file | Attachment menu icon for the bot in TGS format for the official native macOS app; may be null. |
+  | default_icon | file | Default icon for the bot in SVG format; may be null. |
+  | ios_static_icon | file | Icon for the bot in SVG format for the official iOS app; may be null. |
+  | ios_animated_icon | file | Icon for the bot in TGS format for the official iOS app; may be null. |
+  | ios_side_menu_icon | file | Icon for the bot in PNG format for the official iOS app side menu; may be null. |
+  | android_icon | file | Icon for the bot in TGS format for the official Android app; may be null. |
+  | android_side_menu_icon | file | Icon for the bot in SVG format for the official Android app side menu; may be null. |
+  | macos_icon | file | Icon for the bot in TGS format for the official native macOS app; may be null. |
+  | macos_side_menu_icon | file | Icon for the bot in PNG format for the official macOS app side menu; may be null. |
   | icon_color | attachmentMenuBotColor | Color to highlight selected icon of the bot if appropriate; may be null. |
   | web_app_placeholder | file | Default placeholder for opened Web Apps in SVG format; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1attachment_menu_bot.html).
   """
 
-  defstruct "@type": "attachmentMenuBot", "@extra": nil, bot_user_id: nil, supports_self_chat: nil, supports_user_chats: nil, supports_bot_chats: nil, supports_group_chats: nil, supports_channel_chats: nil, supports_settings: nil, name: nil, name_color: nil, default_icon: nil, ios_static_icon: nil, ios_animated_icon: nil, android_icon: nil, macos_icon: nil, icon_color: nil, web_app_placeholder: nil
+  defstruct "@type": "attachmentMenuBot", "@extra": nil, bot_user_id: nil, supports_self_chat: nil, supports_user_chats: nil, supports_bot_chats: nil, supports_group_chats: nil, supports_channel_chats: nil, request_write_access: nil, is_added: nil, show_in_attachment_menu: nil, show_in_side_menu: nil, show_disclaimer_in_side_menu: nil, name: nil, name_color: nil, default_icon: nil, ios_static_icon: nil, ios_animated_icon: nil, ios_side_menu_icon: nil, android_icon: nil, android_side_menu_icon: nil, macos_icon: nil, macos_side_menu_icon: nil, icon_color: nil, web_app_placeholder: nil
 end
 defmodule PageBlockListItem do
   @moduledoc  """
@@ -8976,6 +13348,21 @@ defmodule PageBlockListItem do
 
   defstruct "@type": "pageBlockListItem", "@extra": nil, label: nil, page_blocks: nil
 end
+defmodule UserSupportInfo do
+  @moduledoc  """
+  Contains custom information about the user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message | formattedText | Information message. |
+  | author | string | Information author. |
+  | date | int32 | Information change date. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_support_info.html).
+  """
+
+  defstruct "@type": "userSupportInfo", "@extra": nil, message: nil, author: nil, date: nil
+end
 defmodule ChatMemberStatusRestricted do
   @moduledoc  """
   The user is under certain restrictions in the chat. Not supported in basic groups and channels.
@@ -8990,6 +13377,21 @@ defmodule ChatMemberStatusRestricted do
   """
 
   defstruct "@type": "chatMemberStatusRestricted", "@extra": nil, is_member: nil, restricted_until_date: nil, permissions: nil
+end
+defmodule StorePaymentPurposePremiumGiveaway do
+  @moduledoc  """
+  The user creating a Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | parameters | premiumGiveawayParameters | Giveaway parameters. |
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1store_payment_purpose_premium_giveaway.html).
+  """
+
+  defstruct "@type": "storePaymentPurposePremiumGiveaway", "@extra": nil, parameters: nil, currency: nil, amount: nil
 end
 defmodule UpdateStickerSet do
   @moduledoc  """
@@ -9014,6 +13416,21 @@ defmodule FileTypeUnknown do
 
   defstruct "@type": "fileTypeUnknown", "@extra": nil
 end
+defmodule ScopeAutosaveSettings do
+  @moduledoc  """
+  Contains autosave settings for an autosave settings scope.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | autosave_photos | bool | True, if photo autosave is enabled. |
+  | autosave_videos | bool | True, if video autosave is enabled. |
+  | max_video_file_size | int53 | The maximum size of a video file to be autosaved, in bytes; 512 KB - 4000 MB. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1scope_autosave_settings.html).
+  """
+
+  defstruct "@type": "scopeAutosaveSettings", "@extra": nil, autosave_photos: nil, autosave_videos: nil, max_video_file_size: nil
+end
 defmodule PageBlockHorizontalAlignmentLeft do
   @moduledoc  """
   The content must be left-aligned.
@@ -9023,6 +13440,20 @@ defmodule PageBlockHorizontalAlignmentLeft do
   """
 
   defstruct "@type": "pageBlockHorizontalAlignmentLeft", "@extra": nil
+end
+defmodule UpdateStoryDeleted do
+  @moduledoc  """
+  A story became inaccessible.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Story identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story_deleted.html).
+  """
+
+  defstruct "@type": "updateStoryDeleted", "@extra": nil, story_sender_chat_id: nil, story_id: nil
 end
 defmodule InputInlineQueryResultPhoto do
   @moduledoc  """
@@ -9061,7 +13492,7 @@ defmodule PushMessageContentInvoice do
 end
 defmodule ReplyMarkupRemoveKeyboard do
   @moduledoc  """
-  Instructs application to remove the keyboard once this message has been received. This kind of keyboard can't be received in an incoming message; instead, UpdateChatReplyMarkup with message_id == 0 will be sent.
+  Instructs application to remove the keyboard once this message has been received. This kind of keyboard can't be received in an incoming message; instead, updateChatReplyMarkup with message_id == 0 will be sent.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9072,9 +13503,19 @@ defmodule ReplyMarkupRemoveKeyboard do
 
   defstruct "@type": "replyMarkupRemoveKeyboard", "@extra": nil, is_personal: nil
 end
+defmodule MessageSourceNotification do
+  @moduledoc  """
+  The message is from a notification.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_notification.html).
+  """
+
+  defstruct "@type": "messageSourceNotification", "@extra": nil
+end
 defmodule AuthenticationCodeTypeCall do
   @moduledoc  """
-  An authentication code is delivered via a phone call to the specified phone number.
+  A digit-only authentication code is delivered via a phone call to the specified phone number.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9108,6 +13549,20 @@ defmodule MessageSendingState do
 
   defstruct "@type": "MessageSendingState", "@extra": nil
 end
+defmodule ChatPhotoStickerTypeRegularOrMask do
+  @moduledoc  """
+  Information about the sticker, which was used to create the chat photo.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sticker_set_id | int64 | Sticker set identifier. |
+  | sticker_id | int64 | Identifier of the sticker in the set. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_photo_sticker_type_regular_or_mask.html).
+  """
+
+  defstruct "@type": "chatPhotoStickerTypeRegularOrMask", "@extra": nil, sticker_set_id: nil, sticker_id: nil
+end
 defmodule PassportElementTypeDriverLicense do
   @moduledoc  """
   A Telegram Passport element containing the user's driver license.
@@ -9134,12 +13589,32 @@ defmodule InlineKeyboardButtonTypeSwitchInline do
   | Name | Type | Description |
   |------|------| ------------|
   | query | string | Inline query to be sent to the bot. |
-  | in_current_chat | bool | True, if the inline query must be sent from the current chat. |
+  | target_chat | TargetChat | Target chat from which to send the inline query. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1inline_keyboard_button_type_switch_inline.html).
   """
 
-  defstruct "@type": "inlineKeyboardButtonTypeSwitchInline", "@extra": nil, query: nil, in_current_chat: nil
+  defstruct "@type": "inlineKeyboardButtonTypeSwitchInline", "@extra": nil, query: nil, target_chat: nil
+end
+defmodule FileTypePhotoStory do
+  @moduledoc  """
+  The file is a photo published as a story.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1file_type_photo_story.html).
+  """
+
+  defstruct "@type": "fileTypePhotoStory", "@extra": nil
+end
+defmodule UserPrivacySettingShowBirthdate do
+  @moduledoc  """
+  A privacy setting for managing whether the user's birthdate is visible.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_show_birthdate.html).
+  """
+
+  defstruct "@type": "userPrivacySettingShowBirthdate", "@extra": nil
 end
 defmodule DraftMessage do
   @moduledoc  """
@@ -9147,14 +13622,15 @@ defmodule DraftMessage do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reply_to_message_id | int53 | Identifier of the replied message; 0 if none. |
+  | reply_to | InputMessageReplyTo | Information about the message to be replied; must be of the type <a class="el" href="classtd_1_1td__api_1_1input_message_reply_to_message.html">inputMessageReplyToMessage</a>; may be null if none. |
   | date | int32 | Point in time (Unix timestamp) when the draft was created. |
-  | input_message_text | InputMessageContent | Content of the message draft; must be of the type <a class="el" href="classtd_1_1td__api_1_1input_message_text.html">inputMessageText</a>. |
+  | input_message_text | InputMessageContent | Content of the message draft; must be of the type <a class="el" href="classtd_1_1td__api_1_1input_message_text.html">inputMessageText</a>, <a class="el" href="classtd_1_1td__api_1_1input_message_video_note.html">inputMessageVideoNote</a>, or <a class="el" href="classtd_1_1td__api_1_1input_message_voice_note.html">inputMessageVoiceNote</a>. |
+  | effect_id | int64 | Identifier of the effect to apply to the message when it is sent; 0 if none. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1draft_message.html).
   """
 
-  defstruct "@type": "draftMessage", "@extra": nil, reply_to_message_id: nil, date: nil, input_message_text: nil
+  defstruct "@type": "draftMessage", "@extra": nil, reply_to: nil, date: nil, input_message_text: nil, effect_id: nil
 end
 defmodule UpdateFileAddedToDownloads do
   @moduledoc  """
@@ -9179,15 +13655,53 @@ defmodule GroupCallVideoQuality do
 
   defstruct "@type": "GroupCallVideoQuality", "@extra": nil
 end
+defmodule UpdateForumTopicInfo do
+  @moduledoc  """
+  Basic information about a topic in a forum chat was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | info | forumTopicInfo | New information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_forum_topic_info.html).
+  """
+
+  defstruct "@type": "updateForumTopicInfo", "@extra": nil, chat_id: nil, info: nil
+end
 defmodule ThumbnailFormatTgs do
   @moduledoc  """
-  The thumbnail is in TGS format. It will be used only for TGS sticker sets.
+  The thumbnail is in TGS format. It will be used only for sticker sets.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1thumbnail_format_tgs.html).
   """
 
   defstruct "@type": "thumbnailFormatTgs", "@extra": nil
+end
+defmodule SuggestedActionSetBirthdate do
+  @moduledoc  """
+  Suggests the user to set birthdate.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_set_birthdate.html).
+  """
+
+  defstruct "@type": "suggestedActionSetBirthdate", "@extra": nil
+end
+defmodule ChatAvailableReactionsSome do
+  @moduledoc  """
+  Only specific reactions are available in the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reactions | ReactionType | The list of reactions. |
+  | max_reaction_count | int32 | The maximum allowed number of reactions per message; 1-11. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_available_reactions_some.html).
+  """
+
+  defstruct "@type": "chatAvailableReactionsSome", "@extra": nil, reactions: nil, max_reaction_count: nil
 end
 defmodule InputPassportElementUtilityBill do
   @moduledoc  """
@@ -9215,6 +13729,16 @@ defmodule Backgrounds do
 
   defstruct "@type": "backgrounds", "@extra": nil, backgrounds: nil
 end
+defmodule BusinessFeatureBots do
+  @moduledoc  """
+  The ability to connect a bot to the account.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_bots.html).
+  """
+
+  defstruct "@type": "businessFeatureBots", "@extra": nil
+end
 defmodule PassportElementTypeUtilityBill do
   @moduledoc  """
   A Telegram Passport element containing the user's utility bill.
@@ -9225,15 +13749,90 @@ defmodule PassportElementTypeUtilityBill do
 
   defstruct "@type": "passportElementTypeUtilityBill", "@extra": nil
 end
-defmodule ChatReportReasonCustom do
+defmodule AuthenticationCodeTypeSmsPhrase do
   @moduledoc  """
-  A custom reason provided by the user.
+  An authentication code is a phrase from multiple words delivered via an SMS message to the specified phone number; non-official applications may not receive this type of code.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | first_word | string | The first word of the phrase if known. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_custom.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authentication_code_type_sms_phrase.html).
   """
 
-  defstruct "@type": "chatReportReasonCustom", "@extra": nil
+  defstruct "@type": "authenticationCodeTypeSmsPhrase", "@extra": nil, first_word: nil
+end
+defmodule PremiumFeatureChatBoost do
+  @moduledoc  """
+  The ability to boost chats.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_chat_boost.html).
+  """
+
+  defstruct "@type": "premiumFeatureChatBoost", "@extra": nil
+end
+defmodule LocationAddress do
+  @moduledoc  """
+  Describes an address of a location.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | country_code | string | A two-letter ISO 3166-1 alpha-2 country code. |
+  | state | string | State, if applicable; empty if unknown. |
+  | city | string | City; empty if unknown. |
+  | street | string | The address; empty if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1location_address.html).
+  """
+
+  defstruct "@type": "locationAddress", "@extra": nil, country_code: nil, state: nil, city: nil, street: nil
+end
+defmodule ChatPhotoSticker do
+  @moduledoc  """
+  Information about the sticker, which was used to create the chat photo. The sticker is shown at the center of the photo and occupies at most 67% of it.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | type | ChatPhotoStickerType | Type of the sticker. |
+  | background_fill | BackgroundFill | The fill to be used as background for the sticker; rotation angle in <a class="el" href="classtd_1_1td__api_1_1background_fill_gradient.html">backgroundFillGradient</a> isn't supported. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_photo_sticker.html).
+  """
+
+  defstruct "@type": "chatPhotoSticker", "@extra": nil, type: nil, background_fill: nil
+end
+defmodule StarTransaction do
+  @moduledoc  """
+  Represents a transaction changing the amount of owned Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | string | Unique identifier of the transaction. |
+  | star_count | int53 | The amount of added owned Telegram stars; negative for outgoing transactions. |
+  | is_refund | bool | True, if the transaction is a refund of a previous transaction. |
+  | date | int32 | Point in time (Unix timestamp) when the transaction was completed. |
+  | partner | StarTransactionPartner | Source of the incoming transaction, or its recipient for outgoing transactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction.html).
+  """
+
+  defstruct "@type": "starTransaction", "@extra": nil, id: nil, star_count: nil, is_refund: nil, date: nil, partner: nil
+end
+defmodule Birthdate do
+  @moduledoc  """
+  Represents a birthdate of a user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | day | int32 | Day of the month; 1-31. |
+  | month | int32 | Month of the year; 1-12. |
+  | year | int32 | Birth year; 0 if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1birthdate.html).
+  """
+
+  defstruct "@type": "birthdate", "@extra": nil, day: nil, month: nil, year: nil
 end
 defmodule UpdateChatReadOutbox do
   @moduledoc  """
@@ -9259,7 +13858,7 @@ defmodule Background do
   | is_default | bool | True, if this is one of default backgrounds. |
   | is_dark | bool | True, if the background is dark and is recommended to be used with dark theme. |
   | name | string | Unique background name. |
-  | document | document | Document with the background; may be null. Null only for filled backgrounds. |
+  | document | document | Document with the background; may be null. Null only for filled and chat theme backgrounds. |
   | type | BackgroundType | Type of the background. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1background.html).
@@ -9267,9 +13866,25 @@ defmodule Background do
 
   defstruct "@type": "background", "@extra": nil, id: nil, is_default: nil, is_dark: nil, name: nil, document: nil, type: nil
 end
+defmodule PrepaidPremiumGiveaway do
+  @moduledoc  """
+  Describes a prepaid Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int64 | Unique identifier of the prepaid giveaway. |
+  | winner_count | int32 | Number of users which will receive Telegram Premium subscription gift codes. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+  | payment_date | int32 | Point in time (Unix timestamp) when the giveaway was paid. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1prepaid_premium_giveaway.html).
+  """
+
+  defstruct "@type": "prepaidPremiumGiveaway", "@extra": nil, id: nil, winner_count: nil, month_count: nil, payment_date: nil
+end
 defmodule UpdateMessageContentOpened do
   @moduledoc  """
-  The message content was opened. Updates voice note messages to "listened", video note messages to "viewed" and starts the TTL timer for self-destructing messages.
+  The message content was opened. Updates voice note messages to "listened", video note messages to "viewed" and starts the self-destruct timer.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9319,16 +13934,17 @@ defmodule InputBackgroundLocal do
 end
 defmodule InternalLinkTypePublicChat do
   @moduledoc  """
-  The link is a link to a chat by its username. Call searchPublicChat with the given chat username to process the link.
+  The link is a link to a chat by its username. Call searchPublicChat with the given chat username to process the link If the chat is found, open its profile information screen or the chat itself. If draft text isn't empty and the chat is a private chat with a regular user, then put the draft text in the input field.
 
   | Name | Type | Description |
   |------|------| ------------|
   | chat_username | string | Username of the chat. |
+  | draft_text | string | Draft text for message to send in the chat. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_public_chat.html).
   """
 
-  defstruct "@type": "internalLinkTypePublicChat", "@extra": nil, chat_username: nil
+  defstruct "@type": "internalLinkTypePublicChat", "@extra": nil, chat_username: nil, draft_text: nil
 end
 defmodule TextEntityTypeUrl do
   @moduledoc  """
@@ -9339,6 +13955,21 @@ defmodule TextEntityTypeUrl do
   """
 
   defstruct "@type": "textEntityTypeUrl", "@extra": nil
+end
+defmodule StoryInfo do
+  @moduledoc  """
+  Contains basic information about a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_id | int32 | Unique story identifier among stories of the given sender. |
+  | date | int32 | Point in time (Unix timestamp) when the story was published. |
+  | is_for_close_friends | bool | True, if the story is available only to close friends. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_info.html).
+  """
+
+  defstruct "@type": "storyInfo", "@extra": nil, story_id: nil, date: nil, is_for_close_friends: nil
 end
 defmodule CallProblem do
   @moduledoc  """
@@ -9374,7 +14005,7 @@ defmodule FileTypeNone do
 end
 defmodule ChatEventPermissionsChanged do
   @moduledoc  """
-  The chat permissions was changed.
+  The chat permissions were changed.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9396,6 +14027,16 @@ defmodule CallStateHangingUp do
 
   defstruct "@type": "callStateHangingUp", "@extra": nil
 end
+defmodule BusinessFeatureLocation do
+  @moduledoc  """
+  The ability to set location.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_location.html).
+  """
+
+  defstruct "@type": "businessFeatureLocation", "@extra": nil
+end
 defmodule TestVectorIntObject do
   @moduledoc  """
   A simple object containing a vector of objects that hold a number; for testing only.
@@ -9415,7 +14056,7 @@ defmodule ChatMemberStatusCreator do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | custom_title | string | A custom title of the owner; 0-16 characters without emojis; applicable to supergroups only. |
+  | custom_title | string | A custom title of the owner; 0-16 characters without emoji; applicable to supergroups only. |
   | is_anonymous | bool | True, if the creator isn't shown in the chat member list and sends messages anonymously; applicable to supergroups only. |
   | is_member | bool | True, if the user is a member of the chat. |
 
@@ -9448,7 +14089,7 @@ defmodule InputInlineQueryResultArticle do
 end
 defmodule InternalLinkTypeBotStartInGroup do
   @moduledoc  """
-  The link is a link to a Telegram bot, which is supposed to be added to a group chat. Call searchPublicChat with the given bot username, check that the user is a bot and can be added to groups, ask the current user to select a basic group or a supergroup chat to add the bot to, taking into account that bots can be added to a public supergroup only by administrators of the supergroup. If administrator rights are provided by the link, call getChatMember to receive the current bot rights in the chat and if the bot already is an administrator, check that the current user can edit its administrator rights, combine received rights with the requested administrator rights, show confirmation box to the user, and call setChatMemberStatus with the chosen chat and confirmed administrator rights. Before call to setChatMemberStatus it may be required to upgrade the chosen basic group chat to a supergroup chat. Then if start_parameter isn't empty, call sendBotStartMessage with the given start parameter and the chosen chat, otherwise just send /start message with bot's username added to the chat.
+  The link is a link to a Telegram bot, which is supposed to be added to a group chat. Call searchPublicChat with the given bot username, check that the user is a bot and can be added to groups, ask the current user to select a basic group or a supergroup chat to add the bot to, taking into account that bots can be added to a public supergroup only by administrators of the supergroup. If administrator rights are provided by the link, call getChatMember to receive the current bot rights in the chat and if the bot already is an administrator, check that the current user can edit its administrator rights, combine received rights with the requested administrator rights, show confirmation box to the user, and call setChatMemberStatus with the chosen chat and confirmed administrator rights. Before call to setChatMemberStatus it may be required to upgrade the chosen basic group chat to a supergroup chat. Then, if start_parameter isn't empty, call sendBotStartMessage with the given start parameter and the chosen chat; otherwise, just send /start message with bot's username added to the chat.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9498,11 +14139,12 @@ defmodule ChatPhotoInfo do
   | big | file | A big (640x640) chat photo variant in JPEG format. The file can be downloaded only before the photo is changed. |
   | minithumbnail | minithumbnail | Chat photo minithumbnail; may be null. |
   | has_animation | bool | True, if the photo has animated variant. |
+  | is_personal | bool | True, if the photo is visible only for the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_photo_info.html).
   """
 
-  defstruct "@type": "chatPhotoInfo", "@extra": nil, small: nil, big: nil, minithumbnail: nil, has_animation: nil
+  defstruct "@type": "chatPhotoInfo", "@extra": nil, small: nil, big: nil, minithumbnail: nil, has_animation: nil, is_personal: nil
 end
 defmodule ThumbnailFormatMpeg4 do
   @moduledoc  """
@@ -9518,11 +14160,14 @@ defmodule UserStatusLastMonth do
   @moduledoc  """
   The user is offline, but was online last month.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | by_my_privacy_settings | bool | Exact user's status is hidden because the current user enabled <a class="el" href="classtd_1_1td__api_1_1user_privacy_setting_show_status.html">userPrivacySettingShowStatus</a> privacy setting for the user and has no Telegram Premium. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_status_last_month.html).
   """
 
-  defstruct "@type": "userStatusLastMonth", "@extra": nil
+  defstruct "@type": "userStatusLastMonth", "@extra": nil, by_my_privacy_settings: nil
 end
 defmodule InlineKeyboardButton do
   @moduledoc  """
@@ -9538,6 +14183,19 @@ defmodule InlineKeyboardButton do
 
   defstruct "@type": "inlineKeyboardButton", "@extra": nil, text: nil, type: nil
 end
+defmodule BackgroundTypeChatTheme do
+  @moduledoc  """
+  A background from a chat theme; can be used only as a chat background in channels.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | theme_name | string | Name of the chat theme. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1background_type_chat_theme.html).
+  """
+
+  defstruct "@type": "backgroundTypeChatTheme", "@extra": nil, theme_name: nil
+end
 defmodule ChatEventIsAllHistoryAvailableToggled do
   @moduledoc  """
   The is_all_history_available setting of a supergroup was toggled.
@@ -9551,9 +14209,22 @@ defmodule ChatEventIsAllHistoryAvailableToggled do
 
   defstruct "@type": "chatEventIsAllHistoryAvailableToggled", "@extra": nil, is_all_history_available: nil
 end
+defmodule StickerFullTypeRegular do
+  @moduledoc  """
+  The sticker is a regular sticker.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | premium_animation | file | Premium animation of the sticker; may be null. If present, only Telegram Premium users can use the sticker. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_full_type_regular.html).
+  """
+
+  defstruct "@type": "stickerFullTypeRegular", "@extra": nil, premium_animation: nil
+end
 defmodule InternalLinkTypePrivacyAndSecuritySettings do
   @moduledoc  """
-  The link is a link to the privacy and security settings section of the app.
+  The link is a link to the privacy and security section of the app settings.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_privacy_and_security_settings.html).
@@ -9583,16 +14254,6 @@ defmodule FileTypeSecret do
   """
 
   defstruct "@type": "fileTypeSecret", "@extra": nil
-end
-defmodule ChatReportReasonChildAbuse do
-  @moduledoc  """
-  The chat has child abuse related content.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_child_abuse.html).
-  """
-
-  defstruct "@type": "chatReportReasonChildAbuse", "@extra": nil
 end
 defmodule NotificationSettingsScopeGroupChats do
   @moduledoc  """
@@ -9670,6 +14331,34 @@ defmodule GroupCallVideoSourceGroup do
 
   defstruct "@type": "groupCallVideoSourceGroup", "@extra": nil, semantics: nil, source_ids: nil
 end
+defmodule StarTransactions do
+  @moduledoc  """
+  Represents a list of Telegram star transactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | star_count | int53 | The amount of owned Telegram stars. |
+  | transactions | starTransaction | List of transactions with Telegram stars. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transactions.html).
+  """
+
+  defstruct "@type": "starTransactions", "@extra": nil, star_count: nil, transactions: nil, next_offset: nil
+end
+defmodule UpdateStory do
+  @moduledoc  """
+  A story was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story | story | The new information about the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story.html).
+  """
+
+  defstruct "@type": "updateStory", "@extra": nil, story: nil
+end
 defmodule PremiumSource do
   @moduledoc  """
 
@@ -9678,6 +14367,16 @@ defmodule PremiumSource do
   """
 
   defstruct "@type": "PremiumSource", "@extra": nil
+end
+defmodule PremiumLimitTypeStorySuggestedReactionAreaCount do
+  @moduledoc  """
+  The maximum number of suggested reaction areas on a story.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_story_suggested_reaction_area_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeStorySuggestedReactionAreaCount", "@extra": nil
 end
 defmodule ChatStatisticsAdministratorActionsInfo do
   @moduledoc  """
@@ -9694,6 +14393,22 @@ defmodule ChatStatisticsAdministratorActionsInfo do
   """
 
   defstruct "@type": "chatStatisticsAdministratorActionsInfo", "@extra": nil, user_id: nil, deleted_message_count: nil, banned_user_count: nil, restricted_user_count: nil
+end
+defmodule BusinessBotManageBar do
+  @moduledoc  """
+  Contains information about a business bot that manages the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | User identifier of the bot. |
+  | manage_url | string | URL to be opened to manage the bot. |
+  | is_bot_paused | bool | True, if the bot is paused. Use <a class="el" href="classtd_1_1td__api_1_1toggle_business_connected_bot_chat_is_paused.html">toggleBusinessConnectedBotChatIsPaused</a> to change the value of the field. |
+  | can_bot_reply | bool | True, if the bot can reply. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_bot_manage_bar.html).
+  """
+
+  defstruct "@type": "businessBotManageBar", "@extra": nil, bot_user_id: nil, manage_url: nil, is_bot_paused: nil, can_bot_reply: nil
 end
 defmodule UpdateNewInlineQuery do
   @moduledoc  """
@@ -9713,6 +14428,20 @@ defmodule UpdateNewInlineQuery do
 
   defstruct "@type": "updateNewInlineQuery", "@extra": nil, id: nil, sender_user_id: nil, user_location: nil, chat_type: nil, query: nil, offset: nil
 end
+defmodule FactCheck do
+  @moduledoc  """
+  Describes a fact-check added to the message by an independent checker.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | formattedText | Text of the fact-check. |
+  | country_code | string | A two-letter ISO 3166-1 alpha-2 country code of the country for which the fact-check is shown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1fact_check.html).
+  """
+
+  defstruct "@type": "factCheck", "@extra": nil, text: nil, country_code: nil
+end
 defmodule DeviceTokenUbuntuPush do
   @moduledoc  """
   A token for Ubuntu Push Client service.
@@ -9728,13 +14457,30 @@ defmodule DeviceTokenUbuntuPush do
 end
 defmodule UserPrivacySettingRuleAllowContacts do
   @moduledoc  """
-  A rule to allow all of a user's contacts to do something.
+  A rule to allow all contacts of the user to do something.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_rule_allow_contacts.html).
   """
 
   defstruct "@type": "userPrivacySettingRuleAllowContacts", "@extra": nil
+end
+defmodule StarPaymentOption do
+  @moduledoc  """
+  Describes an option for buying Telegram stars.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | currency | string | ISO 4217 currency code for the payment. |
+  | amount | int53 | The amount to pay, in the smallest units of the currency. |
+  | star_count | int53 | Number of Telegram stars that will be purchased. |
+  | store_product_id | string | Identifier of the store product associated with the option; may be empty if none. |
+  | is_additional | bool | True, if the option must be shown only in the full list of payment options. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_payment_option.html).
+  """
+
+  defstruct "@type": "starPaymentOption", "@extra": nil, currency: nil, amount: nil, star_count: nil, store_product_id: nil, is_additional: nil
 end
 defmodule LanguagePackString do
   @moduledoc  """
@@ -9763,22 +14509,72 @@ defmodule MessageVenue do
 
   defstruct "@type": "messageVenue", "@extra": nil, venue: nil
 end
-defmodule InternalLinkTypePassportDataRequest do
+defmodule BusinessAwayMessageScheduleCustom do
   @moduledoc  """
-  The link contains a request of Telegram passport data. Call getPassportAuthorizationForm with the given parameters to process the link if the link was received from outside of the application, otherwise ignore it.
+  Send away messages only in the specified time span.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | bot_user_id | int53 | User identifier of the service's bot. |
+  | start_date | int32 | Point in time (Unix timestamp) when the away messages will start to be sent. |
+  | end_date | int32 | Point in time (Unix timestamp) when the away messages will stop to be sent. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_away_message_schedule_custom.html).
+  """
+
+  defstruct "@type": "businessAwayMessageScheduleCustom", "@extra": nil, start_date: nil, end_date: nil
+end
+defmodule EmojiCategoryType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_emoji_category_type.html).
+  """
+
+  defstruct "@type": "EmojiCategoryType", "@extra": nil
+end
+defmodule InternalLinkTypePassportDataRequest do
+  @moduledoc  """
+  The link contains a request of Telegram passport data. Call getPassportAuthorizationForm with the given parameters to process the link if the link was received from outside of the application; otherwise, ignore it.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | bot_user_id | int53 | User identifier of the service's bot; the corresponding user may be unknown yet. |
   | scope | string | Telegram Passport element types requested by the service. |
   | public_key | string | Service's public key. |
   | nonce | string | Unique request identifier provided by the service. |
-  | callback_url | string | An HTTP URL to open once the request is finished or canceled with the parameter tg_passport=success or tg_passport=cancel respectively. If empty, then the link tgbot{bot_user_id}://passport/success or tgbot{bot_user_id}://passport/cancel needs to be opened instead. |
+  | callback_url | string | An HTTP URL to open once the request is finished, canceled, or failed with the parameters tg_passport=success, tg_passport=cancel, or tg_passport=error&error=... respectively. If empty, then onActivityResult method must be used to return response on Android, or the link tgbot{bot_user_id}://passport/success or tgbot{bot_user_id}://passport/cancel must be opened otherwise. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_passport_data_request.html).
   """
 
   defstruct "@type": "internalLinkTypePassportDataRequest", "@extra": nil, bot_user_id: nil, scope: nil, public_key: nil, nonce: nil, callback_url: nil
+end
+defmodule StoryAreaPosition do
+  @moduledoc  """
+  Describes position of a clickable rectangle area on a story media.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | x_percentage | double | The abscissa of the rectangle's center, as a percentage of the media width. |
+  | y_percentage | double | The ordinate of the rectangle's center, as a percentage of the media height. |
+  | width_percentage | double | The width of the rectangle, as a percentage of the media width. |
+  | height_percentage | double | The height of the rectangle, as a percentage of the media height. |
+  | rotation_angle | double | Clockwise rotation angle of the rectangle, in degrees; 0-360. |
+  | corner_radius_percentage | double | The radius of the rectangle corner rounding, as a percentage of the media width. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_position.html).
+  """
+
+  defstruct "@type": "storyAreaPosition", "@extra": nil, x_percentage: nil, y_percentage: nil, width_percentage: nil, height_percentage: nil, rotation_angle: nil, corner_radius_percentage: nil
+end
+defmodule StarTransactionPartner do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_star_transaction_partner.html).
+  """
+
+  defstruct "@type": "StarTransactionPartner", "@extra": nil
 end
 defmodule PushMessageContentMediaAlbum do
   @moduledoc  """
@@ -9788,7 +14584,7 @@ defmodule PushMessageContentMediaAlbum do
   |------|------| ------------|
   | total_count | int32 | Number of messages in the album. |
   | has_photos | bool | True, if the album has at least one photo. |
-  | has_videos | bool | True, if the album has at least one video. |
+  | has_videos | bool | True, if the album has at least one video file. |
   | has_audios | bool | True, if the album has at least one audio file. |
   | has_documents | bool | True, if the album has at least one document. |
 
@@ -9814,7 +14610,7 @@ defmodule InputMessageForwarded do
   | Name | Type | Description |
   |------|------| ------------|
   | from_chat_id | int53 | Identifier for the chat this forwarded message came from. |
-  | message_id | int53 | Identifier of the message to forward. |
+  | message_id | int53 | Identifier of the message to forward. A message can be forwarded only if message.can_be_forwarded. |
   | in_game_share | bool | True, if a game message is being shared from a launched game; applies only to game messages. |
   | copy_options | messageCopyOptions | Options to be used to copy content of the message without reference to the original sender; pass null to forward the message as usual. |
 
@@ -9864,9 +14660,18 @@ defmodule Point do
 
   defstruct "@type": "point", "@extra": nil, x: nil, y: nil
 end
+defmodule ReportChatSponsoredMessageResult do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_report_chat_sponsored_message_result.html).
+  """
+
+  defstruct "@type": "ReportChatSponsoredMessageResult", "@extra": nil
+end
 defmodule InputFileId do
   @moduledoc  """
-  A file defined by its unique ID.
+  A file defined by its unique identifier.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -9913,6 +14718,15 @@ defmodule TargetChat do
 
   defstruct "@type": "TargetChat", "@extra": nil
 end
+defmodule InputMessageReplyTo do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_input_message_reply_to.html).
+  """
+
+  defstruct "@type": "InputMessageReplyTo", "@extra": nil
+end
 defmodule MessageSenders do
   @moduledoc  """
   Represents a list of message senders.
@@ -9926,6 +14740,26 @@ defmodule MessageSenders do
   """
 
   defstruct "@type": "messageSenders", "@extra": nil, total_count: nil, senders: nil
+end
+defmodule CanSendStoryResultPremiumNeeded do
+  @moduledoc  """
+  The user must subscribe to Telegram Premium to be able to post stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_story_result_premium_needed.html).
+  """
+
+  defstruct "@type": "canSendStoryResultPremiumNeeded", "@extra": nil
+end
+defmodule UserPrivacySettingShowBio do
+  @moduledoc  """
+  A privacy setting for managing whether the user's bio is visible.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_show_bio.html).
+  """
+
+  defstruct "@type": "userPrivacySettingShowBio", "@extra": nil
 end
 defmodule UserPrivacySettingRuleAllowChatMembers do
   @moduledoc  """
@@ -9949,6 +14783,32 @@ defmodule SearchMessagesFilterVoiceNote do
   """
 
   defstruct "@type": "searchMessagesFilterVoiceNote", "@extra": nil
+end
+defmodule UnconfirmedSession do
+  @moduledoc  """
+  Contains information about an unconfirmed session.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int64 | Session identifier. |
+  | log_in_date | int32 | Point in time (Unix timestamp) when the user has logged in. |
+  | device_model | string | Model of the device that was used for the session creation, as provided by the application. |
+  | location | string | A human-readable description of the location from which the session was created, based on the IP address. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1unconfirmed_session.html).
+  """
+
+  defstruct "@type": "unconfirmedSession", "@extra": nil, id: nil, log_in_date: nil, device_model: nil, location: nil
+end
+defmodule ReactionNotificationSourceNone do
+  @moduledoc  """
+  Notifications for reactions are disabled.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_notification_source_none.html).
+  """
+
+  defstruct "@type": "reactionNotificationSourceNone", "@extra": nil
 end
 defmodule PremiumSourceFeature do
   @moduledoc  """
@@ -9978,24 +14838,23 @@ defmodule Countries do
 end
 defmodule MessageInvoice do
   @moduledoc  """
-  A message with an invoice from a bot.
+  A message with an invoice from a bot. Use getInternalLink with internalLinkTypeBotStart to share the invoice.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | title | string | Product title. |
-  | description | formattedText | Product description. |
-  | photo | photo | Product photo; may be null. |
+  | product_info | productInfo | Information about the product. |
   | currency | string | Currency for the product price. |
   | total_amount | int53 | Product total price in the smallest units of the currency. |
-  | start_parameter | string | Unique invoice bot start_parameter. To share an invoice use the URL <a href="https://t.me/{bot_username}?start={start_parameter}">https://t.me/{bot_username}?start={start_parameter}</a>. |
+  | start_parameter | string | Unique invoice bot start_parameter to be passed to <a class="el" href="classtd_1_1td__api_1_1get_internal_link.html">getInternalLink</a>. |
   | is_test | bool | True, if the invoice is a test invoice. |
   | need_shipping_address | bool | True, if the shipping address must be specified. |
   | receipt_message_id | int53 | The identifier of the message with the receipt, after the product has been purchased. |
+  | extended_media | MessageExtendedMedia | Extended media attached to the invoice; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_invoice.html).
   """
 
-  defstruct "@type": "messageInvoice", "@extra": nil, title: nil, description: nil, photo: nil, currency: nil, total_amount: nil, start_parameter: nil, is_test: nil, need_shipping_address: nil, receipt_message_id: nil
+  defstruct "@type": "messageInvoice", "@extra": nil, product_info: nil, currency: nil, total_amount: nil, start_parameter: nil, is_test: nil, need_shipping_address: nil, receipt_message_id: nil, extended_media: nil
 end
 defmodule JsonValueObject do
   @moduledoc  """
@@ -10010,15 +14869,28 @@ defmodule JsonValueObject do
 
   defstruct "@type": "jsonValueObject", "@extra": nil, members: nil
 end
+defmodule PremiumLimitTypeMonthlySentStoryCount do
+  @moduledoc  """
+  The maximum number of stories sent per month.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_monthly_sent_story_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeMonthlySentStoryCount", "@extra": nil
+end
 defmodule UserStatusLastWeek do
   @moduledoc  """
   The user is offline, but was online last week.
 
+  | Name | Type | Description |
+  |------|------| ------------|
+  | by_my_privacy_settings | bool | Exact user's status is hidden because the current user enabled <a class="el" href="classtd_1_1td__api_1_1user_privacy_setting_show_status.html">userPrivacySettingShowStatus</a> privacy setting for the user and has no Telegram Premium. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_status_last_week.html).
   """
 
-  defstruct "@type": "userStatusLastWeek", "@extra": nil
+  defstruct "@type": "userStatusLastWeek", "@extra": nil, by_my_privacy_settings: nil
 end
 defmodule KeyboardButtonTypeRequestPhoneNumber do
   @moduledoc  """
@@ -10069,6 +14941,15 @@ defmodule PushMessageContentLocation do
 
   defstruct "@type": "pushMessageContentLocation", "@extra": nil, is_live: nil, is_pinned: nil
 end
+defmodule StarTransactionDirection do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_star_transaction_direction.html).
+  """
+
+  defstruct "@type": "StarTransactionDirection", "@extra": nil
+end
 defmodule ChatEventInviteLinkDeleted do
   @moduledoc  """
   A revoked chat invite link was deleted.
@@ -10081,6 +14962,20 @@ defmodule ChatEventInviteLinkDeleted do
   """
 
   defstruct "@type": "chatEventInviteLinkDeleted", "@extra": nil, invite_link: nil
+end
+defmodule ReportChatSponsoredMessageResultOptionRequired do
+  @moduledoc  """
+  The user must choose an option to report the message and repeat request with the chosen option.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | title | string | Title for the option choice. |
+  | options | reportChatSponsoredMessageOption | List of available options. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_result_option_required.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageResultOptionRequired", "@extra": nil, title: nil, options: nil
 end
 defmodule ChatEvent do
   @moduledoc  """
@@ -10111,6 +15006,19 @@ defmodule ChatEventVideoChatCreated do
 
   defstruct "@type": "chatEventVideoChatCreated", "@extra": nil, group_call_id: nil
 end
+defmodule ChatListFolder do
+  @moduledoc  """
+  A list of chats added to a chat folder.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_id | int32 | Chat folder identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_list_folder.html).
+  """
+
+  defstruct "@type": "chatListFolder", "@extra": nil, chat_folder_id: nil
+end
 defmodule GroupCall do
   @moduledoc  """
   Describes a group call.
@@ -10120,7 +15028,7 @@ defmodule GroupCall do
   | id | int32 | Group call identifier. |
   | title | string | Group call title. |
   | scheduled_start_date | int32 | Point in time (Unix timestamp) when the group call is supposed to be started by an administrator; 0 if it is already active or was ended. |
-  | enabled_start_notification | bool | True, if the group call is scheduled and the current user will receive a notification when the group call will start. |
+  | enabled_start_notification | bool | True, if the group call is scheduled and the current user will receive a notification when the group call starts. |
   | is_active | bool | True, if the call is active. |
   | is_rtmp_stream | bool | True, if the chat is an RTMP stream instead of an ordinary video chat. |
   | is_joined | bool | True, if the call is joined. |
@@ -10157,9 +15065,44 @@ defmodule ChatEventHasProtectedContentToggled do
 
   defstruct "@type": "chatEventHasProtectedContentToggled", "@extra": nil, has_protected_content: nil
 end
+defmodule MessagePremiumGiftCode do
+  @moduledoc  """
+  A Telegram Premium gift code was created for the user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | creator_id | MessageSender | Identifier of a chat or a user that created the gift code; may be null if unknown. |
+  | is_from_giveaway | bool | True, if the gift code was created for a giveaway. |
+  | is_unclaimed | bool | True, if the winner for the corresponding Telegram Premium subscription wasn't chosen. |
+  | currency | string | Currency for the paid amount; empty if unknown. |
+  | amount | int53 | The paid amount, in the smallest units of the currency; 0 if unknown. |
+  | cryptocurrency | string | Cryptocurrency used to pay for the gift; may be empty if none or unknown. |
+  | cryptocurrency_amount | int64 | The paid amount, in the smallest units of the cryptocurrency; 0 if unknown. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active after code activation. |
+  | sticker | sticker | A sticker to be shown in the message; may be null if unknown. |
+  | code | string | The gift code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_premium_gift_code.html).
+  """
+
+  defstruct "@type": "messagePremiumGiftCode", "@extra": nil, creator_id: nil, is_from_giveaway: nil, is_unclaimed: nil, currency: nil, amount: nil, cryptocurrency: nil, cryptocurrency_amount: nil, month_count: nil, sticker: nil, code: nil
+end
+defmodule QuickReplyMessages do
+  @moduledoc  """
+  Contains a list of quick reply messages.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | messages | quickReplyMessage | List of quick reply messages; messages may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1quick_reply_messages.html).
+  """
+
+  defstruct "@type": "quickReplyMessages", "@extra": nil, messages: nil
+end
 defmodule InputFileRemote do
   @moduledoc  """
-  A file defined by its remote ID. The remote ID is guaranteed to be usable only if the corresponding file is still accessible to the user and known to TDLib. For example, if the file is from a message, then the message must be not deleted and accessible to the user. If the file database is disabled, then the corresponding object with the file must be preloaded by the application.
+  A file defined by its remote identifier. The remote identifier is guaranteed to be usable only if the corresponding file is still accessible to the user and known to TDLib. For example, if the file is from a message, then the message must be not deleted and accessible to the user. If the file database is disabled, then the corresponding object with the file must be preloaded by the application.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -10172,7 +15115,7 @@ defmodule InputFileRemote do
 end
 defmodule InternalLinkTypeLanguageSettings do
   @moduledoc  """
-  The link is a link to the language settings section of the app.
+  The link is a link to the language section of the app settings.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_language_settings.html).
@@ -10297,7 +15240,7 @@ defmodule PremiumLimit do
 end
 defmodule InternalLinkTypeLanguagePack do
   @moduledoc  """
-  The link is a link to a language pack. Call getLanguagePackInfo with the given language pack identifier to process the link.
+  The link is a link to a language pack. Call getLanguagePackInfo with the given language pack identifier to process the link. If the language pack is found and the user wants to apply it, then call setOption for the option "language_pack_id".
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -10308,6 +15251,16 @@ defmodule InternalLinkTypeLanguagePack do
 
   defstruct "@type": "internalLinkTypeLanguagePack", "@extra": nil, language_pack_id: nil
 end
+defmodule MessagePremiumGiveawayCreated do
+  @moduledoc  """
+  A Telegram Premium giveaway was created for the chat.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_premium_giveaway_created.html).
+  """
+
+  defstruct "@type": "messagePremiumGiveawayCreated", "@extra": nil
+end
 defmodule InlineQueryResults do
   @moduledoc  """
   Represents the results of the inline query. Use sendInlineQueryResultMessage to send the result of the query.
@@ -10315,15 +15268,14 @@ defmodule InlineQueryResults do
   | Name | Type | Description |
   |------|------| ------------|
   | inline_query_id | int64 | Unique identifier of the inline query. |
-  | next_offset | string | The offset for the next request. If empty, there are no more results. |
+  | button | inlineQueryResultsButton | Button to be shown above inline query results; may be null. |
   | results | InlineQueryResult | Results of the query. |
-  | switch_pm_text | string | If non-empty, this text must be shown on the button, which opens a private chat with the bot and sends the bot a start message with the switch_pm_parameter. |
-  | switch_pm_parameter | string | Parameter for the bot start message. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1inline_query_results.html).
   """
 
-  defstruct "@type": "inlineQueryResults", "@extra": nil, inline_query_id: nil, next_offset: nil, results: nil, switch_pm_text: nil, switch_pm_parameter: nil
+  defstruct "@type": "inlineQueryResults", "@extra": nil, inline_query_id: nil, button: nil, results: nil, next_offset: nil
 end
 defmodule PremiumFeatureIncreasedLimits do
   @moduledoc  """
@@ -10334,6 +15286,16 @@ defmodule PremiumFeatureIncreasedLimits do
   """
 
   defstruct "@type": "premiumFeatureIncreasedLimits", "@extra": nil
+end
+defmodule InternalLinkTypeEditProfileSettings do
+  @moduledoc  """
+  The link is a link to the edit profile section of the app settings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_edit_profile_settings.html).
+  """
+
+  defstruct "@type": "internalLinkTypeEditProfileSettings", "@extra": nil
 end
 defmodule PageBlockEmbeddedPost do
   @moduledoc  """
@@ -10379,6 +15341,32 @@ defmodule PassportElementIdentityCard do
 
   defstruct "@type": "passportElementIdentityCard", "@extra": nil, identity_card: nil
 end
+defmodule ReportReasonSpam do
+  @moduledoc  """
+  The chat contains spam messages.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_spam.html).
+  """
+
+  defstruct "@type": "reportReasonSpam", "@extra": nil
+end
+defmodule QuickReplyShortcut do
+  @moduledoc  """
+  Describes a shortcut that can be used for a quick reply.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Unique shortcut identifier. |
+  | name | string | The name of the shortcut that can be used to use the shortcut. |
+  | first_message | quickReplyMessage | The first shortcut message. |
+  | message_count | int32 | The total number of messages in the shortcut. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1quick_reply_shortcut.html).
+  """
+
+  defstruct "@type": "quickReplyShortcut", "@extra": nil, id: nil, name: nil, first_message: nil, message_count: nil
+end
 defmodule InputPassportElementPassportRegistration do
   @moduledoc  """
   A Telegram Passport element to be saved containing the user's passport registration.
@@ -10391,6 +15379,27 @@ defmodule InputPassportElementPassportRegistration do
   """
 
   defstruct "@type": "inputPassportElementPassportRegistration", "@extra": nil, passport_registration: nil
+end
+defmodule KeyboardButtonTypeRequestUsers do
+  @moduledoc  """
+  A button that requests users to be shared by the current user; available only in private chats. Use the method shareUsersWithBot to complete the request.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Unique button identifier. |
+  | restrict_user_is_bot | bool | True, if the shared users must or must not be bots. |
+  | user_is_bot | bool | True, if the shared users must be bots; otherwise, the shared users must not be bots. Ignored if restrict_user_is_bot is false. |
+  | restrict_user_is_premium | bool | True, if the shared users must or must not be Telegram Premium users. |
+  | user_is_premium | bool | True, if the shared users must be Telegram Premium users; otherwise, the shared users must not be Telegram Premium users. Ignored if restrict_user_is_premium is false. |
+  | max_quantity | int32 | The maximum number of users to share. |
+  | request_name | bool | Pass true to request name of the users; bots only. |
+  | request_username | bool | Pass true to request username of the users; bots only. |
+  | request_photo | bool | Pass true to request photo of the users; bots only. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1keyboard_button_type_request_users.html).
+  """
+
+  defstruct "@type": "keyboardButtonTypeRequestUsers", "@extra": nil, id: nil, restrict_user_is_bot: nil, user_is_bot: nil, restrict_user_is_premium: nil, user_is_premium: nil, max_quantity: nil, request_name: nil, request_username: nil, request_photo: nil
 end
 defmodule SessionType do
   @moduledoc  """
@@ -10417,7 +15426,7 @@ defmodule SuggestedActionSetPassword do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | authorization_delay | int32 | The number of days to pass between consecutive authorizations if the user declines to set password. |
+  | authorization_delay | int32 | The number of days to pass between consecutive authorizations if the user declines to set password; if 0, then the user is advised to set the password for security reasons. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_set_password.html).
   """
@@ -10442,6 +15451,22 @@ defmodule MessageSender do
   """
 
   defstruct "@type": "MessageSender", "@extra": nil
+end
+defmodule EmojiCategory do
+  @moduledoc  """
+  Describes an emoji category.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | name | string | Name of the category. |
+  | icon | sticker | Custom emoji sticker, which represents icon of the category. |
+  | source | EmojiCategorySource | Source of stickers for the emoji category. |
+  | is_greeting | bool | True, if the category must be shown first when choosing a sticker for the start page. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category.html).
+  """
+
+  defstruct "@type": "emojiCategory", "@extra": nil, name: nil, icon: nil, source: nil, is_greeting: nil
 end
 defmodule InputPassportElementError do
   @moduledoc  """
@@ -10485,6 +15510,20 @@ defmodule InputMessageSticker do
 
   defstruct "@type": "inputMessageSticker", "@extra": nil, sticker: nil, thumbnail: nil, width: nil, height: nil, emoji: nil
 end
+defmodule InputMessageStory do
+  @moduledoc  """
+  A message with a forwarded story. Stories can't be sent to secret chats. A story can be forwarded only if story.can_be_forwarded.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Story identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_story.html).
+  """
+
+  defstruct "@type": "inputMessageStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil
+end
 defmodule InputMessageContact do
   @moduledoc  """
   A message containing a user contact.
@@ -10500,17 +15539,17 @@ defmodule InputMessageContact do
 end
 defmodule LoginUrlInfoOpen do
   @moduledoc  """
-  An HTTP url needs to be open.
+  An HTTP URL needs to be open.
 
   | Name | Type | Description |
   |------|------| ------------|
   | url | string | The URL to open. |
-  | skip_confirm | bool | True, if there is no need to show an ordinary open URL confirm. |
+  | skip_confirmation | bool | True, if there is no need to show an ordinary open URL confirmation. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1login_url_info_open.html).
   """
 
-  defstruct "@type": "loginUrlInfoOpen", "@extra": nil, url: nil, skip_confirm: nil
+  defstruct "@type": "loginUrlInfoOpen", "@extra": nil, url: nil, skip_confirmation: nil
 end
 defmodule JsonValueArray do
   @moduledoc  """
@@ -10561,6 +15600,20 @@ defmodule Count do
 
   defstruct "@type": "count", "@extra": nil, count: nil
 end
+defmodule UpdateChatBackground do
+  @moduledoc  """
+  The chat background was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | background | chatBackground | The new chat background; may be null if background was reset to default. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_background.html).
+  """
+
+  defstruct "@type": "updateChatBackground", "@extra": nil, chat_id: nil, background: nil
+end
 defmodule VectorPathCommandLine do
   @moduledoc  """
   A straight line to a given point.
@@ -10580,14 +15633,16 @@ defmodule MessagePhoto do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | photo | photo | The photo description. |
+  | photo | photo | The photo. |
   | caption | formattedText | Photo caption. |
+  | show_caption_above_media | bool | True, if caption must be shown above the photo; otherwise, caption must be shown below the photo. |
+  | has_spoiler | bool | True, if the photo preview must be covered by a spoiler animation. |
   | is_secret | bool | True, if the photo must be blurred and must be shown only while tapped. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_photo.html).
   """
 
-  defstruct "@type": "messagePhoto", "@extra": nil, photo: nil, caption: nil, is_secret: nil
+  defstruct "@type": "messagePhoto", "@extra": nil, photo: nil, caption: nil, show_caption_above_media: nil, has_spoiler: nil, is_secret: nil
 end
 defmodule PageBlockVerticalAlignmentMiddle do
   @moduledoc  """
@@ -10598,16 +15653,6 @@ defmodule PageBlockVerticalAlignmentMiddle do
   """
 
   defstruct "@type": "pageBlockVerticalAlignmentMiddle", "@extra": nil
-end
-defmodule CheckChatUsernameResultPublicChatsTooMuch do
-  @moduledoc  """
-  The user has too many chats with username, one of them must be made private first.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1check_chat_username_result_public_chats_too_much.html).
-  """
-
-  defstruct "@type": "checkChatUsernameResultPublicChatsTooMuch", "@extra": nil
 end
 defmodule PassportElementAddress do
   @moduledoc  """
@@ -10624,7 +15669,7 @@ defmodule PassportElementAddress do
 end
 defmodule ImportedContacts do
   @moduledoc  """
-  Represents the result of an ImportContacts request.
+  Represents the result of an importContacts request.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -10698,6 +15743,25 @@ defmodule NotificationType do
 
   defstruct "@type": "NotificationType", "@extra": nil
 end
+defmodule StickerFormat do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_sticker_format.html).
+  """
+
+  defstruct "@type": "StickerFormat", "@extra": nil
+end
+defmodule BusinessFeatureUpgradedStories do
+  @moduledoc  """
+  Allowed to use many additional features for stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_upgraded_stories.html).
+  """
+
+  defstruct "@type": "businessFeatureUpgradedStories", "@extra": nil
+end
 defmodule StatisticalGraphError do
   @moduledoc  """
   An error message to be shown to the user instead of the graph.
@@ -10739,7 +15803,13 @@ defmodule ThemeParameters do
   |------|------| ------------|
   | background_color | int32 | A color of the background in the RGB24 format. |
   | secondary_background_color | int32 | A secondary color for the background in the RGB24 format. |
+  | header_background_color | int32 | A color of the header background in the RGB24 format. |
+  | section_background_color | int32 | A color of the section background in the RGB24 format. |
   | text_color | int32 | A color of text in the RGB24 format. |
+  | accent_text_color | int32 | An accent color of the text in the RGB24 format. |
+  | section_header_text_color | int32 | A color of text on the section headers in the RGB24 format. |
+  | subtitle_text_color | int32 | A color of the subtitle text in the RGB24 format. |
+  | destructive_text_color | int32 | A color of the text for destructive actions in the RGB24 format. |
   | hint_color | int32 | A color of hints in the RGB24 format. |
   | link_color | int32 | A color of links in the RGB24 format. |
   | button_color | int32 | A color of the buttons in the RGB24 format. |
@@ -10748,7 +15818,7 @@ defmodule ThemeParameters do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1theme_parameters.html).
   """
 
-  defstruct "@type": "themeParameters", "@extra": nil, background_color: nil, secondary_background_color: nil, text_color: nil, hint_color: nil, link_color: nil, button_color: nil, button_text_color: nil
+  defstruct "@type": "themeParameters", "@extra": nil, background_color: nil, secondary_background_color: nil, header_background_color: nil, section_background_color: nil, text_color: nil, accent_text_color: nil, section_header_text_color: nil, subtitle_text_color: nil, destructive_text_color: nil, hint_color: nil, link_color: nil, button_color: nil, button_text_color: nil
 end
 defmodule UpdateConnectionState do
   @moduledoc  """
@@ -10781,14 +15851,11 @@ defmodule StickerTypeMask do
   @moduledoc  """
   The sticker is a mask in WEBP format to be placed on photos or videos.
 
-  | Name | Type | Description |
-  |------|------| ------------|
-  | mask_position | maskPosition | Position where the mask is placed; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_mask.html).
   """
 
-  defstruct "@type": "stickerTypeMask", "@extra": nil, mask_position: nil
+  defstruct "@type": "stickerTypeMask", "@extra": nil
 end
 defmodule BackgroundFillFreeformGradient do
   @moduledoc  """
@@ -10796,7 +15863,7 @@ defmodule BackgroundFillFreeformGradient do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | colors | int32 | A list of 3 or 4 colors of the freeform gradients in the RGB24 format. |
+  | colors | int32 | A list of 3 or 4 colors of the freeform gradient in the RGB24 format. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1background_fill_freeform_gradient.html).
   """
@@ -10805,7 +15872,7 @@ defmodule BackgroundFillFreeformGradient do
 end
 defmodule ThumbnailFormatWebp do
   @moduledoc  """
-  The thumbnail is in WEBP format. It will be used only for some stickers.
+  The thumbnail is in WEBP format. It will be used only for some stickers and sticker sets.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1thumbnail_format_webp.html).
@@ -10841,6 +15908,21 @@ defmodule InputInvoiceMessage do
 
   defstruct "@type": "inputInvoiceMessage", "@extra": nil, chat_id: nil, message_id: nil
 end
+defmodule FoundWebApp do
+  @moduledoc  """
+  Contains information about a Web App found by its short name.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | web_app | webApp | The Web App. |
+  | request_write_access | bool | True, if the user must be asked for the permission to the bot to send them messages. |
+  | skip_confirmation | bool | True, if there is no need to show an ordinary open URL confirmation before opening the Web App. The field must be ignored and confirmation must be shown anyway if the Web App link was hidden. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_web_app.html).
+  """
+
+  defstruct "@type": "foundWebApp", "@extra": nil, web_app: nil, request_write_access: nil, skip_confirmation: nil
+end
 defmodule ChatInviteLink do
   @moduledoc  """
   Contains a chat invite link.
@@ -10864,6 +15946,20 @@ defmodule ChatInviteLink do
   """
 
   defstruct "@type": "chatInviteLink", "@extra": nil, invite_link: nil, name: nil, creator_user_id: nil, date: nil, edit_date: nil, expiration_date: nil, member_limit: nil, member_count: nil, pending_join_request_count: nil, creates_join_request: nil, is_primary: nil, is_revoked: nil
+end
+defmodule ForumTopicIcon do
+  @moduledoc  """
+  Describes a forum topic icon.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | color | int32 | Color of the topic icon in RGB format. |
+  | custom_emoji_id | int64 | Unique identifier of the custom emoji shown on the topic icon; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forum_topic_icon.html).
+  """
+
+  defstruct "@type": "forumTopicIcon", "@extra": nil, color: nil, custom_emoji_id: nil
 end
 defmodule OptionValueBoolean do
   @moduledoc  """
@@ -10936,17 +16032,19 @@ defmodule UserTypeBot do
 
   | Name | Type | Description |
   |------|------| ------------|
+  | can_be_edited | bool | True, if the bot is owned by the current user and can be edited using the methods <a class="el" href="classtd_1_1td__api_1_1toggle_bot_username_is_active.html">toggleBotUsernameIsActive</a>, <a class="el" href="classtd_1_1td__api_1_1reorder_bot_active_usernames.html">reorderBotActiveUsernames</a>, <a class="el" href="classtd_1_1td__api_1_1set_bot_profile_photo.html">setBotProfilePhoto</a>, <a class="el" href="classtd_1_1td__api_1_1set_bot_name.html">setBotName</a>, <a class="el" href="classtd_1_1td__api_1_1set_bot_info_description.html">setBotInfoDescription</a>, and <a class="el" href="classtd_1_1td__api_1_1set_bot_info_short_description.html">setBotInfoShortDescription</a>. |
   | can_join_groups | bool | True, if the bot can be invited to basic group and supergroup chats. |
   | can_read_all_group_messages | bool | True, if the bot can read all messages in basic group or supergroup chats and not just those addressed to the bot. In private and channel chats a bot can always read all messages. |
   | is_inline | bool | True, if the bot supports inline queries. |
   | inline_query_placeholder | string | Placeholder for inline queries (displayed on the application input field). |
   | need_location | bool | True, if the location of the user is expected to be sent with every inline query to this bot. |
-  | can_be_added_to_attachment_menu | bool | True, if the bot can be added to attachment menu. |
+  | can_connect_to_business | bool | True, if the bot supports connection to Telegram Business accounts. |
+  | can_be_added_to_attachment_menu | bool | True, if the bot can be added to attachment or side menu. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_type_bot.html).
   """
 
-  defstruct "@type": "userTypeBot", "@extra": nil, can_join_groups: nil, can_read_all_group_messages: nil, is_inline: nil, inline_query_placeholder: nil, need_location: nil, can_be_added_to_attachment_menu: nil
+  defstruct "@type": "userTypeBot", "@extra": nil, can_be_edited: nil, can_join_groups: nil, can_read_all_group_messages: nil, is_inline: nil, inline_query_placeholder: nil, need_location: nil, can_connect_to_business: nil, can_be_added_to_attachment_menu: nil
 end
 defmodule UpdateDeleteMessages do
   @moduledoc  """
@@ -10963,6 +16061,21 @@ defmodule UpdateDeleteMessages do
   """
 
   defstruct "@type": "updateDeleteMessages", "@extra": nil, chat_id: nil, message_ids: nil, is_permanent: nil, from_cache: nil
+end
+defmodule UpdateMessageFactCheck do
+  @moduledoc  """
+  A fact-check added to a message was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_id | int53 | Message identifier. |
+  | fact_check | factCheck | The new fact-check. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_message_fact_check.html).
+  """
+
+  defstruct "@type": "updateMessageFactCheck", "@extra": nil, chat_id: nil, message_id: nil, fact_check: nil
 end
 defmodule ChatActionRecordingVideo do
   @moduledoc  """
@@ -11015,16 +16128,6 @@ defmodule PassportElements do
 
   defstruct "@type": "passportElements", "@extra": nil, elements: nil
 end
-defmodule ChatReportReasonPersonalDetails do
-  @moduledoc  """
-  The chat contains messages with personal details.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_report_reason_personal_details.html).
-  """
-
-  defstruct "@type": "chatReportReasonPersonalDetails", "@extra": nil
-end
 defmodule TMeUrlTypeSupergroup do
   @moduledoc  """
   A URL linking to a public supergroup or channel.
@@ -11054,7 +16157,7 @@ defmodule RemoteFile do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | id | string | Remote file identifier; may be empty. Can be used by the current user across application restarts or even from other devices. Uniquely identifies a file, but a file can have a lot of different valid identifiers. If the ID starts with "<a href="http://">http://</a>" or "<a href="https://">https://</a>", it represents the HTTP URL of the file. TDLib is currently unable to download files if only their URL is known. If downloadFile/addFileToDownloads is called on such a file or if it is sent to a secret chat, TDLib starts a file generation process by sending <a class="el" href="classtd_1_1td__api_1_1update_file_generation_start.html">updateFileGenerationStart</a> to the application with the HTTP URL in the original_path and "#url#" as the conversion string. Application must generate the file by downloading it to the specified location. |
+  | id | string | Remote file identifier; may be empty. Can be used by the current user across application restarts or even from other devices. Uniquely identifies a file, but a file can have a lot of different valid identifiers. If the identifier starts with "<a href="http://">http://</a>" or "<a href="https://">https://</a>", it represents the HTTP URL of the file. TDLib is currently unable to download files if only their URL is known. If downloadFile/addFileToDownloads is called on such a file or if it is sent to a secret chat, TDLib starts a file generation process by sending <a class="el" href="classtd_1_1td__api_1_1update_file_generation_start.html">updateFileGenerationStart</a> to the application with the HTTP URL in the original_path and "#url#" as the conversion string. Application must generate the file by downloading it to the specified location. |
   | unique_id | string | Unique file identifier; may be empty if unknown. The unique file identifier which is the same for the same file even for different users and is persistent over time. |
   | is_uploading_active | bool | True, if the file is currently being uploaded (or a remote copy is being generated by some other means). |
   | is_uploading_completed | bool | True, if a remote copy is fully available. |
@@ -11081,13 +16184,54 @@ defmodule UpdateInstalledStickerSets do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_masks | bool | True, if the list of installed mask sticker sets was updated. |
+  | sticker_type | StickerType | Type of the affected stickers. |
   | sticker_set_ids | int64 | The new list of installed ordinary sticker sets. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_installed_sticker_sets.html).
   """
 
-  defstruct "@type": "updateInstalledStickerSets", "@extra": nil, is_masks: nil, sticker_set_ids: nil
+  defstruct "@type": "updateInstalledStickerSets", "@extra": nil, sticker_type: nil, sticker_set_ids: nil
+end
+defmodule ChatMessageSenders do
+  @moduledoc  """
+  Represents a list of message senders, which can be used to send messages in a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | senders | chatMessageSender | List of available message senders. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_message_senders.html).
+  """
+
+  defstruct "@type": "chatMessageSenders", "@extra": nil, senders: nil
+end
+defmodule AuthorizationStateWaitEmailAddress do
+  @moduledoc  """
+  TDLib needs the user's email address to authorize. Call setAuthenticationEmailAddress to provide the email address, or directly call checkAuthenticationEmailCode with Apple ID/Google ID token if allowed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | allow_apple_id | bool | True, if authorization through Apple ID is allowed. |
+  | allow_google_id | bool | True, if authorization through Google ID is allowed. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_email_address.html).
+  """
+
+  defstruct "@type": "authorizationStateWaitEmailAddress", "@extra": nil, allow_apple_id: nil, allow_google_id: nil
+end
+defmodule ChatEventEmojiStatusChanged do
+  @moduledoc  """
+  The chat emoji status was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_emoji_status | emojiStatus | Previous emoji status; may be null if none. |
+  | new_emoji_status | emojiStatus | New emoji status; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_emoji_status_changed.html).
+  """
+
+  defstruct "@type": "chatEventEmojiStatusChanged", "@extra": nil, old_emoji_status: nil, new_emoji_status: nil
 end
 defmodule ChatEvents do
   @moduledoc  """
@@ -11124,6 +16268,20 @@ defmodule ChatStatistics do
 
   defstruct "@type": "ChatStatistics", "@extra": nil
 end
+defmodule ChatBoostLink do
+  @moduledoc  """
+  Contains an HTTPS link to boost a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | link | string | The link. |
+  | is_public | bool | True, if the link will work for non-members of the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_link.html).
+  """
+
+  defstruct "@type": "chatBoostLink", "@extra": nil, link: nil, is_public: nil
+end
 defmodule InputIdentityDocument do
   @moduledoc  """
   An identity document to be saved to Telegram Passport.
@@ -11131,7 +16289,7 @@ defmodule InputIdentityDocument do
   | Name | Type | Description |
   |------|------| ------------|
   | number | string | Document number; 1-24 characters. |
-  | expiry_date | date | Document expiry date; pass null if not applicable. |
+  | expiration_date | date | Document expiration date; pass null if not applicable. |
   | front_side | InputFile | Front side of the document. |
   | reverse_side | InputFile | Reverse side of the document; only for driver license and identity card; pass null otherwise. |
   | selfie | InputFile | Selfie with the document; pass null if unavailable. |
@@ -11140,7 +16298,7 @@ defmodule InputIdentityDocument do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_identity_document.html).
   """
 
-  defstruct "@type": "inputIdentityDocument", "@extra": nil, number: nil, expiry_date: nil, front_side: nil, reverse_side: nil, selfie: nil, translation: nil
+  defstruct "@type": "inputIdentityDocument", "@extra": nil, number: nil, expiration_date: nil, front_side: nil, reverse_side: nil, selfie: nil, translation: nil
 end
 defmodule UserPrivacySettingRuleRestrictAll do
   @moduledoc  """
@@ -11189,6 +16347,25 @@ defmodule LogStreamDefault do
 
   defstruct "@type": "logStreamDefault", "@extra": nil
 end
+defmodule MessageSource do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_source.html).
+  """
+
+  defstruct "@type": "MessageSource", "@extra": nil
+end
+defmodule BusinessFeatureAwayMessage do
+  @moduledoc  """
+  The ability to set up an away message.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_away_message.html).
+  """
+
+  defstruct "@type": "businessFeatureAwayMessage", "@extra": nil
+end
 defmodule JsonValueNumber do
   @moduledoc  """
   Represents a numeric JSON value.
@@ -11215,6 +16392,15 @@ defmodule ChatEventVideoChatParticipantIsMutedToggled do
   """
 
   defstruct "@type": "chatEventVideoChatParticipantIsMutedToggled", "@extra": nil, participant_id: nil, is_muted: nil
+end
+defmodule MessageReadDate do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_read_date.html).
+  """
+
+  defstruct "@type": "MessageReadDate", "@extra": nil
 end
 defmodule OptionValueEmpty do
   @moduledoc  """
@@ -11256,7 +16442,7 @@ defmodule NotificationSettingsScopeChannelChats do
 end
 defmodule ChatActionBarReportUnrelatedLocation do
   @moduledoc  """
-  The chat is a location-based supergroup, which can be reported as having unrelated location using the method reportChat with the reason chatReportReasonUnrelatedLocation.
+  The chat is a location-based supergroup, which can be reported as having unrelated location using the method reportChat with the reason reportReasonUnrelatedLocation.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_action_bar_report_unrelated_location.html).
@@ -11286,6 +16472,34 @@ defmodule ChatLists do
   """
 
   defstruct "@type": "chatLists", "@extra": nil, chat_lists: nil
+end
+defmodule InputTextQuote do
+  @moduledoc  """
+  Describes manually chosen quote from another message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | formattedText | Text of the quote; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_reply_quote_length_max") characters. Only Bold, Italic, Underline, Strikethrough, Spoiler, and CustomEmoji entities are allowed to be kept and must be kept in the quote. |
+  | position | int32 | Quote position in the original message in UTF-16 code units. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_text_quote.html).
+  """
+
+  defstruct "@type": "inputTextQuote", "@extra": nil, text: nil, position: nil
+end
+defmodule InputStoryAreaTypeLocation do
+  @moduledoc  """
+  An area pointing to a location.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | location | location | The location. |
+  | address | locationAddress | Address of the location; pass null if unknown. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_location.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypeLocation", "@extra": nil, location: nil, address: nil
 end
 defmodule DeviceTokenMicrosoftPush do
   @moduledoc  """
@@ -11328,6 +16542,19 @@ defmodule ChatMemberStatusBanned do
 
   defstruct "@type": "chatMemberStatusBanned", "@extra": nil, banned_until_date: nil
 end
+defmodule UpdateQuickReplyShortcut do
+  @moduledoc  """
+  Basic information about a quick reply shortcut has changed. This update is guaranteed to come before the quick shortcut name is returned to the application.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut | quickReplyShortcut | New data about the shortcut. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_quick_reply_shortcut.html).
+  """
+
+  defstruct "@type": "updateQuickReplyShortcut", "@extra": nil, shortcut: nil
+end
 defmodule BotCommandScope do
   @moduledoc  """
 
@@ -11336,6 +16563,16 @@ defmodule BotCommandScope do
   """
 
   defstruct "@type": "BotCommandScope", "@extra": nil
+end
+defmodule EmojiCategoryTypeEmojiStatus do
+  @moduledoc  """
+  The category must be used for emoji status selection.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_type_emoji_status.html).
+  """
+
+  defstruct "@type": "emojiCategoryTypeEmojiStatus", "@extra": nil
 end
 defmodule SessionTypeAndroid do
   @moduledoc  """
@@ -11346,6 +16583,15 @@ defmodule SessionTypeAndroid do
   """
 
   defstruct "@type": "sessionTypeAndroid", "@extra": nil
+end
+defmodule RevenueWithdrawalState do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_revenue_withdrawal_state.html).
+  """
+
+  defstruct "@type": "RevenueWithdrawalState", "@extra": nil
 end
 defmodule InlineQueryResultContact do
   @moduledoc  """
@@ -11361,6 +16607,22 @@ defmodule InlineQueryResultContact do
   """
 
   defstruct "@type": "inlineQueryResultContact", "@extra": nil, id: nil, contact: nil, thumbnail: nil
+end
+defmodule InputStoryContentVideo do
+  @moduledoc  """
+  A video story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | video | InputFile | Video to be sent. The video size must be 720x1280. The video must be streamable and stored in MPEG4 format, after encoding with x265 codec and key frames added each second. |
+  | added_sticker_file_ids | int32 | File identifiers of the stickers added to the video, if applicable. |
+  | duration | double | Precise duration of the video, in seconds; 0-60. |
+  | is_animation | bool | True, if the video has no sound. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_content_video.html).
+  """
+
+  defstruct "@type": "inputStoryContentVideo", "@extra": nil, video: nil, added_sticker_file_ids: nil, duration: nil, is_animation: nil
 end
 defmodule File do
   @moduledoc  """
@@ -11406,23 +16668,33 @@ defmodule UpdateUser do
 
   defstruct "@type": "updateUser", "@extra": nil, user: nil
 end
+defmodule StoryContentUnsupported do
+  @moduledoc  """
+  A story content that is not supported in the current TDLib version.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_content_unsupported.html).
+  """
+
+  defstruct "@type": "storyContentUnsupported", "@extra": nil
+end
 defmodule MessageLinkInfo do
   @moduledoc  """
-  Contains information about a link to a message in a chat.
+  Contains information about a link to a message or a forum topic in a chat.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | is_public | bool | True, if the link is a public link for a message in a chat. |
-  | chat_id | int53 | If found, identifier of the chat to which the message belongs, 0 otherwise. |
+  | is_public | bool | True, if the link is a public link for a message or a forum topic in a chat. |
+  | chat_id | int53 | If found, identifier of the chat to which the link points, 0 otherwise. |
+  | message_thread_id | int53 | If found, identifier of the message thread in which to open the message, or a forum topic to open if the message is missing. |
   | message | message | If found, the linked message; may be null. |
-  | media_timestamp | int32 | Timestamp from which the video/audio/video note/voice note playing must start, in seconds; 0 if not specified. The media can be in the message content or in its web page preview. |
+  | media_timestamp | int32 | Timestamp from which the video/audio/video note/voice note/story playing must start, in seconds; 0 if not specified. The media can be in the message content or in its web page preview. |
   | for_album | bool | True, if the whole media album to which the message belongs is linked. |
-  | for_comment | bool | True, if the message is linked as a channel post comment or from a message thread. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_link_info.html).
   """
 
-  defstruct "@type": "messageLinkInfo", "@extra": nil, is_public: nil, chat_id: nil, message: nil, media_timestamp: nil, for_album: nil, for_comment: nil
+  defstruct "@type": "messageLinkInfo", "@extra": nil, is_public: nil, chat_id: nil, message_thread_id: nil, message: nil, media_timestamp: nil, for_album: nil
 end
 defmodule SearchMessagesFilterChatPhoto do
   @moduledoc  """
@@ -11433,6 +16705,16 @@ defmodule SearchMessagesFilterChatPhoto do
   """
 
   defstruct "@type": "searchMessagesFilterChatPhoto", "@extra": nil
+end
+defmodule EmojiCategoryTypeDefault do
+  @moduledoc  """
+  The category must be used by default (e.g., for custom emoji or animation search).
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_type_default.html).
+  """
+
+  defstruct "@type": "emojiCategoryTypeDefault", "@extra": nil
 end
 defmodule InputInvoiceName do
   @moduledoc  """
@@ -11468,13 +16750,13 @@ defmodule AvailableReaction do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reaction | string | Text representation of the reaction. |
+  | type | ReactionType | Type of the reaction. |
   | needs_premium | bool | True, if Telegram Premium is needed to send the reaction. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1available_reaction.html).
   """
 
-  defstruct "@type": "availableReaction", "@extra": nil, reaction: nil, needs_premium: nil
+  defstruct "@type": "availableReaction", "@extra": nil, type: nil, needs_premium: nil
 end
 defmodule FileTypeWallpaper do
   @moduledoc  """
@@ -11485,6 +16767,20 @@ defmodule FileTypeWallpaper do
   """
 
   defstruct "@type": "fileTypeWallpaper", "@extra": nil
+end
+defmodule RecommendedChatFolder do
+  @moduledoc  """
+  Describes a recommended chat folder.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | folder | chatFolder | The chat folder. |
+  | description | string | Chat folder description. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recommended_chat_folder.html).
+  """
+
+  defstruct "@type": "recommendedChatFolder", "@extra": nil, folder: nil, description: nil
 end
 defmodule CallbackQueryAnswer do
   @moduledoc  """
@@ -11523,12 +16819,44 @@ defmodule LoginUrlInfoRequestConfirmation do
   | url | string | An HTTP URL to be opened. |
   | domain | string | A domain of the URL. |
   | bot_user_id | int53 | User identifier of a bot linked with the website. |
-  | request_write_access | bool | True, if the user needs to be requested to give the permission to the bot to send them messages. |
+  | request_write_access | bool | True, if the user must be asked for the permission to the bot to send them messages. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1login_url_info_request_confirmation.html).
   """
 
   defstruct "@type": "loginUrlInfoRequestConfirmation", "@extra": nil, url: nil, domain: nil, bot_user_id: nil, request_write_access: nil
+end
+defmodule BusinessOpeningHours do
+  @moduledoc  """
+  Describes opening hours of a business.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | time_zone_id | string | Unique time zone identifier. |
+  | opening_hours | businessOpeningHoursInterval | Intervals of the time when the business is open. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_opening_hours.html).
+  """
+
+  defstruct "@type": "businessOpeningHours", "@extra": nil, time_zone_id: nil, opening_hours: nil
+end
+defmodule MessageReplyToMessage do
+  @moduledoc  """
+  Describes a message replied by a given message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | The identifier of the chat to which the message belongs; may be 0 if the replied message is in unknown chat. |
+  | message_id | int53 | The identifier of the message; may be 0 if the replied message is in unknown chat. |
+  | quote | textQuote | Chosen quote from the replied message; may be null if none. |
+  | origin | MessageOrigin | Information about origin of the message if the message was from another chat or topic; may be null for messages from the same chat. |
+  | origin_send_date | int32 | Point in time (Unix timestamp) when the message was sent if the message was from another chat or topic; 0 for messages from the same chat. |
+  | content | MessageContent | Media content of the message if the message was from another chat or topic; may be null for messages from the same chat and messages without media. Can be only one of the following types: <a class="el" href="classtd_1_1td__api_1_1message_animation.html">messageAnimation</a>, <a class="el" href="classtd_1_1td__api_1_1message_audio.html">messageAudio</a>, <a class="el" href="classtd_1_1td__api_1_1message_contact.html">messageContact</a>, <a class="el" href="classtd_1_1td__api_1_1message_dice.html">messageDice</a>, <a class="el" href="classtd_1_1td__api_1_1message_document.html">messageDocument</a>, <a class="el" href="classtd_1_1td__api_1_1message_game.html">messageGame</a>, <a class="el" href="classtd_1_1td__api_1_1message_invoice.html">messageInvoice</a>, <a class="el" href="classtd_1_1td__api_1_1message_location.html">messageLocation</a>, <a class="el" href="classtd_1_1td__api_1_1message_photo.html">messagePhoto</a>, <a class="el" href="classtd_1_1td__api_1_1message_poll.html">messagePoll</a>, <a class="el" href="classtd_1_1td__api_1_1message_premium_giveaway.html">messagePremiumGiveaway</a>, <a class="el" href="classtd_1_1td__api_1_1message_premium_giveaway_winners.html">messagePremiumGiveawayWinners</a>, <a class="el" href="classtd_1_1td__api_1_1message_sticker.html">messageSticker</a>, <a class="el" href="classtd_1_1td__api_1_1message_story.html">messageStory</a>, <a class="el" href="classtd_1_1td__api_1_1message_text.html">messageText</a> (for link preview), <a class="el" href="classtd_1_1td__api_1_1message_venue.html">messageVenue</a>, <a class="el" href="classtd_1_1td__api_1_1message_video.html">messageVideo</a>, <a class="el" href="classtd_1_1td__api_1_1message_video_note.html">messageVideoNote</a>, or <a class="el" href="classtd_1_1td__api_1_1message_voice_note.html">messageVoiceNote</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_reply_to_message.html).
+  """
+
+  defstruct "@type": "messageReplyToMessage", "@extra": nil, chat_id: nil, message_id: nil, quote: nil, origin: nil, origin_send_date: nil, content: nil
 end
 defmodule ChatInviteLinks do
   @moduledoc  """
@@ -11584,7 +16912,7 @@ defmodule CallProblemInterruptions do
 end
 defmodule ThumbnailFormatWebm do
   @moduledoc  """
-  The thumbnail is in WEBM format. It will be used only for WEBM sticker sets.
+  The thumbnail is in WEBM format. It will be used only for sticker sets.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1thumbnail_format_webm.html).
@@ -11610,6 +16938,39 @@ defmodule ChatActionBar do
   """
 
   defstruct "@type": "ChatActionBar", "@extra": nil
+end
+defmodule BusinessFeatureQuickReplies do
+  @moduledoc  """
+  The ability to use quick replies.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_quick_replies.html).
+  """
+
+  defstruct "@type": "businessFeatureQuickReplies", "@extra": nil
+end
+defmodule PremiumFeatureForumTopicIcon do
+  @moduledoc  """
+  The ability to set a custom emoji as a forum topic icon.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_forum_topic_icon.html).
+  """
+
+  defstruct "@type": "premiumFeatureForumTopicIcon", "@extra": nil
+end
+defmodule UpdateChatActiveStories do
+  @moduledoc  """
+  The list of active stories posted by a specific chat has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | active_stories | chatActiveStories | The new list of active stories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_active_stories.html).
+  """
+
+  defstruct "@type": "updateChatActiveStories", "@extra": nil, active_stories: nil
 end
 defmodule ChatMembersFilterBots do
   @moduledoc  """
@@ -11644,6 +17005,20 @@ defmodule UserPrivacySettingShowLinkInForwardedMessages do
   """
 
   defstruct "@type": "userPrivacySettingShowLinkInForwardedMessages", "@extra": nil
+end
+defmodule UpdateStoryListChatCount do
+  @moduledoc  """
+  Number of chats in a story list has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_list | StoryList | The story list. |
+  | chat_count | int32 | Approximate total number of chats with active stories in the list. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story_list_chat_count.html).
+  """
+
+  defstruct "@type": "updateStoryListChatCount", "@extra": nil, story_list: nil, chat_count: nil
 end
 defmodule InternalLinkTypeVideoChat do
   @moduledoc  """
@@ -11680,15 +17055,17 @@ defmodule VideoNote do
   | Name | Type | Description |
   |------|------| ------------|
   | duration | int32 | Duration of the video, in seconds; as defined by the sender. |
+  | waveform | bytes | A waveform representation of the video note's audio in 5-bit format; may be empty if unknown. |
   | length | int32 | Video width and height; as defined by the sender. |
   | minithumbnail | minithumbnail | Video minithumbnail; may be null. |
   | thumbnail | thumbnail | Video thumbnail in JPEG format; as defined by the sender; may be null. |
+  | speech_recognition_result | SpeechRecognitionResult | Result of speech recognition in the video note; may be null. |
   | video | file | File containing the video. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1video_note.html).
   """
 
-  defstruct "@type": "videoNote", "@extra": nil, duration: nil, length: nil, minithumbnail: nil, thumbnail: nil, video: nil
+  defstruct "@type": "videoNote", "@extra": nil, duration: nil, waveform: nil, length: nil, minithumbnail: nil, thumbnail: nil, speech_recognition_result: nil, video: nil
 end
 defmodule PremiumFeatureAnimatedProfilePhoto do
   @moduledoc  """
@@ -11723,6 +17100,16 @@ defmodule UserPrivacySettingAllowCalls do
 
   defstruct "@type": "userPrivacySettingAllowCalls", "@extra": nil
 end
+defmodule CanSendMessageToUserResultUserRestrictsNewChats do
+  @moduledoc  """
+  The user can't be messaged, because they restrict new chats with non-contacts.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_message_to_user_result_user_restricts_new_chats.html).
+  """
+
+  defstruct "@type": "canSendMessageToUserResultUserRestrictsNewChats", "@extra": nil
+end
 defmodule SearchMessagesFilterUnreadMention do
   @moduledoc  """
   Returns only messages with unread mentions of the current user, or messages that are replies to their messages. When using this filter the results can't be additionally filtered by a query, a message thread or by the sending user.
@@ -11732,6 +17119,19 @@ defmodule SearchMessagesFilterUnreadMention do
   """
 
   defstruct "@type": "searchMessagesFilterUnreadMention", "@extra": nil
+end
+defmodule StoryOriginHiddenUser do
+  @moduledoc  """
+  The original story was sent by an unknown user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | sender_name | string | Name of the story sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_origin_hidden_user.html).
+  """
+
+  defstruct "@type": "storyOriginHiddenUser", "@extra": nil, sender_name: nil
 end
 defmodule CallDiscardReason do
   @moduledoc  """
@@ -11762,20 +17162,21 @@ defmodule Sticker do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | set_id | int64 | The identifier of the sticker set to which the sticker belongs; 0 if none. |
+  | id | int64 | Unique sticker identifier within the set; 0 if none. |
+  | set_id | int64 | Identifier of the sticker set to which the sticker belongs; 0 if none. |
   | width | int32 | Sticker width; as defined by the sender. |
   | height | int32 | Sticker height; as defined by the sender. |
   | emoji | string | Emoji corresponding to the sticker. |
-  | type | StickerType | Sticker type. |
+  | format | StickerFormat | Sticker format. |
+  | full_type | StickerFullType | Sticker's full type. |
   | outline | closedVectorPath | Sticker's outline represented as a list of closed vector paths; may be empty. The coordinate system origin is in the upper-left corner. |
   | thumbnail | thumbnail | Sticker thumbnail in WEBP or JPEG format; may be null. |
-  | premium_animation | file | Premium animation of the sticker; may be null. If present, only Premium users can send the sticker. |
   | sticker | file | File containing the sticker. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker.html).
   """
 
-  defstruct "@type": "sticker", "@extra": nil, set_id: nil, width: nil, height: nil, emoji: nil, type: nil, outline: nil, thumbnail: nil, premium_animation: nil, sticker: nil
+  defstruct "@type": "sticker", "@extra": nil, id: nil, set_id: nil, width: nil, height: nil, emoji: nil, format: nil, full_type: nil, outline: nil, thumbnail: nil, sticker: nil
 end
 defmodule PremiumState do
   @moduledoc  """
@@ -11784,14 +17185,14 @@ defmodule PremiumState do
   | Name | Type | Description |
   |------|------| ------------|
   | state | formattedText | Text description of the state of the current Premium subscription; may be empty if the current user has no Telegram Premium subscription. |
-  | currency | string | ISO 4217 currency code for Telegram Premium subscription payment. |
-  | monthly_amount | int53 | Monthly subscription payment for Telegram Premium subscription, in the smallest units of the currency. |
+  | payment_options | premiumStatePaymentOption | The list of available options for buying Telegram Premium. |
   | animations | premiumFeaturePromotionAnimation | The list of available promotion animations for Premium features. |
+  | business_animations | businessFeaturePromotionAnimation | The list of available promotion animations for Business features. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_state.html).
   """
 
-  defstruct "@type": "premiumState", "@extra": nil, state: nil, currency: nil, monthly_amount: nil, animations: nil
+  defstruct "@type": "premiumState", "@extra": nil, state: nil, payment_options: nil, animations: nil, business_animations: nil
 end
 defmodule SearchMessagesFilterUrl do
   @moduledoc  """
@@ -11805,13 +17206,22 @@ defmodule SearchMessagesFilterUrl do
 end
 defmodule MessageExpiredPhoto do
   @moduledoc  """
-  An expired photo message (self-destructed after TTL has elapsed).
+  A self-destructed photo message.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_expired_photo.html).
   """
 
   defstruct "@type": "messageExpiredPhoto", "@extra": nil
+end
+defmodule BusinessFeature do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_business_feature.html).
+  """
+
+  defstruct "@type": "BusinessFeature", "@extra": nil
 end
 defmodule ChatEventLogFilters do
   @moduledoc  """
@@ -11831,11 +17241,45 @@ defmodule ChatEventLogFilters do
   | setting_changes | bool | True, if changes in chat settings need to be returned. |
   | invite_link_changes | bool | True, if changes to invite links need to be returned. |
   | video_chat_changes | bool | True, if video chat actions need to be returned. |
+  | forum_changes | bool | True, if forum-related actions need to be returned. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_log_filters.html).
   """
 
-  defstruct "@type": "chatEventLogFilters", "@extra": nil, message_edits: nil, message_deletions: nil, message_pins: nil, member_joins: nil, member_leaves: nil, member_invites: nil, member_promotions: nil, member_restrictions: nil, info_changes: nil, setting_changes: nil, invite_link_changes: nil, video_chat_changes: nil
+  defstruct "@type": "chatEventLogFilters", "@extra": nil, message_edits: nil, message_deletions: nil, message_pins: nil, member_joins: nil, member_leaves: nil, member_invites: nil, member_promotions: nil, member_restrictions: nil, info_changes: nil, setting_changes: nil, invite_link_changes: nil, video_chat_changes: nil, forum_changes: nil
+end
+defmodule AuthorizationStateWaitEmailCode do
+  @moduledoc  """
+  TDLib needs the user's authentication code sent to an email address to authorize. Call checkAuthenticationEmailCode to provide the code.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | allow_apple_id | bool | True, if authorization through Apple ID is allowed. |
+  | allow_google_id | bool | True, if authorization through Google ID is allowed. |
+  | code_info | emailAddressAuthenticationCodeInfo | Information about the sent authentication code. |
+  | email_address_reset_state | EmailAddressResetState | Reset state of the email address; may be null if the email address can't be reset. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_email_code.html).
+  """
+
+  defstruct "@type": "authorizationStateWaitEmailCode", "@extra": nil, allow_apple_id: nil, allow_google_id: nil, code_info: nil, email_address_reset_state: nil
+end
+defmodule TelegramPaymentPurposePremiumGiveaway do
+  @moduledoc  """
+  The user creating a Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | parameters | premiumGiveawayParameters | Giveaway parameters. |
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+  | winner_count | int32 | Number of users which will be able to activate the gift codes. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active for the users. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1telegram_payment_purpose_premium_giveaway.html).
+  """
+
+  defstruct "@type": "telegramPaymentPurposePremiumGiveaway", "@extra": nil, parameters: nil, currency: nil, amount: nil, winner_count: nil, month_count: nil
 end
 defmodule InputInlineQueryResultGame do
   @moduledoc  """
@@ -11904,6 +17348,34 @@ defmodule PushMessageContentGame do
 
   defstruct "@type": "pushMessageContentGame", "@extra": nil, title: nil, is_pinned: nil
 end
+defmodule MessagePremiumGiveawayCompleted do
+  @moduledoc  """
+  A Telegram Premium giveaway without public winners has been completed for the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | giveaway_message_id | int53 | Identifier of the message with the giveaway; can be 0 if the message was deleted. |
+  | winner_count | int32 | Number of winners in the giveaway. |
+  | unclaimed_prize_count | int32 | Number of undistributed prizes. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_premium_giveaway_completed.html).
+  """
+
+  defstruct "@type": "messagePremiumGiveawayCompleted", "@extra": nil, giveaway_message_id: nil, winner_count: nil, unclaimed_prize_count: nil
+end
+defmodule StoryPrivacySettingsContacts do
+  @moduledoc  """
+  The story can be viewed by all contacts except chosen users.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | except_user_ids | int53 | User identifiers of the contacts that can't see the story; always unknown and empty for non-owned stories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_privacy_settings_contacts.html).
+  """
+
+  defstruct "@type": "storyPrivacySettingsContacts", "@extra": nil, except_user_ids: nil
+end
 defmodule RichTextSuperscript do
   @moduledoc  """
   A superscript rich text.
@@ -11960,6 +17432,23 @@ defmodule PageBlockAnimation do
 
   defstruct "@type": "pageBlockAnimation", "@extra": nil, animation: nil, caption: nil, need_autoplay: nil
 end
+defmodule AccentColor do
+  @moduledoc  """
+  Contains information about supported accent color for user/chat name, background of empty chat photo, replies to messages and link previews.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int32 | Accent color identifier. |
+  | built_in_accent_color_id | int32 | Identifier of a built-in color to use in places, where only one color is needed; 0-6. |
+  | light_theme_colors | int32 | The list of 1-3 colors in RGB format, describing the accent color, as expected to be shown in light themes. |
+  | dark_theme_colors | int32 | The list of 1-3 colors in RGB format, describing the accent color, as expected to be shown in dark themes. |
+  | min_channel_chat_boost_level | int32 | The minimum chat boost level required to use the color in a channel chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1accent_color.html).
+  """
+
+  defstruct "@type": "accentColor", "@extra": nil, id: nil, built_in_accent_color_id: nil, light_theme_colors: nil, dark_theme_colors: nil, min_channel_chat_boost_level: nil
+end
 defmodule RichTextIcon do
   @moduledoc  """
   A small image inside the text.
@@ -11975,6 +17464,22 @@ defmodule RichTextIcon do
 
   defstruct "@type": "richTextIcon", "@extra": nil, document: nil, width: nil, height: nil
 end
+defmodule SharedChat do
+  @moduledoc  """
+  Contains information about a chat shared with a bot.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | title | string | Title of the chat; for bots only. |
+  | username | string | Username of the chat; for bots only. |
+  | photo | photo | Photo of the chat; for bots only; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1shared_chat.html).
+  """
+
+  defstruct "@type": "sharedChat", "@extra": nil, chat_id: nil, title: nil, username: nil, photo: nil
+end
 defmodule DeviceTokenTizenPush do
   @moduledoc  """
   A token for Tizen Push Service.
@@ -11987,6 +17492,47 @@ defmodule DeviceTokenTizenPush do
   """
 
   defstruct "@type": "deviceTokenTizenPush", "@extra": nil, reg_id: nil
+end
+defmodule ChatEventForumTopicToggleIsClosed do
+  @moduledoc  """
+  A forum topic was closed or reopened.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic_info | forumTopicInfo | New information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_toggle_is_closed.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicToggleIsClosed", "@extra": nil, topic_info: nil
+end
+defmodule FirebaseAuthenticationSettingsIos do
+  @moduledoc  """
+  Settings for Firebase Authentication in the official iOS application.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | device_token | string | Device token from Apple Push Notification service. |
+  | is_app_sandbox | bool | True, if App Sandbox is enabled. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1firebase_authentication_settings_ios.html).
+  """
+
+  defstruct "@type": "firebaseAuthenticationSettingsIos", "@extra": nil, device_token: nil, is_app_sandbox: nil
+end
+defmodule ChatEventForumTopicEdited do
+  @moduledoc  """
+  A forum topic was edited.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_topic_info | forumTopicInfo | Old information about the topic. |
+  | new_topic_info | forumTopicInfo | New information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_edited.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicEdited", "@extra": nil, old_topic_info: nil, new_topic_info: nil
 end
 defmodule PushMessageContentGameScore do
   @moduledoc  """
@@ -12002,6 +17548,21 @@ defmodule PushMessageContentGameScore do
   """
 
   defstruct "@type": "pushMessageContentGameScore", "@extra": nil, title: nil, score: nil, is_pinned: nil
+end
+defmodule Usernames do
+  @moduledoc  """
+  Describes usernames assigned to a user, a supergroup, or a channel.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | active_usernames | string | List of active usernames; the first one must be shown as the primary username. The order of active usernames can be changed with <a class="el" href="classtd_1_1td__api_1_1reorder_active_usernames.html">reorderActiveUsernames</a>, <a class="el" href="classtd_1_1td__api_1_1reorder_bot_active_usernames.html">reorderBotActiveUsernames</a> or <a class="el" href="classtd_1_1td__api_1_1reorder_supergroup_active_usernames.html">reorderSupergroupActiveUsernames</a>. |
+  | disabled_usernames | string | List of currently disabled usernames; the username can be activated with <a class="el" href="classtd_1_1td__api_1_1toggle_username_is_active.html">toggleUsernameIsActive</a>, <a class="el" href="classtd_1_1td__api_1_1toggle_bot_username_is_active.html">toggleBotUsernameIsActive</a>, or <a class="el" href="classtd_1_1td__api_1_1toggle_supergroup_username_is_active.html">toggleSupergroupUsernameIsActive</a>. |
+  | editable_username | string | The active username, which can be changed with <a class="el" href="classtd_1_1td__api_1_1set_username.html">setUsername</a> or <a class="el" href="classtd_1_1td__api_1_1set_supergroup_username.html">setSupergroupUsername</a>. Information about other active usernames can be received using <a class="el" href="classtd_1_1td__api_1_1get_collectible_item_info.html">getCollectibleItemInfo</a>. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1usernames.html).
+  """
+
+  defstruct "@type": "usernames", "@extra": nil, active_usernames: nil, disabled_usernames: nil, editable_username: nil
 end
 defmodule NotificationGroupType do
   @moduledoc  """
@@ -12036,6 +17597,22 @@ defmodule MessageBasicGroupChatCreate do
 
   defstruct "@type": "messageBasicGroupChatCreate", "@extra": nil, title: nil, member_user_ids: nil
 end
+defmodule StoryInteraction do
+  @moduledoc  """
+  Represents interaction with a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | actor_id | MessageSender | Identifier of the user or chat that made the interaction. |
+  | interaction_date | int32 | Approximate point in time (Unix timestamp) when the interaction happened. |
+  | block_list | BlockList | Block list to which the actor is added; may be null if none or for chat stories. |
+  | type | StoryInteractionType | Type of the interaction. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interaction.html).
+  """
+
+  defstruct "@type": "storyInteraction", "@extra": nil, actor_id: nil, interaction_date: nil, block_list: nil, type: nil
+end
 defmodule PremiumSourceLink do
   @moduledoc  """
   A user opened an internal link of the type internalLinkTypePremiumFeatures.
@@ -12059,6 +17636,16 @@ defmodule SearchMessagesFilterMention do
 
   defstruct "@type": "searchMessagesFilterMention", "@extra": nil
 end
+defmodule PremiumStoryFeatureVideoQuality do
+  @moduledoc  """
+  The ability to choose better quality for viewed stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_video_quality.html).
+  """
+
+  defstruct "@type": "premiumStoryFeatureVideoQuality", "@extra": nil
+end
 defmodule InlineKeyboardButtonType do
   @moduledoc  """
 
@@ -12077,6 +17664,20 @@ defmodule CallDiscardReasonEmpty do
   """
 
   defstruct "@type": "callDiscardReasonEmpty", "@extra": nil
+end
+defmodule InputStoryAreaTypePreviousVenue do
+  @moduledoc  """
+  An area pointing to a venue already added to the story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | venue_provider | string | Provider of the venue. |
+  | venue_id | string | Identifier of the venue in the provider database. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_previous_venue.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypePreviousVenue", "@extra": nil, venue_provider: nil, venue_id: nil
 end
 defmodule UpdateAnimatedEmojiMessageClicked do
   @moduledoc  """
@@ -12118,16 +17719,17 @@ defmodule Proxies do
 end
 defmodule InternalLinkTypeStickerSet do
   @moduledoc  """
-  The link is a link to a sticker set. Call searchStickerSet with the given sticker set name to process the link and show the sticker set.
+  The link is a link to a sticker set. Call searchStickerSet with the given sticker set name to process the link and show the sticker set. If the sticker set is found and the user wants to add it, then call changeStickerSet.
 
   | Name | Type | Description |
   |------|------| ------------|
   | sticker_set_name | string | Name of the sticker set. |
+  | expect_custom_emoji | bool | True, if the sticker set is expected to contain custom emoji. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_sticker_set.html).
   """
 
-  defstruct "@type": "internalLinkTypeStickerSet", "@extra": nil, sticker_set_name: nil
+  defstruct "@type": "internalLinkTypeStickerSet", "@extra": nil, sticker_set_name: nil, expect_custom_emoji: nil
 end
 defmodule SupergroupMembersFilterRestricted do
   @moduledoc  """
@@ -12152,6 +17754,31 @@ defmodule NotificationGroupTypeMentions do
 
   defstruct "@type": "notificationGroupTypeMentions", "@extra": nil
 end
+defmodule PremiumStoryFeaturePriorityOrder do
+  @moduledoc  """
+  Stories of the current user are displayed before stories of non-Premium contacts, supergroups, and channels.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_priority_order.html).
+  """
+
+  defstruct "@type": "premiumStoryFeaturePriorityOrder", "@extra": nil
+end
+defmodule ChatFolderInviteLinkInfo do
+  @moduledoc  """
+  Contains information about an invite link to a chat folder.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folder_info | chatFolderInfo | Basic information about the chat folder; chat folder identifier will be 0 if the user didn't have the chat folder yet. |
+  | missing_chat_ids | int53 | Identifiers of the chats from the link, which aren't added to the folder yet. |
+  | added_chat_ids | int53 | Identifiers of the chats from the link, which are added to the folder already. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder_invite_link_info.html).
+  """
+
+  defstruct "@type": "chatFolderInviteLinkInfo", "@extra": nil, chat_folder_info: nil, missing_chat_ids: nil, added_chat_ids: nil
+end
 defmodule LocalFile do
   @moduledoc  """
   Represents a local file.
@@ -12172,18 +17799,71 @@ defmodule LocalFile do
 
   defstruct "@type": "localFile", "@extra": nil, path: nil, can_be_downloaded: nil, can_be_deleted: nil, is_downloading_active: nil, is_downloading_completed: nil, download_offset: nil, downloaded_prefix_size: nil, downloaded_size: nil
 end
+defmodule UpdateMessageReaction do
+  @moduledoc  """
+  User changed its reactions on a message with public reactions; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_id | int53 | Message identifier. |
+  | actor_id | MessageSender | Identifier of the user or chat that changed reactions. |
+  | date | int32 | Point in time (Unix timestamp) when the reactions were changed. |
+  | old_reaction_types | ReactionType | Old list of chosen reactions. |
+  | new_reaction_types | ReactionType | New list of chosen reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_message_reaction.html).
+  """
+
+  defstruct "@type": "updateMessageReaction", "@extra": nil, chat_id: nil, message_id: nil, actor_id: nil, date: nil, old_reaction_types: nil, new_reaction_types: nil
+end
+defmodule ChatEventCustomEmojiStickerSetChanged do
+  @moduledoc  """
+  The supergroup sticker set with allowed custom emoji was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | old_sticker_set_id | int64 | Previous identifier of the chat sticker set; 0 if none. |
+  | new_sticker_set_id | int64 | New identifier of the chat sticker set; 0 if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_custom_emoji_sticker_set_changed.html).
+  """
+
+  defstruct "@type": "chatEventCustomEmojiStickerSetChanged", "@extra": nil, old_sticker_set_id: nil, new_sticker_set_id: nil
+end
+defmodule SavedMessagesTopicTypeMyNotes do
+  @moduledoc  """
+  Topic containing messages sent by the current user of forwarded from an unknown chat.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_topic_type_my_notes.html).
+  """
+
+  defstruct "@type": "savedMessagesTopicTypeMyNotes", "@extra": nil
+end
+defmodule MessageSourceOther do
+  @moduledoc  """
+  The message is from some other source.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_source_other.html).
+  """
+
+  defstruct "@type": "messageSourceOther", "@extra": nil
+end
 defmodule UpdateTrendingStickerSets do
   @moduledoc  """
   The list of trending sticker sets was updated or some of them were viewed.
 
   | Name | Type | Description |
   |------|------| ------------|
+  | sticker_type | StickerType | Type of the affected stickers. |
   | sticker_sets | trendingStickerSets | The prefix of the list of trending sticker sets with the newest trending sticker sets. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_trending_sticker_sets.html).
   """
 
-  defstruct "@type": "updateTrendingStickerSets", "@extra": nil, sticker_sets: nil
+  defstruct "@type": "updateTrendingStickerSets", "@extra": nil, sticker_type: nil, sticker_sets: nil
 end
 defmodule PageBlockVerticalAlignmentTop do
   @moduledoc  """
@@ -12204,13 +17884,28 @@ defmodule PhoneNumberAuthenticationSettings do
   | allow_flash_call | bool | Pass true if the authentication code may be sent via a flash call to the specified phone number. |
   | allow_missed_call | bool | Pass true if the authentication code may be sent via a missed call to the specified phone number. |
   | is_current_phone_number | bool | Pass true if the authenticated phone number is used on the current device. |
+  | has_unknown_phone_number | bool | Pass true if there is a SIM card in the current device, but it is not possible to check whether phone number matches. |
   | allow_sms_retriever_api | bool | For official applications only. True, if the application can use Android SMS Retriever API (requires Google Play Services >= 10.2) to automatically receive the authentication code from the SMS. See <a href="https://developers.google.com/identity/sms-retriever/">https://developers.google.com/identity/sms-retriever/</a> for more details. |
+  | firebase_authentication_settings | FirebaseAuthenticationSettings | For official Android and iOS applications only; pass null otherwise. Settings for Firebase Authentication. |
   | authentication_tokens | string | List of up to 20 authentication tokens, recently received in <a class="el" href="classtd_1_1td__api_1_1update_option.html">updateOption</a>("authentication_token") in previously logged out sessions. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1phone_number_authentication_settings.html).
   """
 
-  defstruct "@type": "phoneNumberAuthenticationSettings", "@extra": nil, allow_flash_call: nil, allow_missed_call: nil, is_current_phone_number: nil, allow_sms_retriever_api: nil, authentication_tokens: nil
+  defstruct "@type": "phoneNumberAuthenticationSettings", "@extra": nil, allow_flash_call: nil, allow_missed_call: nil, is_current_phone_number: nil, has_unknown_phone_number: nil, allow_sms_retriever_api: nil, firebase_authentication_settings: nil, authentication_tokens: nil
+end
+defmodule SpeechRecognitionResultText do
+  @moduledoc  """
+  The speech recognition successfully finished.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | string | Recognized text. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1speech_recognition_result_text.html).
+  """
+
+  defstruct "@type": "speechRecognitionResultText", "@extra": nil, text: nil
 end
 defmodule TopChatCategoryBots do
   @moduledoc  """
@@ -12236,23 +17931,107 @@ defmodule UpdateChatVideoChat do
 
   defstruct "@type": "updateChatVideoChat", "@extra": nil, chat_id: nil, video_chat: nil
 end
+defmodule MessageEffect do
+  @moduledoc  """
+  Contains information about an effect added to a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int64 | Unique identifier of the effect. |
+  | static_icon | sticker | Static icon for the effect in WEBP format; may be null if none. |
+  | emoji | string | Emoji corresponding to the effect that can be used if static icon isn't available. |
+  | is_premium | bool | True, if Telegram Premium subscription is required to use the effect. |
+  | type | MessageEffectType | Type of the effect. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_effect.html).
+  """
+
+  defstruct "@type": "messageEffect", "@extra": nil, id: nil, static_icon: nil, emoji: nil, is_premium: nil, type: nil
+end
+defmodule TextQuote do
+  @moduledoc  """
+  Describes manually or automatically chosen quote from another message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | formattedText | Text of the quote. Only Bold, Italic, Underline, Strikethrough, Spoiler, and CustomEmoji entities can be present in the text. |
+  | position | int32 | Approximate quote position in the original message in UTF-16 code units as specified by the message sender. |
+  | is_manual | bool | True, if the quote was manually chosen by the message sender. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1text_quote.html).
+  """
+
+  defstruct "@type": "textQuote", "@extra": nil, text: nil, position: nil, is_manual: nil
+end
+defmodule CanSendMessageToUserResultOk do
+  @moduledoc  """
+  The user can be messaged.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1can_send_message_to_user_result_ok.html).
+  """
+
+  defstruct "@type": "canSendMessageToUserResultOk", "@extra": nil
+end
+defmodule StoryAreaTypeVenue do
+  @moduledoc  """
+  An area pointing to a venue.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | venue | venue | Information about the venue. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_type_venue.html).
+  """
+
+  defstruct "@type": "storyAreaTypeVenue", "@extra": nil, venue: nil
+end
 defmodule CallStateReady do
   @moduledoc  """
   The call is ready to use.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | protocol | callProtocol | Call protocols supported by the peer. |
+  | protocol | callProtocol | Call protocols supported by the other call participant. |
   | servers | callServer | List of available call servers. |
   | config | string | A JSON-encoded call config. |
   | encryption_key | bytes | Call encryption key. |
-  | emojis | string | Encryption key emojis fingerprint. |
+  | emojis | string | Encryption key fingerprint represented as 4 emoji. |
   | allow_p2p | bool | True, if peer-to-peer connection is allowed by users privacy settings. |
+  | custom_parameters | string | Custom JSON-encoded call parameters to be passed to tgcalls. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1call_state_ready.html).
   """
 
-  defstruct "@type": "callStateReady", "@extra": nil, protocol: nil, servers: nil, config: nil, encryption_key: nil, emojis: nil, allow_p2p: nil
+  defstruct "@type": "callStateReady", "@extra": nil, protocol: nil, servers: nil, config: nil, encryption_key: nil, emojis: nil, allow_p2p: nil, custom_parameters: nil
+end
+defmodule PremiumGiftCodePaymentOption do
+  @moduledoc  """
+  Describes an option for creating Telegram Premium gift codes.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | currency | string | ISO 4217 currency code for Telegram Premium gift code payment. |
+  | amount | int53 | The amount to pay, in the smallest units of the currency. |
+  | user_count | int32 | Number of users which will be able to activate the gift codes. |
+  | month_count | int32 | Number of months the Telegram Premium subscription will be active. |
+  | store_product_id | string | Identifier of the store product associated with the option; may be empty if none. |
+  | store_product_quantity | int32 | Number of times the store product must be paid. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_gift_code_payment_option.html).
+  """
+
+  defstruct "@type": "premiumGiftCodePaymentOption", "@extra": nil, currency: nil, amount: nil, user_count: nil, month_count: nil, store_product_id: nil, store_product_quantity: nil
+end
+defmodule PremiumFeatureMessagePrivacy do
+  @moduledoc  """
+  The ability to disallow incoming voice and video note messages in private chats using setUserPrivacySettingRules with userPrivacySettingAllowPrivateVoiceAndVideoNoteMessages and to restrict incoming messages from non-contacts using setNewChatPrivacySettings.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_message_privacy.html).
+  """
+
+  defstruct "@type": "premiumFeatureMessagePrivacy", "@extra": nil
 end
 defmodule CheckChatUsernameResultOk do
   @moduledoc  """
@@ -12263,6 +18042,15 @@ defmodule CheckChatUsernameResultOk do
   """
 
   defstruct "@type": "checkChatUsernameResultOk", "@extra": nil
+end
+defmodule ChatPhotoStickerType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_photo_sticker_type.html).
+  """
+
+  defstruct "@type": "ChatPhotoStickerType", "@extra": nil
 end
 defmodule TextParseModeHTML do
   @moduledoc  """
@@ -12287,6 +18075,34 @@ defmodule InputChatPhotoStatic do
 
   defstruct "@type": "inputChatPhotoStatic", "@extra": nil, photo: nil
 end
+defmodule InputStoryArea do
+  @moduledoc  """
+  Describes a clickable rectangle area on a story media to be added.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | position | storyAreaPosition | Position of the area. |
+  | type | InputStoryAreaType | Type of the area. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area.html).
+  """
+
+  defstruct "@type": "inputStoryArea", "@extra": nil, position: nil, type: nil
+end
+defmodule SponsoredMessages do
+  @moduledoc  """
+  Contains a list of sponsored messages.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | messages | sponsoredMessage | List of sponsored messages. |
+  | messages_between | int32 | The minimum number of messages between shown sponsored messages, or 0 if only one sponsored message must be shown after all ordinary messages. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sponsored_messages.html).
+  """
+
+  defstruct "@type": "sponsoredMessages", "@extra": nil, messages: nil, messages_between: nil
+end
 defmodule CallDiscardReasonDeclined do
   @moduledoc  """
   The call was ended before the conversation started. It was declined by the other party.
@@ -12305,12 +18121,13 @@ defmodule UpdateNewChatJoinRequest do
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
   | request | chatJoinRequest | Join request. |
+  | user_chat_id | int53 | Chat identifier of the private chat with the user. |
   | invite_link | chatInviteLink | The invite link, which was used to send join request; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_new_chat_join_request.html).
   """
 
-  defstruct "@type": "updateNewChatJoinRequest", "@extra": nil, chat_id: nil, request: nil, invite_link: nil
+  defstruct "@type": "updateNewChatJoinRequest", "@extra": nil, chat_id: nil, request: nil, user_chat_id: nil, invite_link: nil
 end
 defmodule TextEntityTypeStrikethrough do
   @moduledoc  """
@@ -12336,6 +18153,22 @@ defmodule ChatEventVideoChatParticipantVolumeLevelChanged do
 
   defstruct "@type": "chatEventVideoChatParticipantVolumeLevelChanged", "@extra": nil, participant_id: nil, volume_level: nil
 end
+defmodule ChatBoostSourceGiveaway do
+  @moduledoc  """
+  The chat created a Telegram Premium giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of a user that won in the giveaway; 0 if none. |
+  | gift_code | string | The created Telegram Premium gift code if it was used by the user or can be claimed by the current user; an empty string otherwise. |
+  | giveaway_message_id | int53 | Identifier of the corresponding giveaway message; can be an identifier of a deleted message. |
+  | is_unclaimed | bool | True, if the winner for the corresponding Telegram Premium subscription wasn't chosen, because there were not enough participants. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_source_giveaway.html).
+  """
+
+  defstruct "@type": "chatBoostSourceGiveaway", "@extra": nil, user_id: nil, gift_code: nil, giveaway_message_id: nil, is_unclaimed: nil
+end
 defmodule DeviceTokenApplePushVoIP do
   @moduledoc  """
   A token for Apple Push Notification service VoIP notifications.
@@ -12357,16 +18190,17 @@ defmodule MessageSendingStateFailed do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | error_code | int32 | An error code; 0 if unknown. |
-  | error_message | string | Error message. |
+  | error | error | The cause of the message sending failure. |
   | can_retry | bool | True, if the message can be re-sent. |
   | need_another_sender | bool | True, if the message can be re-sent only on behalf of a different sender. |
+  | need_another_reply_quote | bool | True, if the message can be re-sent only if another quote is chosen in the message that is replied by the given message. |
+  | need_drop_reply | bool | True, if the message can be re-sent only if the message to be replied is removed. This will be done automatically by <a class="el" href="classtd_1_1td__api_1_1resend_messages.html">resendMessages</a>. |
   | retry_after | double | Time left before the message can be re-sent, in seconds. No update is sent when this field changes. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_sending_state_failed.html).
   """
 
-  defstruct "@type": "messageSendingStateFailed", "@extra": nil, error_code: nil, error_message: nil, can_retry: nil, need_another_sender: nil, retry_after: nil
+  defstruct "@type": "messageSendingStateFailed", "@extra": nil, error: nil, can_retry: nil, need_another_sender: nil, need_another_reply_quote: nil, need_drop_reply: nil, retry_after: nil
 end
 defmodule ProxyTypeMtproto do
   @moduledoc  """
@@ -12381,18 +18215,47 @@ defmodule ProxyTypeMtproto do
 
   defstruct "@type": "proxyTypeMtproto", "@extra": nil, secret: nil
 end
-defmodule MessageForwardOriginMessageImport do
+defmodule ChatStatisticsInteractionInfo do
   @moduledoc  """
-  The message was imported from an exported message history.
+  Contains statistics about interactions with a message sent in the chat or a story sent by the chat.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | sender_name | string | Name of the sender. |
+  | object_type | ChatStatisticsObjectType | Type of the object. |
+  | view_count | int32 | Number of times the object was viewed. |
+  | forward_count | int32 | Number of times the object was forwarded. |
+  | reaction_count | int32 | Number of times reactions were added to the object. |
 
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forward_origin_message_import.html).
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_statistics_interaction_info.html).
   """
 
-  defstruct "@type": "messageForwardOriginMessageImport", "@extra": nil, sender_name: nil
+  defstruct "@type": "chatStatisticsInteractionInfo", "@extra": nil, object_type: nil, view_count: nil, forward_count: nil, reaction_count: nil
+end
+defmodule EmojiCategorySourceSearch do
+  @moduledoc  """
+  The category contains a list of similar emoji to search for in getStickers and searchStickers for stickers, or getInlineQueryResults with the bot getOption("animation_search_bot_username") for animations.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emojis | string | List of emojis to search for. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_category_source_search.html).
+  """
+
+  defstruct "@type": "emojiCategorySourceSearch", "@extra": nil, emojis: nil
+end
+defmodule ChatEventForumTopicToggleIsHidden do
+  @moduledoc  """
+  The General forum topic was hidden or unhidden.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic_info | forumTopicInfo | New information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_toggle_is_hidden.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicToggleIsHidden", "@extra": nil, topic_info: nil
 end
 defmodule InlineQueryResultVenue do
   @moduledoc  """
@@ -12408,6 +18271,16 @@ defmodule InlineQueryResultVenue do
   """
 
   defstruct "@type": "inlineQueryResultVenue", "@extra": nil, id: nil, venue: nil, thumbnail: nil
+end
+defmodule SuggestedActionGiftPremiumForChristmas do
+  @moduledoc  """
+  Suggests the user to gift Telegram Premium to friends for Christmas.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_gift_premium_for_christmas.html).
+  """
+
+  defstruct "@type": "suggestedActionGiftPremiumForChristmas", "@extra": nil
 end
 defmodule PassportElementPhoneNumber do
   @moduledoc  """
@@ -12452,6 +18325,19 @@ defmodule TextEntityTypeBotCommand do
 
   defstruct "@type": "textEntityTypeBotCommand", "@extra": nil
 end
+defmodule EmailAddressAuthenticationCode do
+  @moduledoc  """
+  An authentication code delivered to a user's email address.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | code | string | The code. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1email_address_authentication_code.html).
+  """
+
+  defstruct "@type": "emailAddressAuthenticationCode", "@extra": nil, code: nil
+end
 defmodule FileTypeAnimation do
   @moduledoc  """
   The file is an animation.
@@ -12461,6 +18347,19 @@ defmodule FileTypeAnimation do
   """
 
   defstruct "@type": "fileTypeAnimation", "@extra": nil
+end
+defmodule StoryPrivacySettingsSelectedUsers do
+  @moduledoc  """
+  The story can be viewed by certain specified users.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_ids | int53 | Identifiers of the users; always unknown and empty for non-owned stories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_privacy_settings_selected_users.html).
+  """
+
+  defstruct "@type": "storyPrivacySettingsSelectedUsers", "@extra": nil, user_ids: nil
 end
 defmodule MessageChatChangePhoto do
   @moduledoc  """
@@ -12483,9 +18382,13 @@ defmodule ChatStatisticsChannel do
   |------|------| ------------|
   | period | dateRange | A period to which the statistics applies. |
   | member_count | statisticalValue | Number of members in the chat. |
-  | mean_view_count | statisticalValue | Mean number of times the recently sent messages was viewed. |
-  | mean_share_count | statisticalValue | Mean number of times the recently sent messages was shared. |
-  | enabled_notifications_percentage | double | A percentage of users with enabled notifications for the chat. |
+  | mean_message_view_count | statisticalValue | Mean number of times the recently sent messages were viewed. |
+  | mean_message_share_count | statisticalValue | Mean number of times the recently sent messages were shared. |
+  | mean_message_reaction_count | statisticalValue | Mean number of times reactions were added to the recently sent messages. |
+  | mean_story_view_count | statisticalValue | Mean number of times the recently sent stories were viewed. |
+  | mean_story_share_count | statisticalValue | Mean number of times the recently sent stories were shared. |
+  | mean_story_reaction_count | statisticalValue | Mean number of times reactions were added to the recently sent stories. |
+  | enabled_notifications_percentage | double | A percentage of users with enabled notifications for the chat; 0-100. |
   | member_count_graph | StatisticalGraph | A graph containing number of members in the chat. |
   | join_graph | StatisticalGraph | A graph containing number of members joined and left the chat. |
   | mute_graph | StatisticalGraph | A graph containing number of members muted and unmuted the chat. |
@@ -12494,13 +18397,26 @@ defmodule ChatStatisticsChannel do
   | join_by_source_graph | StatisticalGraph | A graph containing number of new member joins per source. |
   | language_graph | StatisticalGraph | A graph containing number of users viewed chat messages per language. |
   | message_interaction_graph | StatisticalGraph | A graph containing number of chat message views and shares. |
+  | message_reaction_graph | StatisticalGraph | A graph containing number of reactions on messages. |
+  | story_interaction_graph | StatisticalGraph | A graph containing number of story views and shares. |
+  | story_reaction_graph | StatisticalGraph | A graph containing number of reactions on stories. |
   | instant_view_interaction_graph | StatisticalGraph | A graph containing number of views of associated with the chat instant views. |
-  | recent_message_interactions | chatStatisticsMessageInteractionInfo | Detailed statistics about number of views and shares of recently sent messages. |
+  | recent_interactions | chatStatisticsInteractionInfo | Detailed statistics about number of views and shares of recently sent messages and stories. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_statistics_channel.html).
   """
 
-  defstruct "@type": "chatStatisticsChannel", "@extra": nil, period: nil, member_count: nil, mean_view_count: nil, mean_share_count: nil, enabled_notifications_percentage: nil, member_count_graph: nil, join_graph: nil, mute_graph: nil, view_count_by_hour_graph: nil, view_count_by_source_graph: nil, join_by_source_graph: nil, language_graph: nil, message_interaction_graph: nil, instant_view_interaction_graph: nil, recent_message_interactions: nil
+  defstruct "@type": "chatStatisticsChannel", "@extra": nil, period: nil, member_count: nil, mean_message_view_count: nil, mean_message_share_count: nil, mean_message_reaction_count: nil, mean_story_view_count: nil, mean_story_share_count: nil, mean_story_reaction_count: nil, enabled_notifications_percentage: nil, member_count_graph: nil, join_graph: nil, mute_graph: nil, view_count_by_hour_graph: nil, view_count_by_source_graph: nil, join_by_source_graph: nil, language_graph: nil, message_interaction_graph: nil, message_reaction_graph: nil, story_interaction_graph: nil, story_reaction_graph: nil, instant_view_interaction_graph: nil, recent_interactions: nil
+end
+defmodule ReactionUnavailabilityReasonGuest do
+  @moduledoc  """
+  The user isn't a member of the supergroup and can't send messages and reactions there without joining.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_unavailability_reason_guest.html).
+  """
+
+  defstruct "@type": "reactionUnavailabilityReasonGuest", "@extra": nil
 end
 defmodule SessionTypeBrave do
   @moduledoc  """
@@ -12532,18 +18448,19 @@ defmodule InputInvoice do
 end
 defmodule AuthorizationStateWaitPassword do
   @moduledoc  """
-  The user has been authorized, but needs to enter a password to start using the application.
+  The user has been authorized, but needs to enter a 2-step verification password to start using the application. Call checkAuthenticationPassword to provide the password, or requestAuthenticationPasswordRecovery to recover the password, or deleteAccount to delete the account after a week.
 
   | Name | Type | Description |
   |------|------| ------------|
   | password_hint | string | Hint for the password; may be empty. |
   | has_recovery_email_address | bool | True, if a recovery email address has been set up. |
+  | has_passport_data | bool | True, if some Telegram Passport elements were saved. |
   | recovery_email_address_pattern | string | Pattern of the email address to which the recovery email was sent; empty until a recovery email has been sent. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1authorization_state_wait_password.html).
   """
 
-  defstruct "@type": "authorizationStateWaitPassword", "@extra": nil, password_hint: nil, has_recovery_email_address: nil, recovery_email_address_pattern: nil
+  defstruct "@type": "authorizationStateWaitPassword", "@extra": nil, password_hint: nil, has_recovery_email_address: nil, has_passport_data: nil, recovery_email_address_pattern: nil
 end
 defmodule PassportElementErrorSource do
   @moduledoc  """
@@ -12608,6 +18525,19 @@ defmodule Animation do
 
   defstruct "@type": "animation", "@extra": nil, duration: nil, width: nil, height: nil, file_name: nil, mime_type: nil, has_stickers: nil, minithumbnail: nil, thumbnail: nil, animation: nil
 end
+defmodule StoryAreaTypeLink do
+  @moduledoc  """
+  An area pointing to a HTTP or tg:// link.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | url | string | HTTP or tg:// URL to be opened when the area is clicked. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_area_type_link.html).
+  """
+
+  defstruct "@type": "storyAreaTypeLink", "@extra": nil, url: nil
+end
 defmodule MessageChatUpgradeFrom do
   @moduledoc  """
   A supergroup has been created from a basic group.
@@ -12632,9 +18562,19 @@ defmodule FileTypeNotificationSound do
 
   defstruct "@type": "fileTypeNotificationSound", "@extra": nil
 end
+defmodule FirebaseAuthenticationSettingsAndroid do
+  @moduledoc  """
+  Settings for Firebase Authentication in the official Android application.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1firebase_authentication_settings_android.html).
+  """
+
+  defstruct "@type": "firebaseAuthenticationSettingsAndroid", "@extra": nil
+end
 defmodule ChatActionBarReportSpam do
   @moduledoc  """
-  The chat can be reported as spam using the method reportChat with the reason chatReportReasonSpam.
+  The chat can be reported as spam using the method reportChat with the reason reportReasonSpam. If the chat is a private chat with a user with an emoji status, then a notice about emoji status usage must be shown.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -12647,7 +18587,7 @@ defmodule ChatActionBarReportSpam do
 end
 defmodule Emojis do
   @moduledoc  """
-  Represents a list of emoji.
+  Represents a list of emojis.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -12668,6 +18608,25 @@ defmodule CanTransferOwnershipResultOk do
 
   defstruct "@type": "canTransferOwnershipResultOk", "@extra": nil
 end
+defmodule PremiumFeatureBusiness do
+  @moduledoc  """
+  The ability to use Business features.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_feature_business.html).
+  """
+
+  defstruct "@type": "premiumFeatureBusiness", "@extra": nil
+end
+defmodule CollectibleItemType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_collectible_item_type.html).
+  """
+
+  defstruct "@type": "CollectibleItemType", "@extra": nil
+end
 defmodule FileTypePhoto do
   @moduledoc  """
   The file is a photo.
@@ -12680,7 +18639,7 @@ defmodule FileTypePhoto do
 end
 defmodule SavedCredentials do
   @moduledoc  """
-  Contains information about saved card credentials.
+  Contains information about saved payment credentials.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -12692,6 +18651,16 @@ defmodule SavedCredentials do
 
   defstruct "@type": "savedCredentials", "@extra": nil, id: nil, title: nil
 end
+defmodule SuggestedActionUpgradePremium do
+  @moduledoc  """
+  Suggests the user to upgrade the Premium subscription from monthly payments to annual payments.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_upgrade_premium.html).
+  """
+
+  defstruct "@type": "suggestedActionUpgradePremium", "@extra": nil
+end
 defmodule PassportElementErrorSourceSelfie do
   @moduledoc  """
   The selfie with the document contains an error. The error will be considered resolved when the file with the selfie changes.
@@ -12701,6 +18670,19 @@ defmodule PassportElementErrorSourceSelfie do
   """
 
   defstruct "@type": "passportElementErrorSourceSelfie", "@extra": nil
+end
+defmodule InternalLinkTypeUserToken do
+  @moduledoc  """
+  The link is a link to a user by a temporary token. Call searchUserByToken with the given token to process the link. If the user is found, then call createPrivateChat and open the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | The token. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_user_token.html).
+  """
+
+  defstruct "@type": "internalLinkTypeUserToken", "@extra": nil, token: nil
 end
 defmodule InlineQueryResultGame do
   @moduledoc  """
@@ -12733,6 +18715,15 @@ defmodule NotificationSound do
   """
 
   defstruct "@type": "notificationSound", "@extra": nil, id: nil, duration: nil, date: nil, title: nil, data: nil, sound: nil
+end
+defmodule BotWriteAccessAllowReason do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_bot_write_access_allow_reason.html).
+  """
+
+  defstruct "@type": "BotWriteAccessAllowReason", "@extra": nil
 end
 defmodule UserPrivacySettingShowProfilePhoto do
   @moduledoc  """
@@ -12778,6 +18769,19 @@ defmodule InlineQueryResultPhoto do
 
   defstruct "@type": "inlineQueryResultPhoto", "@extra": nil, id: nil, photo: nil, title: nil, description: nil
 end
+defmodule InternalLinkTypeChatFolderInvite do
+  @moduledoc  """
+  The link is an invite link to a chat folder. Call checkChatFolderInviteLink with the given invite link to process the link. If the link is valid and the user wants to join the chat folder, then call addChatFolderByInviteLink.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invite_link | string | Internal representation of the invite link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_chat_folder_invite.html).
+  """
+
+  defstruct "@type": "internalLinkTypeChatFolderInvite", "@extra": nil, invite_link: nil
+end
 defmodule UpdateScopeNotificationSettings do
   @moduledoc  """
   Notification settings for some type of chats were updated.
@@ -12791,6 +18795,95 @@ defmodule UpdateScopeNotificationSettings do
   """
 
   defstruct "@type": "updateScopeNotificationSettings", "@extra": nil, scope: nil, notification_settings: nil
+end
+defmodule ReportReasonCustom do
+  @moduledoc  """
+  A custom reason provided by the user.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_custom.html).
+  """
+
+  defstruct "@type": "reportReasonCustom", "@extra": nil
+end
+defmodule InputStoryContentPhoto do
+  @moduledoc  """
+  A photo story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | photo | InputFile | Photo to send. The photo must be at most 10 MB in size. The photo size must be 1080x1920. |
+  | added_sticker_file_ids | int32 | File identifiers of the stickers added to the photo, if applicable. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_content_photo.html).
+  """
+
+  defstruct "@type": "inputStoryContentPhoto", "@extra": nil, photo: nil, added_sticker_file_ids: nil
+end
+defmodule InputStoryAreaTypeMessage do
+  @moduledoc  """
+  An area pointing to a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the chat with the message. Currently, the chat must be a supergroup or a channel chat. |
+  | message_id | int53 | Identifier of the message. Only successfully sent non-scheduled messages can be specified. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_story_area_type_message.html).
+  """
+
+  defstruct "@type": "inputStoryAreaTypeMessage", "@extra": nil, chat_id: nil, message_id: nil
+end
+defmodule ForumTopicInfo do
+  @moduledoc  """
+  Contains basic information about a forum topic.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_thread_id | int53 | Message thread identifier of the topic. |
+  | name | string | Name of the topic. |
+  | icon | forumTopicIcon | Icon of the topic. |
+  | creation_date | int32 | Point in time (Unix timestamp) when the topic was created. |
+  | creator_id | MessageSender | Identifier of the creator of the topic. |
+  | is_general | bool | True, if the topic is the General topic list. |
+  | is_outgoing | bool | True, if the topic was created by the current user. |
+  | is_closed | bool | True, if the topic is closed. |
+  | is_hidden | bool | True, if the topic is hidden above the topic list and closed; for General topic only. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1forum_topic_info.html).
+  """
+
+  defstruct "@type": "forumTopicInfo", "@extra": nil, message_thread_id: nil, name: nil, icon: nil, creation_date: nil, creator_id: nil, is_general: nil, is_outgoing: nil, is_closed: nil, is_hidden: nil
+end
+defmodule SavedMessagesTag do
+  @moduledoc  """
+  Represents a tag used in Saved Messages or a Saved Messages topic.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tag | ReactionType | The tag. |
+  | label | string | Label of the tag; 0-12 characters. Always empty if the tag is returned for a Saved Messages topic. |
+  | count | int32 | Number of times the tag was used; may be 0 if the tag has non-empty label. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_tag.html).
+  """
+
+  defstruct "@type": "savedMessagesTag", "@extra": nil, tag: nil, label: nil, count: nil
+end
+defmodule ProfileAccentColors do
+  @moduledoc  """
+  Contains information about supported accent colors for user profile photo background in RGB format.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | palette_colors | int32 | The list of 1-2 colors in RGB format, describing the colors, as expected to be shown in the color palette settings. |
+  | background_colors | int32 | The list of 1-2 colors in RGB format, describing the colors, as expected to be used for the profile photo background. |
+  | story_colors | int32 | The list of 2 colors in RGB format, describing the colors of the gradient to be used for the unread active story indicator around profile photo. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1profile_accent_colors.html).
+  """
+
+  defstruct "@type": "profileAccentColors", "@extra": nil, palette_colors: nil, background_colors: nil, story_colors: nil
 end
 defmodule PageBlockCaption do
   @moduledoc  """
@@ -12834,6 +18927,21 @@ defmodule MessageVideoNote do
 
   defstruct "@type": "messageVideoNote", "@extra": nil, video_note: nil, is_viewed: nil, is_secret: nil
 end
+defmodule StorePaymentPurposeGiftedPremium do
+  @moduledoc  """
+  The user gifting Telegram Premium to another user.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of the user to which Premium was gifted. |
+  | currency | string | ISO 4217 currency code of the payment currency. |
+  | amount | int53 | Paid amount, in the smallest units of the currency. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1store_payment_purpose_gifted_premium.html).
+  """
+
+  defstruct "@type": "storePaymentPurposeGiftedPremium", "@extra": nil, user_id: nil, currency: nil, amount: nil
+end
 defmodule SessionTypeEdge do
   @moduledoc  """
   The session is running on the Edge browser.
@@ -12856,6 +18964,23 @@ defmodule InputPassportElementErrorSourceTranslationFiles do
   """
 
   defstruct "@type": "inputPassportElementErrorSourceTranslationFiles", "@extra": nil, file_hashes: nil
+end
+defmodule ChatBoostSlot do
+  @moduledoc  """
+  Describes a slot for chat boost.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | slot_id | int32 | Unique identifier of the slot. |
+  | currently_boosted_chat_id | int53 | Identifier of the currently boosted chat; 0 if none. |
+  | start_date | int32 | Point in time (Unix timestamp) when the chat was boosted; 0 if none. |
+  | expiration_date | int32 | Point in time (Unix timestamp) when the boost will expire. |
+  | cooldown_until_date | int32 | Point in time (Unix timestamp) after which the boost can be used for another chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_slot.html).
+  """
+
+  defstruct "@type": "chatBoostSlot", "@extra": nil, slot_id: nil, currently_boosted_chat_id: nil, start_date: nil, expiration_date: nil, cooldown_until_date: nil
 end
 defmodule InlineKeyboardButtonTypeBuy do
   @moduledoc  """
@@ -12882,6 +19007,16 @@ defmodule MessageCall do
 
   defstruct "@type": "messageCall", "@extra": nil, is_video: nil, discard_reason: nil, duration: nil
 end
+defmodule StickerTypeRegular do
+  @moduledoc  """
+  The sticker is a regular sticker.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1sticker_type_regular.html).
+  """
+
+  defstruct "@type": "stickerTypeRegular", "@extra": nil
+end
 defmodule Chat do
   @moduledoc  """
   A chat. (Can be a private chat, basic group, supergroup, or secret chat.)
@@ -12892,13 +19027,20 @@ defmodule Chat do
   | type | ChatType | Type of the chat. |
   | title | string | Chat title. |
   | photo | chatPhotoInfo | Chat photo; may be null. |
+  | accent_color_id | int32 | Identifier of the accent color for message sender name, and backgrounds of chat photo, reply header, and link preview. |
+  | background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the reply header and link preview background for messages sent by the chat; 0 if none. |
+  | profile_accent_color_id | int32 | Identifier of the profile accent color for the chat's profile; -1 if none. |
+  | profile_background_custom_emoji_id | int64 | Identifier of a custom emoji to be shown on the background of the chat's profile; 0 if none. |
   | permissions | chatPermissions | Actions that non-administrator chat members are allowed to take in the chat. |
-  | last_message | message | Last message in the chat; may be null. |
+  | last_message | message | Last message in the chat; may be null if none or unknown. |
   | positions | chatPosition | Positions of the chat in chat lists. |
+  | chat_lists | ChatList | Chat lists to which the chat belongs. A chat can have a non-zero position in a chat list even it doesn't belong to the chat list and have no position in a chat list even it belongs to the chat list. |
   | message_sender_id | MessageSender | Identifier of a user or chat that is selected to send messages in the chat; may be null if the user can't change message sender. |
+  | block_list | BlockList | Block list to which the chat is added; may be null if none. |
   | has_protected_content | bool | True, if chat content can't be saved locally, forwarded, or copied. |
+  | is_translatable | bool | True, if translation of all messages in the chat must be suggested to the user. |
   | is_marked_as_unread | bool | True, if the chat is marked as unread. |
-  | is_blocked | bool | True, if the chat is blocked by the current user and private messages from the chat can't be received. |
+  | view_as_topics | bool | True, if the chat is a forum supergroup that must be shown in the "View as topics" mode, or Saved Messages chat that must be shown in the "View as chats". |
   | has_scheduled_messages | bool | True, if the chat has scheduled messages. |
   | can_be_deleted_only_for_self | bool | True, if the chat messages can be deleted only for the current user while other users will continue to see the messages. |
   | can_be_deleted_for_all_users | bool | True, if the chat messages can be deleted for all users. |
@@ -12910,20 +19052,23 @@ defmodule Chat do
   | unread_mention_count | int32 | Number of unread messages with a mention/reply in the chat. |
   | unread_reaction_count | int32 | Number of messages with unread reactions in the chat. |
   | notification_settings | chatNotificationSettings | Notification settings for the chat. |
-  | available_reactions | string | List of reactions, available in the chat. |
-  | message_ttl | int32 | Current message Time To Live setting (self-destruct timer) for the chat; 0 if not defined. TTL is counted from the time message or its content is viewed in secret chats and from the send date in other chats. |
+  | available_reactions | ChatAvailableReactions | Types of reaction, available in the chat. |
+  | message_auto_delete_time | int32 | Current message auto-delete or self-destruct timer setting for the chat, in seconds; 0 if disabled. Self-destruct timer in secret chats starts after the message or its content is viewed. Auto-delete timer in other chats starts from the send date. |
+  | emoji_status | emojiStatus | Emoji status to be shown along with chat title; may be null. |
+  | background | chatBackground | Background set for the chat; may be null if none. |
   | theme_name | string | If non-empty, name of a theme, set for the chat. |
-  | action_bar | ChatActionBar | Information about actions which must be possible to do through the chat action bar; may be null. |
+  | action_bar | ChatActionBar | Information about actions which must be possible to do through the chat action bar; may be null if none. |
+  | business_bot_manage_bar | businessBotManageBar | Information about bar for managing a business bot in the chat; may be null if none. |
   | video_chat | videoChat | Information about video chat of the chat. |
-  | pending_join_requests | chatJoinRequestsInfo | Information about pending join requests; may be null. |
+  | pending_join_requests | chatJoinRequestsInfo | Information about pending join requests; may be null if none. |
   | reply_markup_message_id | int53 | Identifier of the message from which reply markup needs to be used; 0 if there is no default custom reply markup in the chat. |
-  | draft_message | draftMessage | A draft of a message in the chat; may be null. |
+  | draft_message | draftMessage | A draft of a message in the chat; may be null if none. |
   | client_data | string | Application-specific data associated with the chat. (For example, the chat scroll position or local chat notification settings can be stored here.) Persistent if the message database is used. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat.html).
   """
 
-  defstruct "@type": "chat", "@extra": nil, id: nil, type: nil, title: nil, photo: nil, permissions: nil, last_message: nil, positions: nil, message_sender_id: nil, has_protected_content: nil, is_marked_as_unread: nil, is_blocked: nil, has_scheduled_messages: nil, can_be_deleted_only_for_self: nil, can_be_deleted_for_all_users: nil, can_be_reported: nil, default_disable_notification: nil, unread_count: nil, last_read_inbox_message_id: nil, last_read_outbox_message_id: nil, unread_mention_count: nil, unread_reaction_count: nil, notification_settings: nil, available_reactions: nil, message_ttl: nil, theme_name: nil, action_bar: nil, video_chat: nil, pending_join_requests: nil, reply_markup_message_id: nil, draft_message: nil, client_data: nil
+  defstruct "@type": "chat", "@extra": nil, id: nil, type: nil, title: nil, photo: nil, accent_color_id: nil, background_custom_emoji_id: nil, profile_accent_color_id: nil, profile_background_custom_emoji_id: nil, permissions: nil, last_message: nil, positions: nil, chat_lists: nil, message_sender_id: nil, block_list: nil, has_protected_content: nil, is_translatable: nil, is_marked_as_unread: nil, view_as_topics: nil, has_scheduled_messages: nil, can_be_deleted_only_for_self: nil, can_be_deleted_for_all_users: nil, can_be_reported: nil, default_disable_notification: nil, unread_count: nil, last_read_inbox_message_id: nil, last_read_outbox_message_id: nil, unread_mention_count: nil, unread_reaction_count: nil, notification_settings: nil, available_reactions: nil, message_auto_delete_time: nil, emoji_status: nil, background: nil, theme_name: nil, action_bar: nil, business_bot_manage_bar: nil, video_chat: nil, pending_join_requests: nil, reply_markup_message_id: nil, draft_message: nil, client_data: nil
 end
 defmodule PassportElementErrorSourceDataField do
   @moduledoc  """
@@ -12972,13 +19117,36 @@ defmodule InputMessagePhoto do
   | added_sticker_file_ids | int32 | File identifiers of the stickers added to the photo, if applicable. |
   | width | int32 | Photo width. |
   | height | int32 | Photo height. |
-  | caption | formattedText | Photo caption; pass null to use an empty caption; 0-GetOption("message_caption_length_max") characters. |
-  | ttl | int32 | Photo TTL (Time To Live), in seconds (0-60). A non-zero TTL can be specified only in private chats. |
+  | caption | formattedText | Photo caption; pass null to use an empty caption; 0-<a class="el" href="classtd_1_1td__api_1_1get_option.html">getOption</a>("message_caption_length_max") characters. |
+  | show_caption_above_media | bool | True, if caption must be shown above the photo; otherwise, caption must be shown below the photo; not supported in secret chats. |
+  | self_destruct_type | MessageSelfDestructType | Photo self-destruct type; pass null if none; private chats only. |
+  | has_spoiler | bool | True, if the photo preview must be covered by a spoiler animation; not supported in secret chats. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_message_photo.html).
   """
 
-  defstruct "@type": "inputMessagePhoto", "@extra": nil, photo: nil, thumbnail: nil, added_sticker_file_ids: nil, width: nil, height: nil, caption: nil, ttl: nil
+  defstruct "@type": "inputMessagePhoto", "@extra": nil, photo: nil, thumbnail: nil, added_sticker_file_ids: nil, width: nil, height: nil, caption: nil, show_caption_above_media: nil, self_destruct_type: nil, has_spoiler: nil
+end
+defmodule StoryVideo do
+  @moduledoc  """
+  Describes a video file sent in a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | duration | double | Duration of the video, in seconds. |
+  | width | int32 | Video width. |
+  | height | int32 | Video height. |
+  | has_stickers | bool | True, if stickers were added to the video. The list of corresponding sticker sets can be received using <a class="el" href="classtd_1_1td__api_1_1get_attached_sticker_sets.html">getAttachedStickerSets</a>. |
+  | is_animation | bool | True, if the video has no sound. |
+  | minithumbnail | minithumbnail | Video minithumbnail; may be null. |
+  | thumbnail | thumbnail | Video thumbnail in JPEG or MPEG4 format; may be null. |
+  | preload_prefix_size | int32 | Size of file prefix, which is supposed to be preloaded, in bytes. |
+  | video | file | File containing the video. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_video.html).
+  """
+
+  defstruct "@type": "storyVideo", "@extra": nil, duration: nil, width: nil, height: nil, has_stickers: nil, is_animation: nil, minithumbnail: nil, thumbnail: nil, preload_prefix_size: nil, video: nil
 end
 defmodule AddedReaction do
   @moduledoc  """
@@ -12986,13 +19154,15 @@ defmodule AddedReaction do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | reaction | string | Text representation of the reaction. |
+  | type | ReactionType | Type of the reaction. |
   | sender_id | MessageSender | Identifier of the chat member, applied the reaction. |
+  | is_outgoing | bool | True, if the reaction was added by the current user. |
+  | date | int32 | Point in time (Unix timestamp) when the reaction was added. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1added_reaction.html).
   """
 
-  defstruct "@type": "addedReaction", "@extra": nil, reaction: nil, sender_id: nil
+  defstruct "@type": "addedReaction", "@extra": nil, type: nil, sender_id: nil, is_outgoing: nil, date: nil
 end
 defmodule UpdateServiceNotification do
   @moduledoc  """
@@ -13075,6 +19245,19 @@ defmodule CanTransferOwnershipResultPasswordNeeded do
 
   defstruct "@type": "canTransferOwnershipResultPasswordNeeded", "@extra": nil
 end
+defmodule FailedToAddMembers do
+  @moduledoc  """
+  Represents a list of users that has failed to be added to a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | failed_to_add_members | failedToAddMember | Information about users that weren't added to the chat. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1failed_to_add_members.html).
+  """
+
+  defstruct "@type": "failedToAddMembers", "@extra": nil, failed_to_add_members: nil
+end
 defmodule SuggestedActionConvertToBroadcastGroup do
   @moduledoc  """
   Suggests the user to convert specified supergroup to a broadcast group.
@@ -13128,6 +19311,39 @@ defmodule RichTextBold do
 
   defstruct "@type": "richTextBold", "@extra": nil, text: nil
 end
+defmodule InviteLinkChatTypeBasicGroup do
+  @moduledoc  """
+  The link is an invite link for a basic group.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1invite_link_chat_type_basic_group.html).
+  """
+
+  defstruct "@type": "inviteLinkChatTypeBasicGroup", "@extra": nil
+end
+defmodule RecommendedChatFolders do
+  @moduledoc  """
+  Contains a list of recommended chat folders.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_folders | recommendedChatFolder | List of recommended chat folders. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recommended_chat_folders.html).
+  """
+
+  defstruct "@type": "recommendedChatFolders", "@extra": nil, chat_folders: nil
+end
+defmodule SuggestedActionSubscribeToAnnualPremium do
+  @moduledoc  """
+  Suggests the user to subscribe to the Premium subscription with annual payments.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_subscribe_to_annual_premium.html).
+  """
+
+  defstruct "@type": "suggestedActionSubscribeToAnnualPremium", "@extra": nil
+end
 defmodule ConnectedWebsite do
   @moduledoc  """
   Contains information about one website the current user is logged in with Telegram.
@@ -13141,13 +19357,13 @@ defmodule ConnectedWebsite do
   | platform | string | Operating system the browser is running on. |
   | log_in_date | int32 | Point in time (Unix timestamp) when the user was logged in. |
   | last_active_date | int32 | Point in time (Unix timestamp) when obtained authorization was last used. |
-  | ip | string | IP address from which the user was logged in, in human-readable format. |
+  | ip_address | string | IP address from which the user was logged in, in human-readable format. |
   | location | string | Human-readable description of a country and a region from which the user was logged in, based on the IP address. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1connected_website.html).
   """
 
-  defstruct "@type": "connectedWebsite", "@extra": nil, id: nil, domain_name: nil, bot_user_id: nil, browser: nil, platform: nil, log_in_date: nil, last_active_date: nil, ip: nil, location: nil
+  defstruct "@type": "connectedWebsite", "@extra": nil, id: nil, domain_name: nil, bot_user_id: nil, browser: nil, platform: nil, log_in_date: nil, last_active_date: nil, ip_address: nil, location: nil
 end
 defmodule UpdateFileGenerationStop do
   @moduledoc  """
@@ -13198,13 +19414,12 @@ defmodule UpdateMessageSendFailed do
   |------|------| ------------|
   | message | message | The failed to send message. |
   | old_message_id | int53 | The previous temporary message identifier. |
-  | error_code | int32 | An error code. |
-  | error_message | string | Error message. |
+  | error | error | The cause of the message sending failure. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_message_send_failed.html).
   """
 
-  defstruct "@type": "updateMessageSendFailed", "@extra": nil, message: nil, old_message_id: nil, error_code: nil, error_message: nil
+  defstruct "@type": "updateMessageSendFailed", "@extra": nil, message: nil, old_message_id: nil, error: nil
 end
 defmodule ChatMembersFilter do
   @moduledoc  """
@@ -13214,6 +19429,16 @@ defmodule ChatMembersFilter do
   """
 
   defstruct "@type": "ChatMembersFilter", "@extra": nil
+end
+defmodule ReportChatSponsoredMessageResultOk do
+  @moduledoc  """
+  The message was reported successfully.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_chat_sponsored_message_result_ok.html).
+  """
+
+  defstruct "@type": "reportChatSponsoredMessageResultOk", "@extra": nil
 end
 defmodule PremiumLimitTypePinnedArchivedChatCount do
   @moduledoc  """
@@ -13263,6 +19488,22 @@ defmodule Thumbnail do
 
   defstruct "@type": "thumbnail", "@extra": nil, format: nil, width: nil, height: nil, file: nil
 end
+defmodule PremiumStatePaymentOption do
+  @moduledoc  """
+  Describes an option for buying or upgrading Telegram Premium for self.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | payment_option | premiumPaymentOption | Information about the payment option. |
+  | is_current | bool | True, if this is the currently used Telegram Premium subscription option. |
+  | is_upgrade | bool | True, if the payment option can be used to upgrade the existing Telegram Premium subscription. |
+  | last_transaction_id | string | Identifier of the last in-store transaction for the currently used option. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_state_payment_option.html).
+  """
+
+  defstruct "@type": "premiumStatePaymentOption", "@extra": nil, payment_option: nil, is_current: nil, is_upgrade: nil, last_transaction_id: nil
+end
 defmodule PremiumFeatureImprovedDownloadSpeed do
   @moduledoc  """
   Improved download speed.
@@ -13280,7 +19521,7 @@ defmodule UpdateChatAction do
   | Name | Type | Description |
   |------|------| ------------|
   | chat_id | int53 | Chat identifier. |
-  | message_thread_id | int53 | If not 0, a message thread identifier in which the action was performed. |
+  | message_thread_id | int53 | If not 0, the message thread identifier in which the action was performed. |
   | sender_id | MessageSender | Identifier of a message sender performing the action. |
   | action | ChatAction | The action. |
 
@@ -13291,7 +19532,7 @@ defmodule UpdateChatAction do
 end
 defmodule AuthenticationCodeTypeTelegramMessage do
   @moduledoc  """
-  An authentication code is delivered via a private Telegram message, which can be viewed from another active session.
+  A digit-only authentication code is delivered via a private Telegram message, which can be viewed from another active session.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -13301,6 +19542,16 @@ defmodule AuthenticationCodeTypeTelegramMessage do
   """
 
   defstruct "@type": "authenticationCodeTypeTelegramMessage", "@extra": nil, length: nil
+end
+defmodule MessageSelfDestructTypeImmediately do
+  @moduledoc  """
+  The message can be opened only once and will be self-destructed once closed.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_self_destruct_type_immediately.html).
+  """
+
+  defstruct "@type": "messageSelfDestructTypeImmediately", "@extra": nil
 end
 defmodule PassportAuthorizationForm do
   @moduledoc  """
@@ -13379,6 +19630,29 @@ defmodule DiceStickers do
 
   defstruct "@type": "DiceStickers", "@extra": nil
 end
+defmodule PhoneNumberCodeTypeVerify do
+  @moduledoc  """
+  Verifies ownership of a phone number to be added to the user's Telegram Passport.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1phone_number_code_type_verify.html).
+  """
+
+  defstruct "@type": "phoneNumberCodeTypeVerify", "@extra": nil
+end
+defmodule ChatEventForumTopicDeleted do
+  @moduledoc  """
+  A forum topic was deleted.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | topic_info | forumTopicInfo | Information about the topic. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_forum_topic_deleted.html).
+  """
+
+  defstruct "@type": "chatEventForumTopicDeleted", "@extra": nil, topic_info: nil
+end
 defmodule AutoDownloadSettings do
   @moduledoc  """
   Contains auto-download settings.
@@ -13392,12 +19666,13 @@ defmodule AutoDownloadSettings do
   | video_upload_bitrate | int32 | The maximum suggested bitrate for uploaded videos, in kbit/s. |
   | preload_large_videos | bool | True, if the beginning of video files needs to be preloaded for instant playback. |
   | preload_next_audio | bool | True, if the next audio track needs to be preloaded while the user is listening to an audio file. |
+  | preload_stories | bool | True, if stories needs to be preloaded. |
   | use_less_data_for_calls | bool | True, if "use less data for calls" option needs to be enabled. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1auto_download_settings.html).
   """
 
-  defstruct "@type": "autoDownloadSettings", "@extra": nil, is_auto_download_enabled: nil, max_photo_file_size: nil, max_video_file_size: nil, max_other_file_size: nil, video_upload_bitrate: nil, preload_large_videos: nil, preload_next_audio: nil, use_less_data_for_calls: nil
+  defstruct "@type": "autoDownloadSettings", "@extra": nil, is_auto_download_enabled: nil, max_photo_file_size: nil, max_video_file_size: nil, max_other_file_size: nil, video_upload_bitrate: nil, preload_large_videos: nil, preload_next_audio: nil, preload_stories: nil, use_less_data_for_calls: nil
 end
 defmodule MessageChatJoinByLink do
   @moduledoc  """
@@ -13408,6 +19683,34 @@ defmodule MessageChatJoinByLink do
   """
 
   defstruct "@type": "messageChatJoinByLink", "@extra": nil
+end
+defmodule BusinessLocation do
+  @moduledoc  """
+  Represents a location of a business.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | location | location | The location; may be null if not specified. |
+  | address | string | Location address; 1-96 characters. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_location.html).
+  """
+
+  defstruct "@type": "businessLocation", "@extra": nil, location: nil, address: nil
+end
+defmodule StoryStatistics do
+  @moduledoc  """
+  A detailed statistics about a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_interaction_graph | StatisticalGraph | A graph containing number of story views and shares. |
+  | story_reaction_graph | StatisticalGraph | A graph containing number of story reactions. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_statistics.html).
+  """
+
+  defstruct "@type": "storyStatistics", "@extra": nil, story_interaction_graph: nil, story_reaction_graph: nil
 end
 defmodule ChatEventMemberLeft do
   @moduledoc  """
@@ -13450,7 +19753,7 @@ defmodule FoundFileDownloads do
   |------|------| ------------|
   | total_counts | downloadedFileCounts | Total number of suitable files, ignoring offset. |
   | files | fileDownload | The list of files. |
-  | next_offset | string | The offset for the next request. If empty, there are no more results. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_file_downloads.html).
   """
@@ -13459,7 +19762,7 @@ defmodule FoundFileDownloads do
 end
 defmodule MessageUnsupported do
   @moduledoc  """
-  Message content that is not supported in the current TDLib version.
+  A message content that is not supported in the current TDLib version.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_unsupported.html).
@@ -13498,10 +19801,10 @@ defmodule Poll do
   | Name | Type | Description |
   |------|------| ------------|
   | id | int64 | Unique poll identifier. |
-  | question | string | Poll question; 1-300 characters. |
+  | question | formattedText | Poll question; 1-300 characters. Only custom emoji entities are allowed. |
   | options | pollOption | List of poll answer options. |
   | total_voter_count | int32 | Total number of voters, participating in the poll. |
-  | recent_voter_user_ids | int53 | User identifiers of recent voters, if the poll is non-anonymous. |
+  | recent_voter_ids | MessageSender | Identifiers of recent voters, if the poll is non-anonymous. |
   | is_anonymous | bool | True, if the poll is anonymous. |
   | type | PollType | Type of the poll. |
   | open_period | int32 | Amount of time the poll will be active after creation, in seconds. |
@@ -13511,7 +19814,7 @@ defmodule Poll do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1poll.html).
   """
 
-  defstruct "@type": "poll", "@extra": nil, id: nil, question: nil, options: nil, total_voter_count: nil, recent_voter_user_ids: nil, is_anonymous: nil, type: nil, open_period: nil, close_date: nil, is_closed: nil
+  defstruct "@type": "poll", "@extra": nil, id: nil, question: nil, options: nil, total_voter_count: nil, recent_voter_ids: nil, is_anonymous: nil, type: nil, open_period: nil, close_date: nil, is_closed: nil
 end
 defmodule PassportElementTypePersonalDetails do
   @moduledoc  """
@@ -13535,6 +19838,20 @@ defmodule InputPassportElementDriverLicense do
   """
 
   defstruct "@type": "inputPassportElementDriverLicense", "@extra": nil, driver_license: nil
+end
+defmodule UpdateStarRevenueStatus do
+  @moduledoc  """
+  The Telegram star revenue earned by a bot or a chat has changed. If star transactions screen of the chat is opened, then getStarTransactions may be called to fetch new transactions.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | owner_id | MessageSender | Identifier of the owner of the Telegram stars. |
+  | status | starRevenueStatus | New Telegram star revenue status. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_star_revenue_status.html).
+  """
+
+  defstruct "@type": "updateStarRevenueStatus", "@extra": nil, owner_id: nil, status: nil
 end
 defmodule InputCredentialsGooglePay do
   @moduledoc  """
@@ -13567,6 +19884,15 @@ defmodule PageBlockRelatedArticle do
 
   defstruct "@type": "pageBlockRelatedArticle", "@extra": nil, url: nil, title: nil, description: nil, photo: nil, author: nil, publish_date: nil
 end
+defmodule PublicForward do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_public_forward.html).
+  """
+
+  defstruct "@type": "PublicForward", "@extra": nil
+end
 defmodule SessionTypeUnknown do
   @moduledoc  """
   The session is running on an unknown type of device.
@@ -13576,6 +19902,33 @@ defmodule SessionTypeUnknown do
   """
 
   defstruct "@type": "sessionTypeUnknown", "@extra": nil
+end
+defmodule UpdateNewBusinessCallbackQuery do
+  @moduledoc  """
+  A new incoming callback query from a business message; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | id | int64 | Unique query identifier. |
+  | sender_user_id | int53 | Identifier of the user who sent the query. |
+  | connection_id | string | Unique identifier of the business connection. |
+  | message | businessMessage | The message from the business account from which the query originated. |
+  | chat_instance | int64 | An identifier uniquely corresponding to the chat a message was sent to. |
+  | payload | CallbackQueryPayload | Query payload. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_new_business_callback_query.html).
+  """
+
+  defstruct "@type": "updateNewBusinessCallbackQuery", "@extra": nil, id: nil, sender_user_id: nil, connection_id: nil, message: nil, chat_instance: nil, payload: nil
+end
+defmodule EmojiCategorySource do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_emoji_category_source.html).
+  """
+
+  defstruct "@type": "EmojiCategorySource", "@extra": nil
 end
 defmodule PageBlockBlockQuote do
   @moduledoc  """
@@ -13593,13 +19946,23 @@ defmodule PageBlockBlockQuote do
 end
 defmodule SuggestedActionEnableArchiveAndMuteNewChats do
   @moduledoc  """
-  Suggests the user to enable "archive_and_mute_new_chats_from_unknown_users" option.
+  Suggests the user to enable archive_and_mute_new_chats_from_unknown_users setting in archiveChatListSettings.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1suggested_action_enable_archive_and_mute_new_chats.html).
   """
 
   defstruct "@type": "suggestedActionEnableArchiveAndMuteNewChats", "@extra": nil
+end
+defmodule ReportReasonViolence do
+  @moduledoc  """
+  The chat promotes violence.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_violence.html).
+  """
+
+  defstruct "@type": "reportReasonViolence", "@extra": nil
 end
 defmodule HttpUrl do
   @moduledoc  """
@@ -13613,6 +19976,15 @@ defmodule HttpUrl do
   """
 
   defstruct "@type": "httpUrl", "@extra": nil, url: nil
+end
+defmodule MessageOrigin do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_origin.html).
+  """
+
+  defstruct "@type": "MessageOrigin", "@extra": nil
 end
 defmodule BotCommandScopeChatAdministrators do
   @moduledoc  """
@@ -13678,7 +20050,7 @@ defmodule CallProtocol do
   | udp_p2p | bool | True, if UDP peer-to-peer connections are supported. |
   | udp_reflector | bool | True, if connection through UDP reflectors is supported. |
   | min_layer | int32 | The minimum supported API layer; use 65. |
-  | max_layer | int32 | The maximum supported API layer; use 65. |
+  | max_layer | int32 | The maximum supported API layer; use 92. |
   | library_versions | string | List of supported tgcalls versions. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1call_protocol.html).
@@ -13699,6 +20071,32 @@ defmodule ChatEventInviteLinkRevoked do
 
   defstruct "@type": "chatEventInviteLinkRevoked", "@extra": nil, invite_link: nil
 end
+defmodule EmojiKeywords do
+  @moduledoc  """
+  Represents a list of emojis with their keywords.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | emoji_keywords | emojiKeyword | List of emojis with their keywords. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_keywords.html).
+  """
+
+  defstruct "@type": "emojiKeywords", "@extra": nil, emoji_keywords: nil
+end
+defmodule SavedMessagesTags do
+  @moduledoc  """
+  Contains a list of tags used in Saved Messages.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | tags | savedMessagesTag | List of tags. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1saved_messages_tags.html).
+  """
+
+  defstruct "@type": "savedMessagesTags", "@extra": nil, tags: nil
+end
 defmodule EncryptedCredentials do
   @moduledoc  """
   Contains encrypted Telegram Passport data credentials.
@@ -13713,16 +20111,6 @@ defmodule EncryptedCredentials do
   """
 
   defstruct "@type": "encryptedCredentials", "@extra": nil, data: nil, hash: nil, secret: nil
-end
-defmodule PremiumLimitTypeChatFilterCount do
-  @moduledoc  """
-  The maximum number of chat filters.
-
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_chat_filter_count.html).
-  """
-
-  defstruct "@type": "premiumLimitTypeChatFilterCount", "@extra": nil
 end
 defmodule ChatActionUploadingDocument do
   @moduledoc  """
@@ -13763,6 +20151,15 @@ defmodule RichTextPlain do
   """
 
   defstruct "@type": "richTextPlain", "@extra": nil, text: nil
+end
+defmodule PaymentReceiptType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_payment_receipt_type.html).
+  """
+
+  defstruct "@type": "PaymentReceiptType", "@extra": nil
 end
 defmodule AuthorizationStateLoggingOut do
   @moduledoc  """
@@ -13841,6 +20238,21 @@ defmodule MessageSticker do
 
   defstruct "@type": "messageSticker", "@extra": nil, sticker: nil, is_premium: nil
 end
+defmodule MessageStory do
+  @moduledoc  """
+  A message with a forwarded story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story_sender_chat_id | int53 | Identifier of the chat that posted the story. |
+  | story_id | int32 | Story identifier. |
+  | via_mention | bool | True, if the story was automatically forwarded because of a mention of the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_story.html).
+  """
+
+  defstruct "@type": "messageStory", "@extra": nil, story_sender_chat_id: nil, story_id: nil, via_mention: nil
+end
 defmodule Chats do
   @moduledoc  """
   Represents a list of chats.
@@ -13854,6 +20266,19 @@ defmodule Chats do
   """
 
   defstruct "@type": "chats", "@extra": nil, total_count: nil, chat_ids: nil
+end
+defmodule MessageSuggestProfilePhoto do
+  @moduledoc  """
+  A profile photo was suggested to a user in a private chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | photo | chatPhoto | The suggested chat photo. Use the method <a class="el" href="classtd_1_1td__api_1_1set_profile_photo.html">setProfilePhoto</a> with <a class="el" href="classtd_1_1td__api_1_1input_chat_photo_previous.html">inputChatPhotoPrevious</a> to apply the photo. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_suggest_profile_photo.html).
+  """
+
+  defstruct "@type": "messageSuggestProfilePhoto", "@extra": nil, photo: nil
 end
 defmodule MessageReplyInfo do
   @moduledoc  """
@@ -13871,6 +20296,19 @@ defmodule MessageReplyInfo do
   """
 
   defstruct "@type": "messageReplyInfo", "@extra": nil, reply_count: nil, recent_replier_ids: nil, last_read_inbox_message_id: nil, last_read_outbox_message_id: nil, last_message_id: nil
+end
+defmodule ChatStatisticsObjectTypeMessage do
+  @moduledoc  """
+  Describes a message sent in the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message_id | int53 | Message identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_statistics_object_type_message.html).
+  """
+
+  defstruct "@type": "chatStatisticsObjectTypeMessage", "@extra": nil, message_id: nil
 end
 defmodule GroupCallVideoQualityThumbnail do
   @moduledoc  """
@@ -13898,6 +20336,20 @@ defmodule StorageStatisticsByChat do
 
   defstruct "@type": "storageStatisticsByChat", "@extra": nil, chat_id: nil, size: nil, count: nil, by_file_type: nil
 end
+defmodule DeviceTokenHuaweiPush do
+  @moduledoc  """
+  A token for HUAWEI Push Service.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | token | string | Device registration token; may be empty to deregister a device. |
+  | encrypt | bool | True, if push notifications must be additionally encrypted. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1device_token_huawei_push.html).
+  """
+
+  defstruct "@type": "deviceTokenHuaweiPush", "@extra": nil, token: nil, encrypt: nil
+end
 defmodule GroupCallParticipantVideoInfo do
   @moduledoc  """
   Contains information about a group call participant's video channel.
@@ -13906,7 +20358,7 @@ defmodule GroupCallParticipantVideoInfo do
   |------|------| ------------|
   | source_groups | groupCallVideoSourceGroup | List of synchronization source groups of the video. |
   | endpoint_id | string | Video channel endpoint identifier. |
-  | is_paused | bool | True if the video is paused. This flag needs to be ignored, if new video frames are received. |
+  | is_paused | bool | True, if the video is paused. This flag needs to be ignored, if new video frames are received. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1group_call_participant_video_info.html).
   """
@@ -13932,6 +20384,19 @@ defmodule CheckStickerSetNameResultNameInvalid do
 
   defstruct "@type": "checkStickerSetNameResultNameInvalid", "@extra": nil
 end
+defmodule UpdateUnconfirmedSession do
+  @moduledoc  """
+  The first unconfirmed session has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | session | unconfirmedSession | The unconfirmed session; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_unconfirmed_session.html).
+  """
+
+  defstruct "@type": "updateUnconfirmedSession", "@extra": nil, session: nil
+end
 defmodule InternalLinkTypeMessageDraft do
   @moduledoc  """
   The link contains a message draft text. A share screen needs to be shown to the user, then the chosen chat must be opened and the text is added to the input field.
@@ -13946,6 +20411,19 @@ defmodule InternalLinkTypeMessageDraft do
 
   defstruct "@type": "internalLinkTypeMessageDraft", "@extra": nil, text: nil, contains_link: nil
 end
+defmodule MessageForumTopicIsClosedToggled do
+  @moduledoc  """
+  A forum topic has been closed or opened.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | is_closed | bool | True, if the topic was closed; otherwise, the topic was reopened. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_forum_topic_is_closed_toggled.html).
+  """
+
+  defstruct "@type": "messageForumTopicIsClosedToggled", "@extra": nil, is_closed: nil
+end
 defmodule MessageVideo do
   @moduledoc  """
   A video message.
@@ -13954,12 +20432,27 @@ defmodule MessageVideo do
   |------|------| ------------|
   | video | video | The video description. |
   | caption | formattedText | Video caption. |
+  | show_caption_above_media | bool | True, if caption must be shown above the video; otherwise, caption must be shown below the video. |
+  | has_spoiler | bool | True, if the video preview must be covered by a spoiler animation. |
   | is_secret | bool | True, if the video thumbnail must be blurred and the video must be shown only while tapped. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_video.html).
   """
 
-  defstruct "@type": "messageVideo", "@extra": nil, video: nil, caption: nil, is_secret: nil
+  defstruct "@type": "messageVideo", "@extra": nil, video: nil, caption: nil, show_caption_above_media: nil, has_spoiler: nil, is_secret: nil
+end
+defmodule ChatEventHasAggressiveAntiSpamEnabledToggled do
+  @moduledoc  """
+  The has_aggressive_anti_spam_enabled setting of a supergroup was toggled.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | has_aggressive_anti_spam_enabled | bool | New value of has_aggressive_anti_spam_enabled. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_event_has_aggressive_anti_spam_enabled_toggled.html).
+  """
+
+  defstruct "@type": "chatEventHasAggressiveAntiSpamEnabledToggled", "@extra": nil, has_aggressive_anti_spam_enabled: nil
 end
 defmodule ChatEventMessageEdited do
   @moduledoc  """
@@ -14000,6 +20493,20 @@ defmodule InputPassportElementErrorSourceTranslationFile do
   """
 
   defstruct "@type": "inputPassportElementErrorSourceTranslationFile", "@extra": nil, file_hash: nil
+end
+defmodule UpdateStorySendSucceeded do
+  @moduledoc  """
+  A story has been successfully sent.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | story | story | The sent story. |
+  | old_story_id | int32 | The previous temporary story identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_story_send_succeeded.html).
+  """
+
+  defstruct "@type": "updateStorySendSucceeded", "@extra": nil, story: nil, old_story_id: nil
 end
 defmodule UpdateMessageEdited do
   @moduledoc  """
@@ -14045,7 +20552,7 @@ defmodule UserPrivacySettingRules do
 end
 defmodule ThumbnailFormatGif do
   @moduledoc  """
-  The thumbnail is in static GIF format. It will be used only for some bot inline results.
+  The thumbnail is in static GIF format. It will be used only for some bot inline query results.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1thumbnail_format_gif.html).
@@ -14138,6 +20645,16 @@ defmodule ReplyMarkup do
 
   defstruct "@type": "ReplyMarkup", "@extra": nil
 end
+defmodule BusinessAwayMessageScheduleOutsideOfOpeningHours do
+  @moduledoc  """
+  Send away messages outside of the business opening hours.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_away_message_schedule_outside_of_opening_hours.html).
+  """
+
+  defstruct "@type": "businessAwayMessageScheduleOutsideOfOpeningHours", "@extra": nil
+end
 defmodule ChatEventLocationChanged do
   @moduledoc  """
   The supergroup location was changed.
@@ -14151,6 +20668,36 @@ defmodule ChatEventLocationChanged do
   """
 
   defstruct "@type": "chatEventLocationChanged", "@extra": nil, old_location: nil, new_location: nil
+end
+defmodule UpdateChatBlockList do
+  @moduledoc  """
+  A chat was blocked or unblocked.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | block_list | BlockList | Block list to which the chat is added; may be null if none. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_block_list.html).
+  """
+
+  defstruct "@type": "updateChatBlockList", "@extra": nil, chat_id: nil, block_list: nil
+end
+defmodule StoryInteractionInfo do
+  @moduledoc  """
+  Contains information about interactions with a story.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | view_count | int32 | Number of times the story was viewed. |
+  | forward_count | int32 | Number of times the story was forwarded; 0 if none or unknown. |
+  | reaction_count | int32 | Number of reactions added to the story; 0 if none or unknown. |
+  | recent_viewer_user_ids | int53 | Identifiers of at most 3 recent viewers of the story. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1story_interaction_info.html).
+  """
+
+  defstruct "@type": "storyInteractionInfo", "@extra": nil, view_count: nil, forward_count: nil, reaction_count: nil, recent_viewer_user_ids: nil
 end
 defmodule AnimatedChatPhoto do
   @moduledoc  """
@@ -14180,6 +20727,21 @@ defmodule RichTextPhoneNumber do
   """
 
   defstruct "@type": "richTextPhoneNumber", "@extra": nil, text: nil, phone_number: nil
+end
+defmodule Stories do
+  @moduledoc  """
+  Represents a list of stories.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Approximate total number of stories found. |
+  | stories | story | The list of stories. |
+  | pinned_story_ids | int32 | Identifiers of the pinned stories; returned only in <a class="el" href="classtd_1_1td__api_1_1get_chat_posted_to_chat_page_stories.html">getChatPostedToChatPageStories</a> with from_story_id == 0. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1stories.html).
+  """
+
+  defstruct "@type": "stories", "@extra": nil, total_count: nil, stories: nil, pinned_story_ids: nil
 end
 defmodule GroupCallRecentSpeaker do
   @moduledoc  """
@@ -14222,6 +20784,15 @@ defmodule DeepLinkInfo do
   """
 
   defstruct "@type": "deepLinkInfo", "@extra": nil, text: nil, need_update_application: nil
+end
+defmodule StorePaymentPurpose do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_store_payment_purpose.html).
+  """
+
+  defstruct "@type": "StorePaymentPurpose", "@extra": nil
 end
 defmodule NetworkTypeNone do
   @moduledoc  """
@@ -14299,7 +20870,7 @@ defmodule Proxy do
   | Name | Type | Description |
   |------|------| ------------|
   | id | int32 | Unique identifier of the proxy. |
-  | server | string | Proxy server IP address. |
+  | server | string | Proxy server domain or IP address. |
   | port | int32 | Proxy server port. |
   | last_used_date | int32 | Point in time (Unix timestamp) when the proxy was last used; 0 if never. |
   | is_enabled | bool | True, if the proxy is enabled now. |
@@ -14352,6 +20923,19 @@ defmodule InputChatPhoto do
 
   defstruct "@type": "InputChatPhoto", "@extra": nil
 end
+defmodule ChatBoostSourcePremium do
+  @moduledoc  """
+  A user with Telegram Premium subscription or gifted Telegram Premium boosted the chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | user_id | int53 | Identifier of the user. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_boost_source_premium.html).
+  """
+
+  defstruct "@type": "chatBoostSourcePremium", "@extra": nil, user_id: nil
+end
 defmodule StatisticalGraphData do
   @moduledoc  """
   A graph data.
@@ -14389,6 +20973,26 @@ defmodule PremiumFeatureUniqueReactions do
 
   defstruct "@type": "premiumFeatureUniqueReactions", "@extra": nil
 end
+defmodule FileTypeVideoStory do
+  @moduledoc  """
+  The file is a video published as a story.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1file_type_video_story.html).
+  """
+
+  defstruct "@type": "fileTypeVideoStory", "@extra": nil
+end
+defmodule PremiumLimitTypeChatFolderInviteLinkCount do
+  @moduledoc  """
+  The maximum number of invite links for a chat folder.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_limit_type_chat_folder_invite_link_count.html).
+  """
+
+  defstruct "@type": "premiumLimitTypeChatFolderInviteLinkCount", "@extra": nil
+end
 defmodule SessionTypeOpera do
   @moduledoc  """
   The session is running on the Opera browser.
@@ -14413,6 +21017,19 @@ defmodule KeyboardButtonTypeRequestPoll do
 
   defstruct "@type": "keyboardButtonTypeRequestPoll", "@extra": nil, force_regular: nil, force_quiz: nil
 end
+defmodule UpdateQuickReplyShortcuts do
+  @moduledoc  """
+  The list of quick reply shortcuts has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | shortcut_ids | int32 | The new list of identifiers of quick reply shortcuts. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_quick_reply_shortcuts.html).
+  """
+
+  defstruct "@type": "updateQuickReplyShortcuts", "@extra": nil, shortcut_ids: nil
+end
 defmodule UpdateUserPrivacySettingRules do
   @moduledoc  """
   Some privacy setting rules have been changed.
@@ -14427,19 +21044,6 @@ defmodule UpdateUserPrivacySettingRules do
 
   defstruct "@type": "updateUserPrivacySettingRules", "@extra": nil, setting: nil, rules: nil
 end
-defmodule MessageWebsiteConnected do
-  @moduledoc  """
-  The current user has connected a website by logging in using Telegram Login Widget on it.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | domain_name | string | Domain name of the connected website. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_website_connected.html).
-  """
-
-  defstruct "@type": "messageWebsiteConnected", "@extra": nil, domain_name: nil
-end
 defmodule NetworkTypeMobile do
   @moduledoc  """
   A mobile network.
@@ -14449,6 +21053,51 @@ defmodule NetworkTypeMobile do
   """
 
   defstruct "@type": "networkTypeMobile", "@extra": nil
+end
+defmodule MessageViewers do
+  @moduledoc  """
+  Represents a list of message viewers.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | viewers | messageViewer | List of message viewers. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_viewers.html).
+  """
+
+  defstruct "@type": "messageViewers", "@extra": nil, viewers: nil
+end
+defmodule StoryList do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_story_list.html).
+  """
+
+  defstruct "@type": "StoryList", "@extra": nil
+end
+defmodule EmojiStatuses do
+  @moduledoc  """
+  Contains a list of custom emoji identifiers for emoji statuses.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | custom_emoji_ids | int64 | The list of custom emoji identifiers. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_statuses.html).
+  """
+
+  defstruct "@type": "emojiStatuses", "@extra": nil, custom_emoji_ids: nil
+end
+defmodule BusinessFeatureStartPage do
+  @moduledoc  """
+  The ability to customize start page.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_feature_start_page.html).
+  """
+
+  defstruct "@type": "businessFeatureStartPage", "@extra": nil
 end
 defmodule ChatMembersFilterMention do
   @moduledoc  """
@@ -14486,6 +21135,21 @@ defmodule TextEntityTypeHashtag do
 
   defstruct "@type": "textEntityTypeHashtag", "@extra": nil
 end
+defmodule MessageOriginChannel do
+  @moduledoc  """
+  The message was originally a post in a channel.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Identifier of the channel chat to which the message was originally sent. |
+  | message_id | int53 | Message identifier of the original message. |
+  | author_signature | string | Original post author signature. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_origin_channel.html).
+  """
+
+  defstruct "@type": "messageOriginChannel", "@extra": nil, chat_id: nil, message_id: nil, author_signature: nil
+end
 defmodule PremiumFeatureDisabledAds do
   @moduledoc  """
   Disabled ads.
@@ -14510,6 +21174,19 @@ defmodule UpdateSupergroupFullInfo do
 
   defstruct "@type": "updateSupergroupFullInfo", "@extra": nil, supergroup_id: nil, supergroup_full_info: nil
 end
+defmodule PublicForwardMessage do
+  @moduledoc  """
+  Contains a public forward as a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | message | message | Information about the message. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1public_forward_message.html).
+  """
+
+  defstruct "@type": "publicForwardMessage", "@extra": nil, message: nil
+end
 defmodule MessageStatistics do
   @moduledoc  """
   A detailed statistics about a message.
@@ -14517,11 +21194,12 @@ defmodule MessageStatistics do
   | Name | Type | Description |
   |------|------| ------------|
   | message_interaction_graph | StatisticalGraph | A graph containing number of message views and shares. |
+  | message_reaction_graph | StatisticalGraph | A graph containing number of message reactions. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_statistics.html).
   """
 
-  defstruct "@type": "messageStatistics", "@extra": nil, message_interaction_graph: nil
+  defstruct "@type": "messageStatistics", "@extra": nil, message_interaction_graph: nil, message_reaction_graph: nil
 end
 defmodule InternalLinkTypeAuthenticationCode do
   @moduledoc  """
@@ -14551,6 +21229,19 @@ defmodule MaskPosition do
   """
 
   defstruct "@type": "maskPosition", "@extra": nil, point: nil, x_shift: nil, y_shift: nil, scale: nil
+end
+defmodule AutosaveSettingsScopeChat do
+  @moduledoc  """
+  Autosave settings applied to a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1autosave_settings_scope_chat.html).
+  """
+
+  defstruct "@type": "autosaveSettingsScopeChat", "@extra": nil, chat_id: nil
 end
 defmodule StickerSets do
   @moduledoc  """
@@ -14582,10 +21273,11 @@ defmodule Supergroup do
   | Name | Type | Description |
   |------|------| ------------|
   | id | int53 | Supergroup or channel identifier. |
-  | username | string | Username of the supergroup or channel; empty for private supergroups or channels. |
+  | usernames | usernames | Usernames of the supergroup or channel; may be null. |
   | date | int32 | Point in time (Unix timestamp) when the current user joined, or the point in time when the supergroup or channel was created, in case the user is not a member. |
-  | status | ChatMemberStatus | Status of the current user in the supergroup or channel; custom title will be always empty. |
-  | member_count | int32 | Number of members in the supergroup or channel; 0 if unknown. Currently, it is guaranteed to be known only if the supergroup or channel was received through <a class="el" href="classtd_1_1td__api_1_1search_public_chats.html">searchPublicChats</a>, <a class="el" href="classtd_1_1td__api_1_1search_chats_nearby.html">searchChatsNearby</a>, <a class="el" href="classtd_1_1td__api_1_1get_inactive_supergroup_chats.html">getInactiveSupergroupChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_suitable_discussion_chats.html">getSuitableDiscussionChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_groups_in_common.html">getGroupsInCommon</a>, or <a class="el" href="classtd_1_1td__api_1_1get_user_privacy_setting_rules.html">getUserPrivacySettingRules</a>. |
+  | status | ChatMemberStatus | Status of the current user in the supergroup or channel; custom title will always be empty. |
+  | member_count | int32 | Number of members in the supergroup or channel; 0 if unknown. Currently, it is guaranteed to be known only if the supergroup or channel was received through <a class="el" href="classtd_1_1td__api_1_1get_chat_similar_chats.html">getChatSimilarChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_chats_to_send_stories.html">getChatsToSendStories</a>, <a class="el" href="classtd_1_1td__api_1_1get_created_public_chats.html">getCreatedPublicChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_groups_in_common.html">getGroupsInCommon</a>, <a class="el" href="classtd_1_1td__api_1_1get_inactive_supergroup_chats.html">getInactiveSupergroupChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_recommended_chats.html">getRecommendedChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_suitable_discussion_chats.html">getSuitableDiscussionChats</a>, <a class="el" href="classtd_1_1td__api_1_1get_user_privacy_setting_rules.html">getUserPrivacySettingRules</a>, <a class="el" href="classtd_1_1td__api_1_1get_video_chat_available_participants.html">getVideoChatAvailableParticipants</a>, <a class="el" href="classtd_1_1td__api_1_1search_chats_nearby.html">searchChatsNearby</a>, <a class="el" href="classtd_1_1td__api_1_1search_public_chats.html">searchPublicChats</a>, or in chatFolderInviteLinkInfo.missing_chat_ids, or in userFullInfo.personal_chat_id, or for chats with messages or stories from <a class="el" href="classtd_1_1td__api_1_1public_forwards.html">publicForwards</a>. |
+  | boost_level | int32 | Approximate boost level for the chat. |
   | has_linked_chat | bool | True, if the channel has a discussion group, or the supergroup is the designated discussion group for a channel. |
   | has_location | bool | True, if the supergroup is connected to a location, i.e. the supergroup is a location-based supergroup. |
   | sign_messages | bool | True, if messages sent to the channel need to contain information about the sender. This field is only applicable to channels. |
@@ -14594,15 +21286,45 @@ defmodule Supergroup do
   | is_slow_mode_enabled | bool | True, if the slow mode is enabled in the supergroup. |
   | is_channel | bool | True, if the supergroup is a channel. |
   | is_broadcast_group | bool | True, if the supergroup is a broadcast group, i.e. only administrators can send messages and there is no limit on the number of members. |
+  | is_forum | bool | True, if the supergroup is a forum with topics. |
   | is_verified | bool | True, if the supergroup or channel is verified. |
   | restriction_reason | string | If non-empty, contains a human-readable description of the reason why access to this supergroup or channel must be restricted. |
   | is_scam | bool | True, if many users reported this supergroup or channel as a scam. |
   | is_fake | bool | True, if many users reported this supergroup or channel as a fake account. |
+  | has_active_stories | bool | True, if the supergroup or channel has non-expired stories available to the current user. |
+  | has_unread_active_stories | bool | True, if the supergroup or channel has unread non-expired stories available to the current user. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1supergroup.html).
   """
 
-  defstruct "@type": "supergroup", "@extra": nil, id: nil, username: nil, date: nil, status: nil, member_count: nil, has_linked_chat: nil, has_location: nil, sign_messages: nil, join_to_send_messages: nil, join_by_request: nil, is_slow_mode_enabled: nil, is_channel: nil, is_broadcast_group: nil, is_verified: nil, restriction_reason: nil, is_scam: nil, is_fake: nil
+  defstruct "@type": "supergroup", "@extra": nil, id: nil, usernames: nil, date: nil, status: nil, member_count: nil, boost_level: nil, has_linked_chat: nil, has_location: nil, sign_messages: nil, join_to_send_messages: nil, join_by_request: nil, is_slow_mode_enabled: nil, is_channel: nil, is_broadcast_group: nil, is_forum: nil, is_verified: nil, restriction_reason: nil, is_scam: nil, is_fake: nil, has_active_stories: nil, has_unread_active_stories: nil
+end
+defmodule UpdateAutosaveSettings do
+  @moduledoc  """
+  Autosave settings for some type of chats were updated.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | scope | AutosaveSettingsScope | Type of chats for which autosave settings were updated. |
+  | settings | scopeAutosaveSettings | The new autosave settings; may be null if the settings are reset to default. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_autosave_settings.html).
+  """
+
+  defstruct "@type": "updateAutosaveSettings", "@extra": nil, scope: nil, settings: nil
+end
+defmodule EmojiCategories do
+  @moduledoc  """
+  Represents a list of emoji categories.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | categories | emojiCategory | List of categories. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1emoji_categories.html).
+  """
+
+  defstruct "@type": "emojiCategories", "@extra": nil, categories: nil
 end
 defmodule NetworkStatisticsEntry do
   @moduledoc  """
@@ -14622,6 +21344,25 @@ defmodule PassportElement do
 
   defstruct "@type": "PassportElement", "@extra": nil
 end
+defmodule MessageExpiredVideoNote do
+  @moduledoc  """
+  A self-destructed video note message.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_expired_video_note.html).
+  """
+
+  defstruct "@type": "messageExpiredVideoNote", "@extra": nil
+end
+defmodule MessageReplyTo do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_message_reply_to.html).
+  """
+
+  defstruct "@type": "MessageReplyTo", "@extra": nil
+end
 defmodule AuthorizationStateClosed do
   @moduledoc  """
   TDLib client is in its final state. All databases are closed and all resources are released. No other updates will be received after this. All queries will be responded to with error code 500. To continue working, one must create a new instance of the TDLib client.
@@ -14632,6 +21373,26 @@ defmodule AuthorizationStateClosed do
 
   defstruct "@type": "authorizationStateClosed", "@extra": nil
 end
+defmodule ReactionNotificationSourceAll do
+  @moduledoc  """
+  Notifications for reactions are shown for all reactions.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1reaction_notification_source_all.html).
+  """
+
+  defstruct "@type": "reactionNotificationSourceAll", "@extra": nil
+end
+defmodule PremiumStoryFeatureCustomExpirationDuration do
+  @moduledoc  """
+  The ability to set custom expiration duration for stories.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_story_feature_custom_expiration_duration.html).
+  """
+
+  defstruct "@type": "premiumStoryFeatureCustomExpirationDuration", "@extra": nil
+end
 defmodule PremiumFeatureIncreasedUploadFileSize do
   @moduledoc  """
   Increased maximum upload file size.
@@ -14641,6 +21402,20 @@ defmodule PremiumFeatureIncreasedUploadFileSize do
   """
 
   defstruct "@type": "premiumFeatureIncreasedUploadFileSize", "@extra": nil
+end
+defmodule UpdateDefaultBackground do
+  @moduledoc  """
+  The default background has changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | for_dark_theme | bool | True, if default background for dark theme has changed. |
+  | background | background | The new default background; may be null. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_default_background.html).
+  """
+
+  defstruct "@type": "updateDefaultBackground", "@extra": nil, for_dark_theme: nil, background: nil
 end
 defmodule Audio do
   @moduledoc  """
@@ -14654,13 +21429,28 @@ defmodule Audio do
   | file_name | string | Original name of the file; as defined by the sender. |
   | mime_type | string | The MIME type of the file; as defined by the sender. |
   | album_cover_minithumbnail | minithumbnail | The minithumbnail of the album cover; may be null. |
-  | album_cover_thumbnail | thumbnail | The thumbnail of the album cover in JPEG format; as defined by the sender. The full size thumbnail is supposed to be extracted from the downloaded file; may be null. |
+  | album_cover_thumbnail | thumbnail | The thumbnail of the album cover in JPEG format; as defined by the sender. The full size thumbnail is supposed to be extracted from the downloaded audio file; may be null. |
+  | external_album_covers | thumbnail | Album cover variants to use if the downloaded audio file contains no album cover. Provided thumbnail dimensions are approximate. |
   | audio | file | File containing the audio. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1audio.html).
   """
 
-  defstruct "@type": "audio", "@extra": nil, duration: nil, title: nil, performer: nil, file_name: nil, mime_type: nil, album_cover_minithumbnail: nil, album_cover_thumbnail: nil, audio: nil
+  defstruct "@type": "audio", "@extra": nil, duration: nil, title: nil, performer: nil, file_name: nil, mime_type: nil, album_cover_minithumbnail: nil, album_cover_thumbnail: nil, external_album_covers: nil, audio: nil
+end
+defmodule MessageReactions do
+  @moduledoc  """
+  Contains a list of reactions added to a message.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | reactions | messageReaction | List of added reactions. |
+  | are_tags | bool | True, if the reactions are tags and Telegram Premium users can filter messages by them. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_reactions.html).
+  """
+
+  defstruct "@type": "messageReactions", "@extra": nil, reactions: nil, are_tags: nil
 end
 defmodule PageBlockTitle do
   @moduledoc  """
@@ -14674,6 +21464,15 @@ defmodule PageBlockTitle do
   """
 
   defstruct "@type": "pageBlockTitle", "@extra": nil, title: nil
+end
+defmodule PaymentFormType do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_payment_form_type.html).
+  """
+
+  defstruct "@type": "PaymentFormType", "@extra": nil
 end
 defmodule RichText do
   @moduledoc  """
@@ -14698,44 +21497,37 @@ defmodule UpdateTermsOfService do
 
   defstruct "@type": "updateTermsOfService", "@extra": nil, terms_of_service_id: nil, terms_of_service: nil
 end
-defmodule RecommendedChatFilters do
-  @moduledoc  """
-  Contains a list of recommended chat filters.
-
-  | Name | Type | Description |
-  |------|------| ------------|
-  | chat_filters | recommendedChatFilter | List of recommended chat filters. |
-
-  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1recommended_chat_filters.html).
-  """
-
-  defstruct "@type": "recommendedChatFilters", "@extra": nil, chat_filters: nil
-end
 defmodule ChatNotificationSettings do
   @moduledoc  """
-  Contains information about notification settings for a chat.
+  Contains information about notification settings for a chat or a forum topic.
 
   | Name | Type | Description |
   |------|------| ------------|
-  | use_default_mute_for | bool | If true, mute_for is ignored and the value for the relevant type of chat is used instead. |
+  | use_default_mute_for | bool | If true, the value for the relevant type of chat or the forum chat is used instead of mute_for. |
   | mute_for | int32 | Time left before notifications will be unmuted, in seconds. |
-  | use_default_sound | bool | If true, the value for the relevant type of chat is used instead of sound_id. |
-  | sound_id | int64 | Identifier of the notification sound to be played; 0 if sound is disabled. |
-  | use_default_show_preview | bool | If true, show_preview is ignored and the value for the relevant type of chat is used instead. |
+  | use_default_sound | bool | If true, the value for the relevant type of chat or the forum chat is used instead of sound_id. |
+  | sound_id | int64 | Identifier of the notification sound to be played for messages; 0 if sound is disabled. |
+  | use_default_show_preview | bool | If true, the value for the relevant type of chat or the forum chat is used instead of show_preview. |
   | show_preview | bool | True, if message content must be displayed in notifications. |
-  | use_default_disable_pinned_message_notifications | bool | If true, disable_pinned_message_notifications is ignored and the value for the relevant type of chat is used instead. |
+  | use_default_mute_stories | bool | If true, the value for the relevant type of chat is used instead of mute_stories. |
+  | mute_stories | bool | True, if story notifications are disabled for the chat. |
+  | use_default_story_sound | bool | If true, the value for the relevant type of chat is used instead of story_sound_id. |
+  | story_sound_id | int64 | Identifier of the notification sound to be played for stories; 0 if sound is disabled. |
+  | use_default_show_story_sender | bool | If true, the value for the relevant type of chat is used instead of show_story_sender. |
+  | show_story_sender | bool | True, if the sender of stories must be displayed in notifications. |
+  | use_default_disable_pinned_message_notifications | bool | If true, the value for the relevant type of chat or the forum chat is used instead of disable_pinned_message_notifications. |
   | disable_pinned_message_notifications | bool | If true, notifications for incoming pinned messages will be created as for an ordinary unread message. |
-  | use_default_disable_mention_notifications | bool | If true, disable_mention_notifications is ignored and the value for the relevant type of chat is used instead. |
+  | use_default_disable_mention_notifications | bool | If true, the value for the relevant type of chat or the forum chat is used instead of disable_mention_notifications. |
   | disable_mention_notifications | bool | If true, notifications for messages with mentions will be created as for an ordinary unread message. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_notification_settings.html).
   """
 
-  defstruct "@type": "chatNotificationSettings", "@extra": nil, use_default_mute_for: nil, mute_for: nil, use_default_sound: nil, sound_id: nil, use_default_show_preview: nil, show_preview: nil, use_default_disable_pinned_message_notifications: nil, disable_pinned_message_notifications: nil, use_default_disable_mention_notifications: nil, disable_mention_notifications: nil
+  defstruct "@type": "chatNotificationSettings", "@extra": nil, use_default_mute_for: nil, mute_for: nil, use_default_sound: nil, sound_id: nil, use_default_show_preview: nil, show_preview: nil, use_default_mute_stories: nil, mute_stories: nil, use_default_story_sound: nil, story_sound_id: nil, use_default_show_story_sender: nil, show_story_sender: nil, use_default_disable_pinned_message_notifications: nil, disable_pinned_message_notifications: nil, use_default_disable_mention_notifications: nil, disable_mention_notifications: nil
 end
 defmodule MessageSchedulingStateSendWhenOnline do
   @moduledoc  """
-  The message will be sent when the peer will be online. Applicable to private chats only and when the exact online status of the peer is known.
+  The message will be sent when the other user is online. Applicable to private chats only and when the exact online status of the other user is known.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_scheduling_state_send_when_online.html).
@@ -14769,6 +21561,15 @@ defmodule TextParseModeMarkdown do
 
   defstruct "@type": "textParseModeMarkdown", "@extra": nil, version: nil
 end
+defmodule ChatAvailableReactions do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_chat_available_reactions.html).
+  """
+
+  defstruct "@type": "ChatAvailableReactions", "@extra": nil
+end
 defmodule JsonValueBoolean do
   @moduledoc  """
   Represents a boolean JSON value.
@@ -14781,6 +21582,21 @@ defmodule JsonValueBoolean do
   """
 
   defstruct "@type": "jsonValueBoolean", "@extra": nil, value: nil
+end
+defmodule ChatFolderInviteLink do
+  @moduledoc  """
+  Contains a chat folder invite link.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | invite_link | string | The chat folder invite link. |
+  | name | string | Name of the link. |
+  | chat_ids | int53 | Identifiers of chats, included in the link. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_folder_invite_link.html).
+  """
+
+  defstruct "@type": "chatFolderInviteLink", "@extra": nil, invite_link: nil, name: nil, chat_ids: nil
 end
 defmodule MessageSenderUser do
   @moduledoc  """
@@ -14828,11 +21644,27 @@ defmodule PaymentProviderSmartGlocal do
   | Name | Type | Description |
   |------|------| ------------|
   | public_token | string | Public payment token. |
+  | tokenize_url | string | URL for sending card tokenization requests. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1payment_provider_smart_glocal.html).
   """
 
-  defstruct "@type": "paymentProviderSmartGlocal", "@extra": nil, public_token: nil
+  defstruct "@type": "paymentProviderSmartGlocal", "@extra": nil, public_token: nil, tokenize_url: nil
+end
+defmodule FoundChatBoosts do
+  @moduledoc  """
+  Contains a list of boosts applied to a chat.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | total_count | int32 | Total number of boosts applied to the chat. |
+  | boosts | chatBoost | List of boosts. |
+  | next_offset | string | The offset for the next request. If empty, then there are no more results. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1found_chat_boosts.html).
+  """
+
+  defstruct "@type": "foundChatBoosts", "@extra": nil, total_count: nil, boosts: nil, next_offset: nil
 end
 defmodule Call do
   @moduledoc  """
@@ -14841,7 +21673,7 @@ defmodule Call do
   | Name | Type | Description |
   |------|------| ------------|
   | id | int32 | Call identifier, not persistent. |
-  | user_id | int53 | Peer user identifier. |
+  | user_id | int53 | User identifier of the other call participant. |
   | is_outgoing | bool | True, if the call is outgoing. |
   | is_video | bool | True, if the call is a video call. |
   | state | CallState | Call state. |
@@ -14861,23 +21693,36 @@ defmodule PassportElementTypeEmailAddress do
 
   defstruct "@type": "passportElementTypeEmailAddress", "@extra": nil
 end
+defmodule InputBusinessChatLink do
+  @moduledoc  """
+  Describes a business chat link to create or edit.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | text | formattedText | Message draft text that will be added to the input field. |
+  | title | string | Link title. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1input_business_chat_link.html).
+  """
+
+  defstruct "@type": "inputBusinessChatLink", "@extra": nil, text: nil, title: nil
+end
 defmodule VoiceNote do
   @moduledoc  """
-  Describes a voice note. The voice note must be encoded with the Opus codec, and stored inside an OGG container. Voice notes can have only a single audio channel.
+  Describes a voice note.
 
   | Name | Type | Description |
   |------|------| ------------|
   | duration | int32 | Duration of the voice note, in seconds; as defined by the sender. |
   | waveform | bytes | A waveform representation of the voice note in 5-bit format. |
-  | mime_type | string | MIME type of the file; as defined by the sender. |
-  | is_recognized | bool | True, if speech recognition is completed; Premium users only. |
-  | recognized_text | string | Recognized text of the voice note; Premium users only. Call <a class="el" href="classtd_1_1td__api_1_1recognize_speech.html">recognizeSpeech</a> to get recognized text of the voice note. |
+  | mime_type | string | MIME type of the file; as defined by the sender. Usually, one of "audio/ogg" for Opus in an OGG container, "audio/mpeg" for an MP3 audio, or "audio/mp4" for an M4A audio. |
+  | speech_recognition_result | SpeechRecognitionResult | Result of speech recognition in the voice note; may be null. |
   | voice | file | File containing the voice note. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1voice_note.html).
   """
 
-  defstruct "@type": "voiceNote", "@extra": nil, duration: nil, waveform: nil, mime_type: nil, is_recognized: nil, recognized_text: nil, voice: nil
+  defstruct "@type": "voiceNote", "@extra": nil, duration: nil, waveform: nil, mime_type: nil, speech_recognition_result: nil, voice: nil
 end
 defmodule PassportElementError do
   @moduledoc  """
@@ -14894,6 +21739,32 @@ defmodule PassportElementError do
 
   defstruct "@type": "passportElementError", "@extra": nil, type: nil, message: nil, source: nil
 end
+defmodule UpdateBusinessConnection do
+  @moduledoc  """
+  A business connection has changed; for bots only.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | connection | businessConnection | New data about the connection. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_business_connection.html).
+  """
+
+  defstruct "@type": "updateBusinessConnection", "@extra": nil, connection: nil
+end
+defmodule SpeechRecognitionResultPending do
+  @moduledoc  """
+  The speech recognition is ongoing.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | partial_text | string | Partially recognized text. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1speech_recognition_result_pending.html).
+  """
+
+  defstruct "@type": "speechRecognitionResultPending", "@extra": nil, partial_text: nil
+end
 defmodule FormattedText do
   @moduledoc  """
   A text with some entities.
@@ -14901,7 +21772,7 @@ defmodule FormattedText do
   | Name | Type | Description |
   |------|------| ------------|
   | text | string | The text. |
-  | entities | textEntity | Entities contained in the text. Entities can be nested, but must not mutually intersect with each other. Pre, Code and PreCode entities can't contain other entities. Bold, Italic, Underline, Strikethrough, and Spoiler entities can contain and to be contained in all other entities. All other entities can't contain each other. |
+  | entities | textEntity | Entities contained in the text. Entities can be nested, but must not mutually intersect with each other. Pre, Code and PreCode entities can't contain other entities. BlockQuote entities can't contain other BlockQuote entities. Bold, Italic, Underline, Strikethrough, and Spoiler entities can contain and can be part of any other entities. All other entities can't contain each other. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1formatted_text.html).
   """
@@ -14932,8 +21803,8 @@ defmodule InputMessagePoll do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | question | string | Poll question; 1-255 characters (up to 300 characters for bots). |
-  | options | string | List of poll answer options, 2-10 strings 1-100 characters each. |
+  | question | formattedText | Poll question; 1-255 characters (up to 300 characters for bots). Only custom emoji entities are allowed to be added and only by Premium users. |
+  | options | formattedText | List of poll answer options, 2-10 strings 1-100 characters each. Only custom emoji entities are allowed to be added and only by Premium users. |
   | is_anonymous | bool | True, if the poll voters are anonymous. Non-anonymous polls can't be sent or forwarded to channels. |
   | type | PollType | Type of the poll. |
   | open_period | int32 | Amount of time the poll will be active after creation, in seconds; for bots only. |
@@ -14945,6 +21816,20 @@ defmodule InputMessagePoll do
 
   defstruct "@type": "inputMessagePoll", "@extra": nil, question: nil, options: nil, is_anonymous: nil, type: nil, open_period: nil, close_date: nil, is_closed: nil
 end
+defmodule BusinessOpeningHoursInterval do
+  @moduledoc  """
+  Describes an interval of time when the business is open.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | start_minute | int32 | The minute's sequence number in a week, starting on Monday, marking the start of the time interval during which the business is open; 0-7*24*60. |
+  | end_minute | int32 | The minute's sequence number in a week, starting on Monday, marking the end of the time interval during which the business is open; 1-8*24*60. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1business_opening_hours_interval.html).
+  """
+
+  defstruct "@type": "businessOpeningHoursInterval", "@extra": nil, start_minute: nil, end_minute: nil
+end
 defmodule ChatPhoto do
   @moduledoc  """
   Describes a chat or user profile photo.
@@ -14955,13 +21840,14 @@ defmodule ChatPhoto do
   | added_date | int32 | Point in time (Unix timestamp) when the photo has been added. |
   | minithumbnail | minithumbnail | Photo minithumbnail; may be null. |
   | sizes | photoSize | Available variants of the photo in JPEG format, in different size. |
-  | animation | animatedChatPhoto | A big (640x640) animated variant of the photo in MPEG4 format; may be null. |
+  | animation | animatedChatPhoto | A big (up to 1280x1280) animated variant of the photo in MPEG4 format; may be null. |
   | small_animation | animatedChatPhoto | A small (160x160) animated variant of the photo in MPEG4 format; may be null even the big animation is available. |
+  | sticker | chatPhotoSticker | Sticker-based version of the chat photo; may be null. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1chat_photo.html).
   """
 
-  defstruct "@type": "chatPhoto", "@extra": nil, id: nil, added_date: nil, minithumbnail: nil, sizes: nil, animation: nil, small_animation: nil
+  defstruct "@type": "chatPhoto", "@extra": nil, id: nil, added_date: nil, minithumbnail: nil, sizes: nil, animation: nil, small_animation: nil, sticker: nil
 end
 defmodule MessageChatDeletePhoto do
   @moduledoc  """
@@ -14972,6 +21858,20 @@ defmodule MessageChatDeletePhoto do
   """
 
   defstruct "@type": "messageChatDeletePhoto", "@extra": nil
+end
+defmodule UpdateChatMessageAutoDeleteTime do
+  @moduledoc  """
+  The message auto-delete or self-destruct timer setting for a chat was changed.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | chat_id | int53 | Chat identifier. |
+  | message_auto_delete_time | int32 | New value of message_auto_delete_time. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1update_chat_message_auto_delete_time.html).
+  """
+
+  defstruct "@type": "updateChatMessageAutoDeleteTime", "@extra": nil, chat_id: nil, message_auto_delete_time: nil
 end
 defmodule ChatActionChoosingLocation do
   @moduledoc  """
@@ -14989,7 +21889,7 @@ defmodule MessageSchedulingStateSendAtDate do
 
   | Name | Type | Description |
   |------|------| ------------|
-  | send_date | int32 | Date the message will be sent. The date must be within 367 days in the future. |
+  | send_date | int32 | Point in time (Unix timestamp) when the message will be sent. The date must be within 367 days in the future. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_scheduling_state_send_at_date.html).
   """
@@ -15003,7 +21903,7 @@ defmodule IdentityDocument do
   | Name | Type | Description |
   |------|------| ------------|
   | number | string | Document number; 1-24 characters. |
-  | expiry_date | date | Document expiry date; may be null if not applicable. |
+  | expiration_date | date | Document expiration date; may be null if not applicable. |
   | front_side | datedFile | Front side of the document. |
   | reverse_side | datedFile | Reverse side of the document; only for driver license and identity card; may be null. |
   | selfie | datedFile | Selfie with the document; may be null. |
@@ -15012,7 +21912,7 @@ defmodule IdentityDocument do
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1identity_document.html).
   """
 
-  defstruct "@type": "identityDocument", "@extra": nil, number: nil, expiry_date: nil, front_side: nil, reverse_side: nil, selfie: nil, translation: nil
+  defstruct "@type": "identityDocument", "@extra": nil, number: nil, expiration_date: nil, front_side: nil, reverse_side: nil, selfie: nil, translation: nil
 end
 defmodule FileDownloadedPrefixSize do
   @moduledoc  """
@@ -15046,7 +21946,7 @@ defmodule DiceStickersSlotMachine do
 end
 defmodule UserPrivacySettingRuleRestrictContacts do
   @moduledoc  """
-  A rule to restrict all contacts of a user from doing something.
+  A rule to restrict all contacts of the user from doing something.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1user_privacy_setting_rule_restrict_contacts.html).
@@ -15068,6 +21968,16 @@ defmodule MessagePositions do
 
   defstruct "@type": "messagePositions", "@extra": nil, total_count: nil, positions: nil
 end
+defmodule StarTransactionPartnerUnsupported do
+  @moduledoc  """
+  The transaction is a transaction with unknown partner.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1star_transaction_partner_unsupported.html).
+  """
+
+  defstruct "@type": "starTransactionPartnerUnsupported", "@extra": nil
+end
 defmodule GroupCallStream do
   @moduledoc  """
   Describes an available stream in a group call.
@@ -15085,7 +21995,7 @@ defmodule GroupCallStream do
 end
 defmodule InternalLinkTypeActiveSessions do
   @moduledoc  """
-  The link is a link to the active sessions section of the application. Use getActiveSessions to handle the link.
+  The link is a link to the Devices section of the application. Use getActiveSessions to get the list of active sessions and show them to the user.
 
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1internal_link_type_active_sessions.html).
@@ -15107,6 +22017,24 @@ defmodule UpdateChatUnreadReactionCount do
 
   defstruct "@type": "updateChatUnreadReactionCount", "@extra": nil, chat_id: nil, unread_reaction_count: nil
 end
+defmodule PremiumGiveawayInfoCompleted do
+  @moduledoc  """
+  Describes a completed giveaway.
+
+  | Name | Type | Description |
+  |------|------| ------------|
+  | creation_date | int32 | Point in time (Unix timestamp) when the giveaway was created. |
+  | actual_winners_selection_date | int32 | Point in time (Unix timestamp) when the winners were selected. May be bigger than winners selection date specified in parameters of the giveaway. |
+  | was_refunded | bool | True, if the giveaway was canceled and was fully refunded. |
+  | winner_count | int32 | Number of winners in the giveaway. |
+  | activation_count | int32 | Number of winners, which activated their gift codes. |
+  | gift_code | string | Telegram Premium gift code that was received by the current user; empty if the user isn't a winner in the giveaway. |
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1premium_giveaway_info_completed.html).
+  """
+
+  defstruct "@type": "premiumGiveawayInfoCompleted", "@extra": nil, creation_date: nil, actual_winners_selection_date: nil, was_refunded: nil, winner_count: nil, activation_count: nil, gift_code: nil
+end
 defmodule MessageAnimation do
   @moduledoc  """
   An animation message (GIF-style).
@@ -15115,16 +22043,18 @@ defmodule MessageAnimation do
   |------|------| ------------|
   | animation | animation | The animation description. |
   | caption | formattedText | Animation caption. |
+  | show_caption_above_media | bool | True, if caption must be shown above the animation; otherwise, caption must be shown below the animation. |
+  | has_spoiler | bool | True, if the animation preview must be covered by a spoiler animation. |
   | is_secret | bool | True, if the animation thumbnail must be blurred and the animation must be shown only while tapped. |
 
   More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1message_animation.html).
   """
 
-  defstruct "@type": "messageAnimation", "@extra": nil, animation: nil, caption: nil, is_secret: nil
+  defstruct "@type": "messageAnimation", "@extra": nil, animation: nil, caption: nil, show_caption_above_media: nil, has_spoiler: nil, is_secret: nil
 end
 defmodule InputChatPhotoAnimation do
   @moduledoc  """
-  An animation in MPEG4 format; must be square, at most 10 seconds long, have width between 160 and 800 and be at most 2MB in size.
+  An animation in MPEG4 format; must be square, at most 10 seconds long, have width between 160 and 1280 and be at most 2MB in size.
 
   | Name | Type | Description |
   |------|------| ------------|
@@ -15135,6 +22065,16 @@ defmodule InputChatPhotoAnimation do
   """
 
   defstruct "@type": "inputChatPhotoAnimation", "@extra": nil, animation: nil, main_frame_timestamp: nil
+end
+defmodule ReportReasonFake do
+  @moduledoc  """
+  The chat represents a fake account.
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1report_reason_fake.html).
+  """
+
+  defstruct "@type": "reportReasonFake", "@extra": nil
 end
 defmodule Photo do
   @moduledoc  """
@@ -15174,6 +22114,15 @@ defmodule DeviceTokenApplePush do
   """
 
   defstruct "@type": "deviceTokenApplePush", "@extra": nil, device_token: nil, is_app_sandbox: nil
+end
+defmodule ReactionNotificationSource do
+  @moduledoc  """
+
+
+  More details on [telegram's documentation](https://core.telegram.org/tdlib/docs/classtd_1_1td__api_1_1_reaction_notification_source.html).
+  """
+
+  defstruct "@type": "ReactionNotificationSource", "@extra": nil
 end
 defmodule Error do
   @moduledoc  """

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm", "00e3ebdc821fb3a36957320d49e8f4bfa310d73ea31c90e5f925dc75e030da8f"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "tdlib_json_cli": {:git, "https://github.com/PushSMS/tdlib-json-cli", "ad3300d1b7d327df7950e027ba670cd93ac30026", [submodules: true]},
+  "tdlib_json_cli": {:git, "https://github.com/PushSMS/tdlib-json-cli", "37238cc696771fd91808ff5afbaeed471facfcd5", [submodules: true]},
 }


### PR DESCRIPTION
На основе последней версии tdlib 1.8.31 https://github.com/tdlib/td/tree/63c7d0301825b78c30dc7307f1f1466be049eb79 командой `mix generate_types` перегенерены файлы `lib/tdlib/method.ex` и `lib/tdlib/object.ex` ([подробне о генерации тут ](https://www.notion.so/Tdlib-f7609bb0e3b648518cf7f4a9a8e931e6)).

Также пришлось поправить пару мелочей, связанных тем как работает новая версия.