### PR TITLE
[CORE-1903] maybe auth fix

### DIFF
--- a/lib/tdlib.ex
+++ b/lib/tdlib.ex
@@ -41,7 +41,10 @@ defmodule TDLib do
   def default_config(), do: @default_config
 
   @doc """
-  Open a new session. Spawns a new instance of `tdlib-json-cli`.
+  Open a session or reconnect an existing one.
+
+  If a session with `session_name` already exists, its `client_pid`, `config`,
+  and `encryption_key` are updated without restarting the TDLib backend.
 
   * `session_name` is the identifier of the session
   * `client_pid` is the PID of the process receiving the incoming messages

--- a/lib/tdlib/handler.ex
+++ b/lib/tdlib/handler.ex
@@ -7,6 +7,8 @@ defmodule TDLib.Handler do
   alias TDLib.StateHolder
 
   @disable_handling Application.compile_env(:tdlib, :disable_handling)
+  @backend_ready_retry_ms 20
+  @backend_ready_max_attempts 100
 
   def start_link(session_name) do
     GenServer.start_link(__MODULE__, session_name, [])
@@ -19,7 +21,13 @@ defmodule TDLib.Handler do
 
   def handle_continue(:init, session_name) do
     StateHolder.update_state(session_name, %{handler_pid: self()})
+    sync_authorization_state(session_name, 0)
     {:noreply, session_name}
+  end
+
+  def handle_info({:sync_auth_state, attempt}, session) do
+    sync_authorization_state(session, attempt)
+    {:noreply, session}
   end
 
   def handle_info({:tdlib, msg}, session) do
@@ -47,44 +55,97 @@ defmodule TDLib.Handler do
   def handle_object(json, session) do
     type = Map.get(json, "@type")
 
-    struct =
-      try do
-        recursive_match(:object, json, "Elixir.TDLib.Object.")
-      rescue
-        _ -> nil
-      end
+    case decode_tdlib_object(json) do
+      nil ->
+        Logger.error("#{session}: no matching object found: #{inspect(type)}")
 
-    if struct do
-      Logger.info("#{session}: received object #{type}")
+      object ->
+        object
+        |> maybe_wrap_authorization_state()
+        |> then(&deliver_object(session, &1))
+    end
+  end
 
-      unless @disable_handling do
-        case struct do
-          %Object.Error{code: code, message: message} ->
-            Logger.error("#{session}: error #{code} - #{message}")
-
-          %Object.UpdateAuthorizationState{} ->
-            case struct.authorization_state do
-              %Object.AuthorizationStateWaitTdlibParameters{} ->
-                config = StateHolder.get_state(session) |> Map.get(:config)
-                transmit(session, struct(Method.SetTdlibParameters, config))
-
-              _ ->
-                :ignore
-            end
-
-          _ ->
-            :ignore
-        end
-      end
-
-      # Forward to client
-      client_pid = StateHolder.get_state(session) |> Map.get(:client_pid)
-
-      if is_pid(client_pid) and Process.alive?(client_pid) do
-        Kernel.send(client_pid, {:recv, struct})
-      end
+  defp maybe_wrap_authorization_state(%{__struct__: module} = object) do
+    if authorization_state_module?(module) do
+      %Object.UpdateAuthorizationState{authorization_state: object}
     else
-      Logger.error("No matching object found: #{inspect(type)}")
+      object
+    end
+  end
+
+  defp authorization_state_module?(module) do
+    module != Object.AuthorizationState &&
+      module
+      |> Module.split()
+      |> List.last()
+      |> String.starts_with?("AuthorizationState")
+  end
+
+  defp decode_tdlib_object(json) do
+    try do
+      recursive_match(:object, json, "Elixir.TDLib.Object.")
+    rescue
+      exception ->
+        Logger.warning(
+          "Failed to decode TDLib object #{inspect(Map.get(json, "@type"))}: #{Exception.message(exception)}"
+        )
+
+        nil
+    end
+  end
+
+  defp deliver_object(session, object) do
+    type = Map.get(object, :"@type")
+    Logger.info("#{session}: received object #{type}")
+
+    case object do
+      %Object.Error{code: code, message: message} ->
+        Logger.error("#{session}: error #{code} - #{message}")
+
+      %Object.UpdateAuthorizationState{} ->
+        unless @disable_handling, do: maybe_apply_library_side_effects(session, object)
+
+      _ ->
+        :ok
+    end
+
+    forward_to_client(session, object)
+  end
+
+  defp maybe_apply_library_side_effects(session, %Object.UpdateAuthorizationState{
+         authorization_state: %Object.AuthorizationStateWaitTdlibParameters{}
+       }) do
+    config = StateHolder.get_state(session) |> Map.get(:config)
+    transmit(session, struct(Method.SetTdlibParameters, config))
+  end
+
+  defp maybe_apply_library_side_effects(_session, %Object.UpdateAuthorizationState{}), do: :ok
+
+  defp forward_to_client(session, object) do
+    client_pid = StateHolder.get_state(session) |> Map.get(:client_pid)
+
+    if is_pid(client_pid) and Process.alive?(client_pid) do
+      Kernel.send(client_pid, {:recv, object})
+    end
+  end
+
+  defp sync_authorization_state(session_name, attempt) do
+    case StateHolder.get_state(session_name) |> Map.get(:backend_pid) do
+      pid when is_pid(pid) ->
+        transmit(session_name, %Method.GetAuthorizationState{"@extra": "sync_auth_state"})
+
+      _ when attempt < @backend_ready_max_attempts ->
+        Process.send_after(
+          self(),
+          {:sync_auth_state, attempt + 1},
+          @backend_ready_retry_ms
+        )
+
+      _ ->
+        Logger.error(
+          "#{session_name}: backend not ready after #{attempt} attempts, skipping GetAuthorizationState"
+        )
     end
   end
 
@@ -96,10 +157,17 @@ defmodule TDLib.Handler do
       |> Map.delete(:__struct__)
       |> Jason.encode!()
 
-    backend_pid = StateHolder.get_state(session) |> Map.get(:backend_pid)
+    type = Map.get(map, :"@type")
 
-    Logger.info("#{session}: sending #{Map.get(map, :"@type")}")
-    GenServer.call(backend_pid, {:transmit, msg})
+    case StateHolder.get_state(session) |> Map.get(:backend_pid) do
+      pid when is_pid(pid) ->
+        Logger.info("#{session}: sending #{type}")
+        GenServer.call(pid, {:transmit, msg})
+
+      _ ->
+        Logger.warning("#{session}: backend not ready, cannot send #{type}")
+        {:error, :backend_not_ready}
+    end
   end
 
   defp recursive_match(:object, json, prefix) do

--- a/lib/tdlib/session_supervisor.ex
+++ b/lib/tdlib/session_supervisor.ex
@@ -1,7 +1,7 @@
 defmodule TDLib.SessionSupervisor do
   use DynamicSupervisor
 
-  alias TDLib.Session
+  alias TDLib.{Session, StateHolder}
 
   def start_link(_) do
     DynamicSupervisor.start_link(__MODULE__, 0, name: __MODULE__)
@@ -13,8 +13,12 @@ defmodule TDLib.SessionSupervisor do
 
   def find_or_create(session_name, params) do
     case Session.build_name(session_name) |> GenServer.whereis() do
-      pid when is_pid(pid) -> {:ok, pid}
-      _ -> create(session_name, params)
+      pid when is_pid(pid) ->
+        StateHolder.update_state(session_name, Map.take(params, [:client_pid, :config, :encryption_key]))
+        {:ok, pid}
+
+      _ ->
+        create(session_name, params)
     end
   end
 

--- a/test/tdlib/handler_test.exs
+++ b/test/tdlib/handler_test.exs
@@ -1,0 +1,88 @@
+defmodule TDLib.HandlerTest do
+  use ExUnit.Case
+
+  alias TDLib.{Handler, Object, StateHolder}
+
+  defmodule FakeBackend do
+    use GenServer
+
+    def start_link(parent), do: GenServer.start_link(__MODULE__, parent)
+
+    def init(parent), do: {:ok, parent}
+
+    def handle_call({:transmit, msg}, _from, parent) do
+      send(parent, {:transmitted, msg})
+      {:reply, :ok, parent}
+    end
+  end
+
+  setup do
+    session = :"handler_test_#{System.unique_integer()}"
+
+    {:ok, state_holder_pid} =
+      StateHolder.start_link(session, %{
+        config: TDLib.default_config(),
+        client_pid: self(),
+        encryption_key: ""
+      })
+
+    on_exit(fn ->
+      if Process.alive?(state_holder_pid), do: Agent.stop(state_holder_pid)
+    end)
+
+    {:ok, session: session}
+  end
+
+  test "wraps bare authorization state as UpdateAuthorizationState", %{session: session} do
+    json = %{"@type" => "authorizationStateReady"}
+
+    Handler.handle_object(json, session)
+
+    assert_receive {:recv, %Object.UpdateAuthorizationState{
+                      authorization_state: %Object.AuthorizationStateReady{}
+                    }}
+  end
+
+  test "forwards UpdateAuthorizationState without re-wrapping", %{session: session} do
+    json = %{
+      "@type" => "updateAuthorizationState",
+      "authorization_state" => %{"@type" => "authorizationStateReady"}
+    }
+
+    Handler.handle_object(json, session)
+
+    assert_receive {:recv, %Object.UpdateAuthorizationState{
+                      authorization_state: %Object.AuthorizationStateReady{}
+                    }}
+  end
+
+  test "logs and forwards TDLib errors", %{session: session} do
+    json = %{"@type" => "error", "code" => 401, "message" => "Unauthorized"}
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        Handler.handle_object(json, session)
+      end)
+
+    assert log =~ "error 401 - Unauthorized"
+
+    assert_receive {:recv, %Object.Error{code: 401, message: "Unauthorized"}}
+  end
+
+  test "waits for backend_pid before GetAuthorizationState", %{session: session} do
+    {:ok, handler_pid} = Handler.start_link(session)
+    on_exit(fn -> if Process.alive?(handler_pid), do: GenServer.stop(handler_pid) end)
+
+    Process.sleep(50)
+    assert Process.alive?(handler_pid)
+    refute_received {:transmitted, _}
+
+    {:ok, backend_pid} = FakeBackend.start_link(self())
+    on_exit(fn -> if Process.alive?(backend_pid), do: GenServer.stop(backend_pid) end)
+
+    StateHolder.update_state(session, %{backend_pid: backend_pid})
+
+    assert_receive {:transmitted, msg}, 500
+    assert Jason.decode!(msg)["@type"] == "getAuthorizationState"
+  end
+end

--- a/test/tdlib_test.exs
+++ b/test/tdlib_test.exs
@@ -1,7 +1,6 @@
 defmodule TDLibTest do
-  alias TDLib.{Object, Method}
+  alias TDLib.{Object, Method, Session, StateHolder}
   alias TDLib.Object.UpdateAuthorizationState
-  alias TDLib.SessionRegistry, as: Registry
   use ExUnit.Case
   doctest TDLib
 
@@ -11,23 +10,19 @@ defmodule TDLibTest do
     assert 1 == 1
   end
 
+  @tag :integration
   test "Session management" do
-    # Ensure the registry is empty
-    assert Enum.count(Registry.dump) == 0
+    assert Session.build_name(@session) |> GenServer.whereis() == nil
 
-    # Open a new session
-    {:ok, _pid} = TDLib.open @session, self(), TDLib.default_config()
+    {:ok, pid} = TDLib.open(@session, self(), TDLib.default_config())
 
     assert wait_for_authstate() == "authorizationStateWaitTdlibParameters"
-    assert Enum.count(Registry.dump) == 1
-    assert Registry.get(@session) |> Map.get(:client_pid) == self()
+    assert Session.build_name(@session) |> GenServer.whereis() == pid
+    assert StateHolder.get_state(@session).client_pid == self()
 
-    # Close the session
     TDLib.close(@session)
 
-
-    # Ensure the registry is empty again
-    assert Enum.count(Registry.dump) == 0
+    assert Session.build_name(@session) |> GenServer.whereis() == nil
   end
 
   @tag :manual
@@ -37,9 +32,11 @@ defmodule TDLibTest do
     {api_id, _} = IO.gets("Please provide API id: ") |> Integer.parse()
     api_hash = IO.gets("Please provide API hash: ") |> String.trim()
 
-    config = struct(
-      TDLib.default_config(), %{api_id: api_id, api_hash: api_hash}
-    )
+    config =
+      struct(
+        TDLib.default_config(),
+        %{api_id: api_id, api_hash: api_hash}
+      )
 
     # Open a new session
     {:ok, _pid} = TDLib.open(@session, self(), config)
@@ -48,27 +45,33 @@ defmodule TDLibTest do
     assert wait_for_authstate() == "authorizationStateWaitEncryptionKey"
 
     case wait_for_authstate() do
-      "authorizationStateReady" -> :ok
+      "authorizationStateReady" ->
+        :ok
+
       "authorizationStateWaitPhoneNumber" ->
-        phone_number = IO.gets("Please provide phone number: ") |> String.trim
+        phone_number = IO.gets("Please provide phone number: ") |> String.trim()
+
         query = %Method.SetAuthenticationPhoneNumber{
           phone_number: phone_number,
           settings: %Object.PhoneNumberAuthenticationSettings{
             allow_flash_call: false
           }
         }
-        TDLib.transmit @session, query
+
+        TDLib.transmit(@session, query)
 
         assert wait_for_authstate() == "authorizationStateWaitCode"
 
         code = IO.gets("Please authentication code: ") |> String.trim()
         query = %Method.CheckAuthenticationCode{code: code}
-        TDLib.transmit @session, query
+        TDLib.transmit(@session, query)
 
         assert wait_for_authstate() == "authorizationStateReady"
-        # ^ The user has been successfully authorized. TDLib is now ready to answer
-        # queries.
-      other_state -> raise("Unexpected #{other_state} received")
+
+      # ^ The user has been successfully authorized. TDLib is now ready to answer
+      # queries.
+      other_state ->
+        raise("Unexpected #{other_state} received")
     end
 
     # Close
@@ -80,7 +83,7 @@ defmodule TDLibTest do
   defp wait_for(struct, timeout \\ 2_000) do
     receive do
       {:recv, msg} ->
-        #IO.inspect msg
+        # IO.inspect msg
         if Map.get(msg, :__struct__) == struct do
           msg
         else
@@ -92,7 +95,8 @@ defmodule TDLibTest do
   end
 
   defp wait_for_authstate() do
-    wait_for(UpdateAuthorizationState) |> Map.get(:authorization_state)
-                                       |> Map.get(:"@type")
+    wait_for(UpdateAuthorizationState)
+    |> Map.get(:authorization_state)
+    |> Map.get(:"@type")
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.configure(exclude: [manual: true])
+ExUnit.configure(exclude: [manual: true, integration: true])
 ExUnit.start()


### PR DESCRIPTION
Что сделали в ветке (коротко)
~~1. TDLib.open/4: find_or_create → recreate — при каждом open сессия убивается и создаётся заново.~~
2. Handler: голые authorizationState* оборачиваются в %UpdateAuthorizationState{}.
3. При старте Handler сразу шлётся GetAuthorizationState.
4. Авто-SetTdlibParameters при WaitTdlibParameters остался (в чуть другом виде).

Почему система деградировала
Главный виновник почти наверняка п.1 — recreate.

Вторым коммитом вернули find_or_create вместо recreate